### PR TITLE
refactor(core): Phase-1 core refactor for cost & material modules

### DIFF
--- a/addons/smart_construction_core/README.md
+++ b/addons/smart_construction_core/README.md
@@ -1,0 +1,8 @@
+# Smart Construction Core
+
+## 兼容模型说明
+
+- 由于早期版本使用过 `project.budget.line`，为了保证老数据库升级安全，在 `models/budget_compat.py` 中保留了一个兼容模型：
+  - `_name = 'project.budget.line'`
+  - `_table = 'project_budget_boq_line'`
+- 该模型只用于 ORM 元数据兼容，**不要在新代码中引用**。新代码一律使用 `project.budget.boq.line`。

--- a/addons/smart_construction_core/models/__init__.py
+++ b/addons/smart_construction_core/models/__init__.py
@@ -5,6 +5,7 @@ from . import document_center
 from . import contract_center
 from . import project_contract
 from . import cost_domain
+from . import budget_compat
 from . import purchase_extend
 from . import account_extend
 from . import stock_extend

--- a/addons/smart_construction_core/models/budget_compat.py
+++ b/addons/smart_construction_core/models/budget_compat.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+
+class ProjectBudgetLineCompat(models.Model):
+    """
+    兼容层：历史模型 project.budget.line -> 现用 project.budget.boq.line。
+    避免数据库残留记录升级时报“KeyError: 'project.budget.line'”。 
+    """
+
+    _name = "project.budget.line"
+    _description = "项目预算行(兼容层)"
+    _inherit = "project.budget.boq.line"
+    _table = "project_budget_boq_line"

--- a/addons/smart_construction_core/models/cost_domain.py
+++ b/addons/smart_construction_core/models/cost_domain.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+成本域聚合工具 / 领域服务。
+
+兼容模型 project.budget.line 已移动至 budget_compat.py，
+避免 cost_domain.py 里同时承担“领域服务 + 兼容层”的职责。
+"""
 from odoo import api, fields, models
 from odoo.exceptions import UserError
 
@@ -436,15 +442,3 @@ class ProjectProgressEntry(models.Model):
                 blocked_states=("paused", "closed", "closing"),
             )
         return super().create(vals_list)
-
-
-class ProjectBudgetLineCompat(models.Model):
-    """
-    兼容层：历史模型 project.budget.line -> 现用 project.budget.boq.line。
-    避免数据库残留记录升级时报“KeyError: 'project.budget.line'”。
-    """
-
-    _name = "project.budget.line"
-    _description = "项目预算行(兼容层)"
-    _inherit = "project.budget.boq.line"
-    _table = "project_budget_boq_line"


### PR DESCRIPTION
核心重构：
- 物资计划模型与视图调整
- 采购行增加 plan_line_id / plan_id 反向字段
- 物资计划统计字段与动作优化
- 与 Odoo 17 标准模型兼容（避免升级崩溃）

本地测试：已在本地环境完整启动 Odoo，并验证关键菜单和动作。
