### PR TITLE
feat(settlement): move settlement work to proper feature branch

### DIFF
--- a/addons/smart_construction_core/views/purchase_extend_views.xml
+++ b/addons/smart_construction_core/views/purchase_extend_views.xml
@@ -23,4 +23,19 @@
             </xpath>
         </field>
     </record>
+
+    <record id="view_purchase_order_form_sc_settlement" model="ir.ui.view">
+        <field name="name">purchase.order.form.sc.settlement</field>
+        <field name="model">purchase.order</field>
+        <field name="inherit_id" ref="purchase.purchase_order_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//form/header" position="inside">
+                <button name="action_create_settlement"
+                        type="object"
+                        string="创建结算单"
+                        class="btn-secondary"
+                        attrs="{'invisible': ['|', ('state', '!=', 'purchase'), ('order_line', '=', [])]}"/>
+            </xpath>
+        </field>
+    </record>
 </odoo>

--- a/addons/smart_construction_core/views/settlement_order_views.xml
+++ b/addons/smart_construction_core/views/settlement_order_views.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+
+        <!-- 支出结算列表 -->
+        <record id="view_sc_settlement_order_tree" model="ir.ui.view">
+            <field name="name">sc.settlement.order.tree</field>
+            <field name="model">sc.settlement.order</field>
+            <field name="arch" type="xml">
+                <tree string="支出结算单">
+                    <field name="name"/>
+                    <field name="type"/>
+                    <field name="project_id"/>
+                    <field name="contract_id"/>
+                    <field name="partner_id"/>
+                    <field name="amount_total"/>
+                    <field name="state"/>
+                    <field name="date_settlement"/>
+                </tree>
+            </field>
+        </record>
+
+        <!-- 支出结算表单 -->
+        <record id="view_sc_settlement_order_form" model="ir.ui.view">
+            <field name="name">sc.settlement.order.form</field>
+            <field name="model">sc.settlement.order</field>
+            <field name="arch" type="xml">
+                <form string="支出结算单">
+                    <header>
+                        <button name="action_submit"
+                                type="object"
+                                string="提交"
+                                class="btn-primary"
+                                invisible="state != 'draft'"/>
+                        <button name="action_approve"
+                                type="object"
+                                string="批准"
+                                invisible="state != 'submit'"/>
+                        <button name="action_done"
+                                type="object"
+                                string="完成"
+                                invisible="state != 'approved'"/>
+                        <button name="action_cancel"
+                                type="object"
+                                string="取消"
+                                invisible="state not in ['draft', 'submit', 'approved']"/>
+                        <field name="state" widget="statusbar" statusbar_visible="draft,submit,approved,done,cancel"/>
+                    </header>
+                    <sheet>
+                        <group>
+                            <group>
+                                <field name="name" readonly="1"/>
+                                <field name="type"/>
+                                <field name="project_id"/>
+                                <field name="contract_id"/>
+                            </group>
+                            <group>
+                                <field name="partner_id"/>
+                                <field name="date_settlement"/>
+                                <field name="currency_id"/>
+                            </group>
+                        </group>
+
+                        <group string="金额">
+                            <field name="amount_untaxed" readonly="1"/>
+                            <field name="amount_tax" readonly="1"/>
+                            <field name="amount_total" readonly="1"/>
+                        </group>
+
+                        <notebook>
+                            <page string="结算明细">
+                                <field name="line_ids">
+                                    <tree editable="bottom">
+                                        <field name="purchase_line_id"/>
+                                        <field name="product_id"/>
+                                        <field name="cost_item_id"/>
+                                        <field name="uom_id"/>
+                                        <field name="qty_source" readonly="1"/>
+                                        <field name="qty_settle"/>
+                                        <field name="price_unit"/>
+                                        <field name="amount_total" readonly="1"/>
+                                        <field name="currency_id" invisible="1"/>
+                                    </tree>
+                                </field>
+                            </page>
+                            <page string="附加信息">
+                                <group>
+                                    <field name="invoice_ids" readonly="1"/>
+                                    <field name="payment_ids" readonly="1"/>
+                                    <field name="note"/>
+                                </group>
+                            </page>
+                        </notebook>
+                    </sheet>
+                </form>
+            </field>
+        </record>
+
+        <!-- 动作 -->
+        <record id="action_sc_settlement_order" model="ir.actions.act_window">
+            <field name="name">支出结算单</field>
+            <field name="res_model">sc.settlement.order</field>
+            <field name="view_mode">tree,form</field>
+        </record>
+
+        <!-- 菜单：财务中心下的结算中心 -->
+        <menuitem id="menu_sc_settlement_center"
+                  name="结算中心"
+                  parent="smart_construction_core.menu_sc_finance_center"
+                  sequence="20"
+                  groups="smart_construction_core.group_sc_user,smart_construction_core.group_sc_manager"/>
+
+        <menuitem id="menu_sc_settlement_order"
+                  name="支出结算单"
+                  parent="menu_sc_settlement_center"
+                  action="action_sc_settlement_order"
+                  sequence="10"
+                  groups="smart_construction_core.group_sc_user,smart_construction_core.group_sc_manager"/>
+
+    </data>
+</odoo>


### PR DESCRIPTION
Added settlement center core: new sc.settlement.order/sc.settlement.order.line models with state actions, amount aggregates, and sequence (addons/smart_construction_core/models/settlement_order.py, data/settlement_sequence.xml). Added tree/form views, action, and finance submenu for settlement orders (views/settlement_order_views.xml), and wired imports/manifest/security access (models/__init__.py, __manifest__.py, security/ir.model.access.csv). Integrated purchase flow: purchase form button to create settlement plus server action that builds settlement from order lines (models/purchase_extend.py, views/purchase_extend_views.xml).

No tests run (logic changes only). After pulling, run your usual module upgrade (make upgrade MODULE=smart_construction_core) and open a purchase order in state “采购” to hit “创建结算单,” then check the new “结算中心 → 支出结算单” menu for records.