### PR TITLE
Portal Shell v0.6: minimal write loop (intent-only) + system-bound gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ db.reset.manual: guard.prod.forbid check-compose-env
 # ======================================================
 # ==================== Verify / Gate ===================
 # ======================================================
-.PHONY: verify.baseline verify.demo verify.p0 verify.p0.flow verify.overview verify.overview.entry verify.overview.logic verify.portal.dashboard verify.portal.execute_button verify.portal.fe_smoke.host verify.portal.fe_smoke.container verify.portal.view_state verify.portal.v0_5.host verify.portal.v0_5.all verify.portal.v0_5.container verify.smart_core verify.e2e.contract verify.prod.guard prod.guard.mail_from prod.fix.mail_from gate.baseline gate.demo gate.full
+.PHONY: verify.baseline verify.demo verify.p0 verify.p0.flow verify.overview verify.overview.entry verify.overview.logic verify.portal.dashboard verify.portal.execute_button verify.portal.fe_smoke.host verify.portal.fe_smoke.container verify.portal.view_state verify.portal.v0_5.host verify.portal.v0_5.all verify.portal.v0_5.container verify.portal.v0_6.container verify.smart_core verify.e2e.contract verify.prod.guard prod.guard.mail_from prod.fix.mail_from gate.baseline gate.demo gate.full
 verify.baseline: guard.prod.danger check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/baseline.sh
 verify.demo: guard.prod.forbid check-compose-project check-compose-env
@@ -440,6 +440,8 @@ verify.portal.v0_5.all: verify.portal.view_state verify.portal.v0_5.container
 	@echo "[OK] verify.portal.v0_5.all done"
 verify.portal.v0_5.container: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 ARTIFACTS_DIR=/mnt/artifacts DB_NAME=$(DB_NAME) MVP_MENU_XMLID=$(MVP_MENU_XMLID) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) node /mnt/scripts/verify/fe_mvp_list_smoke.js"
+verify.portal.v0_6.container: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 ARTIFACTS_DIR=/mnt/artifacts DB_NAME=$(DB_NAME) MVP_MODEL=$(MVP_MODEL) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) CREATE_NAME=$(CREATE_NAME) UPDATE_NAME=$(UPDATE_NAME) node /mnt/scripts/verify/fe_mvp_write_smoke.js"
 verify.smart_core: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/smart_core.sh
 verify.prod.guard: check-compose-env

--- a/addons/smart_core/handlers/api_data_write.py
+++ b/addons/smart_core/handlers/api_data_write.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# 📄 smart_core/handlers/api_data_write.py
+# v0.6: Minimal write intent (create/update) for project.project
+
+import logging
+from typing import Any, Dict, List
+
+from odoo.exceptions import AccessError
+
+from ..core.base_handler import BaseIntentHandler
+
+_logger = logging.getLogger(__name__)
+
+
+class ApiDataWriteHandler(BaseIntentHandler):
+    """
+    Intent: api.data.create / api.data.write
+    - 限定 model=project.project
+    - 字段白名单写入
+    - 返回固定写入契约
+    """
+
+    INTENT_TYPE = "api.data.create"
+    ALIASES = ["api.data.write"]
+    DESCRIPTION = "Portal Shell v0.6 minimal write intent (create/update)"
+    VERSION = "0.6.0"
+    ETAG_ENABLED = False
+
+    ALLOWED_MODEL = "project.project"
+    ALLOWED_FIELDS = {"name", "description", "date_start"}
+
+    def _err(self, code: int, message: str):
+        return {"ok": False, "error": {"code": code, "message": message}, "code": code}
+
+    def _collect_params(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        params = {}
+        if isinstance(payload, dict):
+            params.update(payload.get("params") or {})
+            params.update(payload.get("payload") or {})
+        if isinstance(self.params, dict):
+            params.update(self.params)
+        return params
+
+    def _get_context(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        ctx = params.get("context")
+        return ctx if isinstance(ctx, dict) else {}
+
+    def _get_model(self, params: Dict[str, Any]) -> str:
+        model = params.get("model") or params.get("res_model") or ""
+        return str(model).strip()
+
+    def _get_vals(self, params: Dict[str, Any]) -> Dict[str, Any]:
+        vals = params.get("vals") or params.get("values") or {}
+        return vals if isinstance(vals, dict) else {}
+
+    def _get_id(self, params: Dict[str, Any]) -> int:
+        for key in ("id", "record_id"):
+            if key in params:
+                try:
+                    return int(params.get(key))
+                except Exception:
+                    return 0
+        ids = params.get("ids")
+        if isinstance(ids, list) and ids:
+            try:
+                return int(ids[0])
+            except Exception:
+                return 0
+        return 0
+
+    def _filter_vals(self, vals: Dict[str, Any]) -> Dict[str, Any]:
+        return {k: v for k, v in vals.items() if k in self.ALLOWED_FIELDS}
+
+    def handle(self, payload=None, ctx=None):
+        payload = payload or {}
+        params = self._collect_params(payload)
+        intent = (payload.get("intent") or "").strip().lower()
+        model = self._get_model(params)
+
+        if not model:
+            return self._err(400, "缺少参数 model")
+        if model != self.ALLOWED_MODEL:
+            return self._err(403, f"模型不允许写入: {model}")
+        if model not in self.env:
+            return self._err(404, f"未知模型: {model}")
+
+        vals = self._get_vals(params)
+        if not vals:
+            return self._err(400, "缺少参数 vals")
+
+        illegal_fields = sorted(set(vals.keys()) - self.ALLOWED_FIELDS)
+        if illegal_fields:
+            return self._err(400, f"字段不允许写入: {', '.join(illegal_fields)}")
+
+        safe_vals = self._filter_vals(vals)
+        if not safe_vals:
+            return self._err(400, "vals 中无可写字段")
+
+        context = self._get_context(params)
+        env_model = self.env[model].with_context(context)
+
+        trace_id = ""
+        if isinstance(self.context, dict):
+            trace_id = self.context.get("trace_id") or ""
+
+        if intent == "api.data.write":
+            record_id = self._get_id(params)
+            if not record_id:
+                return self._err(400, "缺少参数 id")
+
+            rec = env_model.browse(record_id).exists()
+            if not rec:
+                return self._err(404, "记录不存在")
+
+            try:
+                env_model.check_access_rights("write")
+                rec.check_access_rule("write")
+                rec.write(safe_vals)
+            except AccessError as ae:
+                _logger.warning("api.data.write AccessError on %s: %s", model, ae)
+                return self._err(403, "无写入权限")
+            except Exception as e:
+                _logger.exception("api.data.write failed on %s", model)
+                return self._err(500, str(e))
+
+            data = {
+                "id": rec.id,
+                "model": model,
+                "written_fields": sorted(safe_vals.keys()),
+                "values": safe_vals,
+            }
+            meta = {"trace_id": trace_id, "write_mode": "update", "source": "portal-shell"}
+            return {"ok": True, "data": data, "meta": meta}
+
+        if intent == "api.data.create":
+            try:
+                env_model.check_access_rights("create")
+                rec = env_model.create(safe_vals)
+            except AccessError as ae:
+                _logger.warning("api.data.create AccessError on %s: %s", model, ae)
+                return self._err(403, "无创建权限")
+            except Exception as e:
+                _logger.exception("api.data.create failed on %s", model)
+                return self._err(500, str(e))
+
+            data = {
+                "id": rec.id,
+                "model": model,
+                "written_fields": sorted(safe_vals.keys()),
+                "values": safe_vals,
+            }
+            meta = {"trace_id": trace_id, "write_mode": "create", "source": "portal-shell"}
+            return {"ok": True, "data": data, "meta": meta}
+
+        return self._err(400, f"未知写入意图: {intent}")

--- a/docs/ops/codex_execution_allowlist.md
+++ b/docs/ops/codex_execution_allowlist.md
@@ -212,6 +212,7 @@ Codex **只能** 在以下分支类型中执行自治操作：
 * `make verify.portal.v0_5.host`（host 调试用，非 gate）
 * `make verify.portal.v0_5.all`
 * `make verify.portal.v0_5.container`
+* `make verify.portal.v0_6.container`
 * `scripts/verify/*_smoke.sh`
 
 #### 明确禁止

--- a/docs/ops/releases/frontend_v0_6_notes.md
+++ b/docs/ops/releases/frontend_v0_6_notes.md
@@ -1,0 +1,61 @@
+# Frontend v0.6 Release Notes (Draft)
+
+## MVP Anchor (Business)
+- model: project.project
+- write_fields: name, description, date_start
+
+## Write Contract (v0.6)
+Response shape:
+```
+{
+  "ok": true,
+  "data": {
+    "id": <number>,
+    "model": "project.project",
+    "written_fields": ["name"],
+    "values": { "name": "..." }
+  },
+  "meta": {
+    "trace_id": "...",
+    "write_mode": "create|update",
+    "source": "portal-shell"
+  }
+}
+```
+
+## Verification (System-bound)
+### Verification Plane
+Official release gate is **container plane** only.
+
+### Gate Sequence (Container Plane)
+1. `make verify.portal.view_state`
+2. `make verify.portal.fe_smoke.container`
+3. `make verify.portal.v0_6.container`
+
+### Gate Command (template)
+```
+make verify.portal.v0_6.container \
+  DB_NAME=sc_demo \
+  MVP_MODEL=project.project \
+  ROOT_XMLID=smart_construction_core.menu_sc_root \
+  E2E_LOGIN=svc_project_ro \
+  E2E_PASSWORD='***' \
+  ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/<TIMESTAMP>
+```
+
+### Verification Output (2026-02-03)
+- [x] `make verify.portal.view_state` (PASS)
+- [x] `make verify.portal.fe_smoke.container DB_NAME=sc_demo E2E_LOGIN=svc_project_ro E2E_PASSWORD=***` (PASS)
+- [x] `make verify.portal.v0_6.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T065521` (PASS)
+
+## MVP Trace
+- write_status: ok
+- read_back_match: true
+- trace_id: aa44be5c0b20
+- record_id: 44
+
+## Artifacts
+- fe_mvp_write_smoke logs: artifacts/codex/portal-shell-v0_6/20260203T065521/
+
+## Attempts (Fail)
+- (none)

--- a/frontend/apps/web/src/api/data.ts
+++ b/frontend/apps/web/src/api/data.ts
@@ -83,3 +83,27 @@ export async function writeRecord(params: {
     },
   });
 }
+
+export type ApiDataWriteContract = {
+  id: number;
+  model: string;
+  written_fields: string[];
+  values: Record<string, unknown>;
+};
+
+export async function writeRecordV6(params: {
+  model: string;
+  id: number;
+  values: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}) {
+  return intentRequest<ApiDataWriteContract>({
+    intent: 'api.data.write',
+    params: {
+      model: params.model,
+      id: params.id,
+      values: params.values,
+      context: params.context ?? {},
+    },
+  });
+}

--- a/frontend/apps/web/src/views/RecordView.vue
+++ b/frontend/apps/web/src/views/RecordView.vue
@@ -7,11 +7,15 @@
       </div>
       <div class="actions">
         <button class="ghost" @click="goBack">Back</button>
-        <button @click="reload" :disabled="status === 'loading'">Reload</button>
+        <button v-if="status === 'ok' && canEdit" @click="startEdit">Edit</button>
+        <button v-if="status === 'editing'" @click="save" :disabled="isSaveDisabled">Save</button>
+        <button v-if="status === 'editing'" class="ghost" @click="cancelEdit">Cancel</button>
+        <button @click="reload" :disabled="status === 'loading' || status === 'saving'">Reload</button>
       </div>
     </header>
 
     <StatusPanel v-if="status === 'loading'" title="Loading record..." variant="info" />
+    <StatusPanel v-else-if="status === 'saving'" title="Saving record..." variant="info" />
     <StatusPanel
       v-else-if="status === 'error'"
       title="Request failed"
@@ -31,7 +35,15 @@
     <section v-else class="card">
       <div v-for="field in fields" :key="field.name" class="field">
         <span class="label">{{ field.label }}</span>
-        <span class="value"><FieldValue :value="field.value" :field="field.descriptor" /></span>
+        <span class="value">
+          <input
+            v-if="status === 'editing' && field.name === 'name'"
+            v-model="draftName"
+            class="input"
+            type="text"
+          />
+          <FieldValue v-else :value="field.value" :field="field.descriptor" />
+        </span>
       </div>
     </section>
   </section>
@@ -41,7 +53,7 @@
 import { computed, onMounted, ref } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import { ApiError } from '../api/client';
-import { readRecord } from '../api/data';
+import { readRecord, writeRecordV6 } from '../api/data';
 import { extractFieldNames, resolveView } from '../app/resolvers/viewResolver';
 import { deriveRecordStatus } from '../app/view_state';
 import type { ViewContract } from '@sc/schema';
@@ -52,12 +64,14 @@ const route = useRoute();
 const router = useRouter();
 const error = ref('');
 const traceId = ref('');
-const status = ref<'idle' | 'loading' | 'ok' | 'empty' | 'error'>('idle');
+const status = ref<'idle' | 'loading' | 'ok' | 'empty' | 'error' | 'editing' | 'saving'>('idle');
 const fields = ref<Array<{ name: string; label: string; value: unknown; descriptor?: ViewContract['fields'][string] }>>([]);
+const draftName = ref('');
 
 const model = computed(() => String(route.params.model || ''));
 const recordId = computed(() => Number(route.params.id));
 const title = computed(() => `Record ${recordId.value}`);
+const canEdit = computed(() => model.value === 'project.project');
 
 async function load() {
   error.value = '';
@@ -89,6 +103,7 @@ async function load() {
       descriptor: view.fields?.[name],
     }));
     status.value = deriveRecordStatus({ error: '', fieldsLength: fields.value.length });
+    draftName.value = String(record?.name ?? '');
   } catch (err) {
     if (err instanceof ApiError) {
       traceId.value = err.traceId ?? '';
@@ -102,6 +117,53 @@ async function load() {
 
 function reload() {
   load();
+}
+
+function startEdit() {
+  if (status.value !== 'ok') {
+    return;
+  }
+  const nameField = fields.value.find((field) => field.name === 'name');
+  draftName.value = String(nameField?.value ?? '');
+  status.value = 'editing';
+}
+
+function cancelEdit() {
+  if (status.value !== 'editing') {
+    return;
+  }
+  const nameField = fields.value.find((field) => field.name === 'name');
+  draftName.value = String(nameField?.value ?? '');
+  status.value = 'ok';
+}
+
+const isSaveDisabled = computed(() => status.value === 'saving' || !draftName.value.trim());
+
+async function save() {
+  if (status.value !== 'editing') {
+    return;
+  }
+  error.value = '';
+  traceId.value = '';
+  status.value = 'saving';
+
+  try {
+    await writeRecordV6({
+      model: model.value,
+      id: recordId.value,
+      values: { name: draftName.value.trim() },
+    });
+    status.value = 'ok';
+    await load();
+  } catch (err) {
+    if (err instanceof ApiError) {
+      traceId.value = err.traceId ?? '';
+      error.value = err.message;
+    } else {
+      error.value = err instanceof Error ? err.message : 'failed to save record';
+    }
+    status.value = 'error';
+  }
 }
 
 function goBack() {
@@ -158,6 +220,14 @@ onMounted(load);
 
 .value {
   color: #0f172a;
+}
+
+.input {
+  width: 100%;
+  padding: 8px 10px;
+  border-radius: 8px;
+  border: 1px solid #cbd5f5;
+  font-size: 14px;
 }
 
 button {

--- a/scripts/verify/fe_mvp_write_smoke.js
+++ b/scripts/verify/fe_mvp_write_smoke.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8070';
+const DB_NAME = process.env.E2E_DB || process.env.DB_NAME || process.env.DB || '';
+const LOGIN = process.env.E2E_LOGIN || 'admin';
+const PASSWORD = process.env.E2E_PASSWORD || process.env.ADMIN_PASSWD || 'admin';
+const ROOT_XMLID = process.env.ROOT_XMLID || 'smart_construction_core.menu_sc_root';
+const MODEL = process.env.MVP_MODEL || 'project.project';
+const CREATE_NAME = process.env.CREATE_NAME || 'Portal Shell v0.6';
+const UPDATE_NAME = process.env.UPDATE_NAME || 'Portal Shell v0.6 Updated';
+const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR || 'artifacts';
+
+const now = new Date();
+const ts = now.toISOString().replace(/[-:]/g, '').slice(0, 15);
+const outDir = path.join(ARTIFACTS_DIR, 'codex', 'portal-shell-v0_6', ts);
+
+function log(msg) {
+  console.log(`[fe_mvp_write_smoke] ${msg}`);
+}
+
+function writeJson(file, obj) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+}
+
+function writeSummary(lines) {
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'summary.md'), lines.join('\n'));
+}
+
+function requestJson(url, payload, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const body = JSON.stringify(payload);
+    const opts = {
+      method: 'POST',
+      hostname: u.hostname,
+      port: u.port || (u.protocol === 'https:' ? 443 : 80),
+      path: u.pathname + u.search,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        ...headers,
+      },
+    };
+    const client = u.protocol === 'https:' ? https : http;
+    const req = client.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        let parsed = {};
+        try {
+          parsed = JSON.parse(data || '{}');
+        } catch {
+          parsed = { raw: data };
+        }
+        resolve({ status: res.statusCode || 0, body: parsed });
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function unwrap(body) {
+  if (body && typeof body === 'object' && 'data' in body) {
+    return body.data || {};
+  }
+  return body || {};
+}
+
+async function main() {
+  if (!DB_NAME) {
+    throw new Error('DB_NAME is required (set DB_NAME or E2E_DB)');
+  }
+
+  const intentUrl = `${BASE_URL}/api/v1/intent`;
+  const summary = [];
+
+  log(`login: ${LOGIN} db=${DB_NAME}`);
+  const loginPayload = { intent: 'login', params: { db: DB_NAME, login: LOGIN, password: PASSWORD } };
+  const loginResp = await requestJson(intentUrl, loginPayload, { 'X-Anonymous-Intent': '1' });
+  if (loginResp.status >= 400 || !loginResp.body.ok) {
+    writeJson(path.join(outDir, 'login.log'), loginResp);
+    throw new Error(`login failed: status=${loginResp.status}`);
+  }
+  const token = (loginResp.body.data || {}).token;
+  if (!token) {
+    throw new Error('login response missing token');
+  }
+
+  const authHeader = {
+    Authorization: `Bearer ${token}`,
+    'X-Odoo-DB': DB_NAME,
+  };
+
+  log('app.init');
+  const initPayload = { intent: 'app.init', params: { db: DB_NAME, scene: 'web', with_preload: false, root_xmlid: ROOT_XMLID } };
+  const initResp = await requestJson(intentUrl, initPayload, authHeader);
+  if (initResp.status >= 400 || !initResp.body.ok) {
+    writeJson(path.join(outDir, 'init.log'), initResp);
+    throw new Error(`app.init failed: status=${initResp.status}`);
+  }
+
+  log('api.data.create');
+  const createPayload = { intent: 'api.data.create', params: { model: MODEL, values: { name: CREATE_NAME } } };
+  const createResp = await requestJson(intentUrl, createPayload, authHeader);
+  writeJson(path.join(outDir, 'write_create.log'), createResp);
+  if (createResp.status >= 400 || !createResp.body.ok) {
+    throw new Error(`create failed: status=${createResp.status}`);
+  }
+  const createData = unwrap(createResp.body);
+  const recordId = createData.id;
+  if (!recordId) {
+    throw new Error('create missing id');
+  }
+
+  log('api.data.write invalid field');
+  const invalidPayload = { intent: 'api.data.write', params: { model: MODEL, id: recordId, values: { __illegal_field: 'x' } } };
+  const invalidResp = await requestJson(intentUrl, invalidPayload, authHeader);
+  writeJson(path.join(outDir, 'write_invalid.log'), invalidResp);
+  const invalidOk = Boolean(invalidResp.body && invalidResp.body.ok === false);
+  summary.push(`write_invalid_ok: ${invalidOk ? 'true' : 'false'}`);
+
+  log('api.data.write');
+  const writePayload = { intent: 'api.data.write', params: { model: MODEL, id: recordId, values: { name: UPDATE_NAME } } };
+  const writeResp = await requestJson(intentUrl, writePayload, authHeader);
+  writeJson(path.join(outDir, 'write_update.log'), writeResp);
+  if (writeResp.status >= 400 || !writeResp.body.ok) {
+    throw new Error(`write failed: status=${writeResp.status}`);
+  }
+  const writeMeta = writeResp.body.meta || {};
+  const writeTraceId = writeMeta.trace_id || '';
+
+  log('api.data.read');
+  const readPayload = { intent: 'api.data', params: { op: 'read', model: MODEL, ids: [recordId], fields: ['id', 'name'] } };
+  const readResp = await requestJson(intentUrl, readPayload, authHeader);
+  writeJson(path.join(outDir, 'read_back.log'), readResp);
+  if (readResp.status >= 400 || !readResp.body.ok) {
+    throw new Error(`read failed: status=${readResp.status}`);
+  }
+  const readData = unwrap(readResp.body);
+  const record = (readData.records || [])[0] || {};
+  const readBackMatch = record.name === UPDATE_NAME;
+
+  summary.push(`write_status: ok`);
+  summary.push(`read_back_match: ${readBackMatch ? 'true' : 'false'}`);
+  summary.push(`trace_id: ${writeTraceId}`);
+  summary.push(`record_id: ${recordId}`);
+
+  writeSummary(summary);
+
+  if (!readBackMatch || !invalidOk) {
+    throw new Error('write smoke assertions failed');
+  }
+
+  log(`PASS write_status=ok read_back_match=${readBackMatch}`);
+  log(`artifacts: ${outDir}`);
+}
+
+main().catch((err) => {
+  console.error(`[fe_mvp_write_smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION

## Summary
Portal Shell v0.6 upgrades v0.5 read-only flow into a minimal, controlled write loop: intent-only create/update on project.project with system-bound verification and artifacts.

## MVP Anchor (Business)
- model: project.project
- write_fields: name, description, date_start

## Write Contract (v0.6)
```
{
  "ok": true,
  "data": {
    "id": <number>,
    "model": "project.project",
    "written_fields": ["name"],
    "values": { "name": "..." }
  },
  "meta": {
    "trace_id": "...",
    "write_mode": "create|update",
    "source": "portal-shell"
  }
}
```

## Official Verification Plane
Container plane only (host plane is debug and not gate).

## Gate Sequence (Container Plane)
1. make verify.portal.view_state
2. make verify.portal.fe_smoke.container
3. make verify.portal.v0_6.container

## Gate Command (latest PASS)
make verify.portal.v0_6.container \
  DB_NAME=sc_demo \
  MVP_MODEL=project.project \
  ROOT_XMLID=smart_construction_core.menu_sc_root \
  E2E_LOGIN=<REVOKED_LEGACY_USERNAME> \
  E2E_PASSWORD='***' \
  ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T065521

## Artifacts (PASS)
- artifacts/codex/portal-shell-v0_6/20260203T065521/write_create.log
- artifacts/codex/portal-shell-v0_6/20260203T065521/write_invalid.log
- artifacts/codex/portal-shell-v0_6/20260203T065521/write_update.log
- artifacts/codex/portal-shell-v0_6/20260203T065521/read_back.log
- artifacts/codex/portal-shell-v0_6/20260203T065521/summary.md

## Fixes / Features
- Backend: intent-only write handler for project.project (field whitelist)
- Frontend: minimal name edit flow in RecordView (edit/save/cancel/reload)
- Verification: v0.6 write smoke script + Makefile gate + allowlist

Freeze note:
Freeze complete for v0.6: container-plane gate PASS with artifacts. Release notes updated and evidence recorded.