### PR TITLE
Portal Shell v0.7 UI: verification-grade UX hardening + UI gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -407,7 +407,7 @@ db.reset.manual: guard.prod.forbid check-compose-env
 # ======================================================
 # ==================== Verify / Gate ===================
 # ======================================================
-.PHONY: verify.baseline verify.demo verify.p0 verify.p0.flow verify.overview verify.overview.entry verify.overview.logic verify.portal.dashboard verify.portal.execute_button verify.portal.fe_smoke.host verify.portal.fe_smoke.container verify.portal.view_state verify.portal.v0_5.host verify.portal.v0_5.all verify.portal.v0_5.container verify.portal.v0_6.container verify.smart_core verify.e2e.contract verify.prod.guard prod.guard.mail_from prod.fix.mail_from gate.baseline gate.demo gate.full
+.PHONY: verify.baseline verify.demo verify.p0 verify.p0.flow verify.overview verify.overview.entry verify.overview.logic verify.portal.dashboard verify.portal.execute_button verify.portal.fe_smoke.host verify.portal.fe_smoke.container verify.portal.view_state verify.portal.guard_groups verify.portal.recordview_hud_smoke.container verify.portal.v0_5.host verify.portal.v0_5.all verify.portal.v0_5.container verify.portal.v0_6.container verify.portal.ui.v0_7.container verify.smart_core verify.e2e.contract verify.prod.guard prod.guard.mail_from prod.fix.mail_from gate.baseline gate.demo gate.full
 verify.baseline: guard.prod.danger check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/baseline.sh
 verify.demo: guard.prod.forbid check-compose-project check-compose-env
@@ -433,6 +433,8 @@ verify.portal.fe_smoke.container: guard.prod.forbid check-compose-project check-
 	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 DB_NAME=$(DB_NAME) AUTH_TOKEN=$(AUTH_TOKEN) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) bash /mnt/scripts/diag/fe_smoke.sh"
 verify.portal.view_state: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) node scripts/verify/fe_view_state_smoke.js
+verify.portal.guard_groups: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) node scripts/verify/fe_guard_groups_smoke.js
 verify.portal.v0_5.host: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) MVP_MENU_XMLID=$(MVP_MENU_XMLID) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) ARTIFACTS_DIR=$(ARTIFACTS_DIR) \
 		node scripts/verify/fe_mvp_list_smoke.js
@@ -442,6 +444,10 @@ verify.portal.v0_5.container: guard.prod.forbid check-compose-project check-comp
 	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 ARTIFACTS_DIR=/mnt/artifacts DB_NAME=$(DB_NAME) MVP_MENU_XMLID=$(MVP_MENU_XMLID) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) node /mnt/scripts/verify/fe_mvp_list_smoke.js"
 verify.portal.v0_6.container: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 ARTIFACTS_DIR=/mnt/artifacts DB_NAME=$(DB_NAME) MVP_MODEL=$(MVP_MODEL) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) CREATE_NAME=$(CREATE_NAME) UPDATE_NAME=$(UPDATE_NAME) node /mnt/scripts/verify/fe_mvp_write_smoke.js"
+verify.portal.recordview_hud_smoke.container: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) $(COMPOSE_BASE) exec -T $(ODOO_SERVICE) sh -lc "BASE_URL=http://localhost:8069 ARTIFACTS_DIR=/mnt/artifacts DB_NAME=$(DB_NAME) MVP_MODEL=$(MVP_MODEL) ROOT_XMLID=$(ROOT_XMLID) E2E_LOGIN=$(E2E_LOGIN) E2E_PASSWORD=$(E2E_PASSWORD) node /mnt/scripts/verify/fe_recordview_hud_smoke.js"
+verify.portal.ui.v0_7.container: verify.portal.view_state verify.portal.guard_groups verify.portal.fe_smoke.container verify.portal.v0_6.container verify.portal.recordview_hud_smoke.container
+	@echo \"[OK] verify.portal.ui.v0_7.container done\"
 verify.smart_core: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/smart_core.sh
 verify.prod.guard: check-compose-env

--- a/docs/ops/codex_execution_allowlist.md
+++ b/docs/ops/codex_execution_allowlist.md
@@ -209,10 +209,13 @@ Codex **只能** 在以下分支类型中执行自治操作：
 * `make verify.portal.fe_smoke.host`（host 调试用，非 gate）
 * `make verify.portal.fe_smoke.container`
 * `make verify.portal.view_state`
+* `make verify.portal.guard_groups`
 * `make verify.portal.v0_5.host`（host 调试用，非 gate）
 * `make verify.portal.v0_5.all`
 * `make verify.portal.v0_5.container`
 * `make verify.portal.v0_6.container`
+* `make verify.portal.recordview_hud_smoke.container`
+* `make verify.portal.ui.v0_7.container`
 * `scripts/verify/*_smoke.sh`
 
 #### 明确禁止

--- a/docs/ops/releases/frontend_v0_7_ui_notes.md
+++ b/docs/ops/releases/frontend_v0_7_ui_notes.md
@@ -31,11 +31,11 @@ make verify.portal.ui.v0_7.container \
 - [x] `make verify.portal.fe_smoke.container DB_NAME=sc_demo E2E_LOGIN=svc_project_ro E2E_PASSWORD=***` (PASS)
 - [x] `make verify.portal.v0_6.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T081729` (PASS)
 - [x] `make verify.portal.recordview_hud_smoke.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T081747` (PASS)
-  - Note: `make verify.portal.ui.v0_7.container` timed out in terminal after v0.6 write smoke; all constituent steps passed.
+- [x] `make verify.portal.ui.v0_7.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T081924` (PASS)
 
 ## Evidence (Artifacts)
-- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T081729/
-- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T081747/
+- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T081920/
+- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T081924/
 
 ## Manual UX Verification (Phase 7)
 - [ ] Loading state visible

--- a/docs/ops/releases/frontend_v0_7_ui_notes.md
+++ b/docs/ops/releases/frontend_v0_7_ui_notes.md
@@ -1,0 +1,48 @@
+# Frontend v0.7 UI Hardening Notes (Draft)
+
+## Scope
+- UX hardening for verification-grade UI (no contract changes)
+- RecordView status clarity + HUD + footer meta
+- Guard utilities to prevent groups-related crashes
+
+## Verification (System-bound)
+### Gate Sequence (Container Plane)
+1. `make verify.portal.view_state`
+2. `make verify.portal.guard_groups`
+3. `make verify.portal.fe_smoke.container`
+4. `make verify.portal.v0_6.container`
+5. `make verify.portal.recordview_hud_smoke.container`
+6. `make verify.portal.ui.v0_7.container`
+
+### Gate Command (template)
+```
+make verify.portal.ui.v0_7.container \
+  DB_NAME=sc_demo \
+  MVP_MODEL=project.project \
+  ROOT_XMLID=smart_construction_core.menu_sc_root \
+  E2E_LOGIN=svc_project_ro \
+  E2E_PASSWORD='***' \
+  ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/<TIMESTAMP>
+```
+
+### Verification Output (2026-02-03)
+- [x] `make verify.portal.view_state` (PASS)
+- [x] `make verify.portal.guard_groups` (PASS)
+- [x] `make verify.portal.fe_smoke.container DB_NAME=sc_demo E2E_LOGIN=svc_project_ro E2E_PASSWORD=***` (PASS)
+- [x] `make verify.portal.v0_6.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T074434` (PASS)
+- [x] `make verify.portal.recordview_hud_smoke.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T074455` (PASS)
+
+## Evidence (Artifacts)
+- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T074434/
+- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T074455/
+
+## Manual UX Verification (Phase 7)
+- [ ] Loading state visible
+- [ ] Empty state distinct
+- [ ] Error shows code + trace_id
+- [ ] Edit/Save/Cancel behavior clear
+- [ ] HUD shows model/record_id/trace_id
+
+## Screenshots (attach)
+- List page (empty or data)
+- Record page (HUD + status bar)

--- a/docs/ops/releases/frontend_v0_7_ui_notes.md
+++ b/docs/ops/releases/frontend_v0_7_ui_notes.md
@@ -29,12 +29,13 @@ make verify.portal.ui.v0_7.container \
 - [x] `make verify.portal.view_state` (PASS)
 - [x] `make verify.portal.guard_groups` (PASS)
 - [x] `make verify.portal.fe_smoke.container DB_NAME=sc_demo E2E_LOGIN=svc_project_ro E2E_PASSWORD=***` (PASS)
-- [x] `make verify.portal.v0_6.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T074434` (PASS)
-- [x] `make verify.portal.recordview_hud_smoke.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T074455` (PASS)
+- [x] `make verify.portal.v0_6.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_6/20260203T081729` (PASS)
+- [x] `make verify.portal.recordview_hud_smoke.container DB_NAME=sc_demo MVP_MODEL=project.project ROOT_XMLID=smart_construction_core.menu_sc_root E2E_LOGIN=svc_project_ro E2E_PASSWORD=*** ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T081747` (PASS)
+  - Note: `make verify.portal.ui.v0_7.container` timed out in terminal after v0.6 write smoke; all constituent steps passed.
 
 ## Evidence (Artifacts)
-- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T074434/
-- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T074455/
+- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T081729/
+- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T081747/
 
 ## Manual UX Verification (Phase 7)
 - [ ] Loading state visible

--- a/frontend/apps/web/src/api/data.ts
+++ b/frontend/apps/web/src/api/data.ts
@@ -1,4 +1,4 @@
-import { intentRequest } from './intents';
+import { intentRequest, intentRequestRaw } from './intents';
 import type {
   ApiDataListResult,
   ApiDataReadResult,
@@ -98,6 +98,23 @@ export async function writeRecordV6(params: {
   context?: Record<string, unknown>;
 }) {
   return intentRequest<ApiDataWriteContract>({
+    intent: 'api.data.write',
+    params: {
+      model: params.model,
+      id: params.id,
+      values: params.values,
+      context: params.context ?? {},
+    },
+  });
+}
+
+export async function writeRecordV6Raw(params: {
+  model: string;
+  id: number;
+  values: Record<string, unknown>;
+  context?: Record<string, unknown>;
+}) {
+  return intentRequestRaw<ApiDataWriteContract>({
     intent: 'api.data.write',
     params: {
       model: params.model,

--- a/frontend/apps/web/src/api/intents.ts
+++ b/frontend/apps/web/src/api/intents.ts
@@ -48,3 +48,18 @@ export async function intentRequest<T>(payload: IntentPayload) {
     throw err;
   }
 }
+
+export async function intentRequestRaw<T>(payload: IntentPayload) {
+  const traceId = generateTraceId();
+  const response = await apiRequest<IntentEnvelope<T>>('/api/v1/intent', {
+    method: 'POST',
+    headers: buildHeaders(payload.intent, traceId),
+    body: JSON.stringify(payload),
+  });
+
+  if (response && typeof response === 'object' && 'data' in response) {
+    return { data: response.data as T, meta: response.meta || {}, traceId };
+  }
+
+  return { data: response as T, meta: {}, traceId };
+}

--- a/frontend/apps/web/src/app/resolvers/viewResolver.ts
+++ b/frontend/apps/web/src/app/resolvers/viewResolver.ts
@@ -1,4 +1,5 @@
 import type { FormField, ViewContract } from '@sc/schema';
+import { asArray } from '../../utils/guards';
 import { intentRequest } from '../../api/intents';
 
 export async function resolveView(model: string, viewType: string) {
@@ -16,15 +17,15 @@ export function extractFieldNames(layout: ViewContract['layout']) {
     }
   };
 
-  layout.groups?.forEach((group) => {
-    group.fields?.forEach((field) => pushField(field));
-    group.sub_groups?.forEach((sub) => sub.fields?.forEach((field) => pushField(field)));
+  asArray(layout.groups).forEach((group) => {
+    asArray(group.fields).forEach((field) => pushField(field));
+    asArray(group.sub_groups).forEach((sub) => asArray(sub.fields).forEach((field) => pushField(field)));
   });
 
-  layout.notebooks?.forEach((notebook) => {
-    notebook.pages?.forEach((page) => {
-      page.groups?.forEach((group) => {
-        group.fields?.forEach((field) => pushField(field));
+  asArray(layout.notebooks).forEach((notebook) => {
+    asArray(notebook.pages).forEach((page) => {
+      asArray(page.groups).forEach((group) => {
+        asArray(group.fields).forEach((field) => pushField(field));
       });
     });
   });

--- a/frontend/apps/web/src/config/debug.ts
+++ b/frontend/apps/web/src/config/debug.ts
@@ -1,0 +1,8 @@
+import type { RouteLocationNormalizedLoaded } from 'vue-router';
+
+export function isHudEnabled(route: RouteLocationNormalizedLoaded) {
+  if (import.meta.env.DEV) {
+    return true;
+  }
+  return route.query.hud === '1';
+}

--- a/frontend/apps/web/src/layouts/AppShell.vue
+++ b/frontend/apps/web/src/layouts/AppShell.vue
@@ -30,10 +30,23 @@
     <section class="content">
       <header class="topbar">
         <div>
-          <p class="eyebrow">Portal Shell v0.2</p>
+          <p class="eyebrow">Portal Shell v0.7 · UX Hardening</p>
+          <div class="breadcrumb">
+            <button
+              v-for="(item, index) in breadcrumb"
+              :key="`${item.label}-${index}`"
+              class="crumb"
+              :class="{ active: index === breadcrumb.length - 1 }"
+              @click="item.to && router.push(item.to)"
+              :disabled="!item.to"
+            >
+              {{ item.label }}
+            </button>
+          </div>
           <h1 class="headline">{{ currentTitle }}</h1>
         </div>
         <div class="meta">
+          <span>User: {{ userName }}</span>
           <span>DB: {{ effectiveDb }}</span>
           <span>Nav v{{ navVersion }}</span>
         </div>
@@ -108,6 +121,55 @@ const currentTitle = computed(() => {
     return `Record ${route.params.id ?? ''}`.trim();
   }
   return 'Workspace';
+});
+
+function findMenuPath(nodes: NavNode[], menuId?: number): NavNode[] {
+  if (!menuId) {
+    return [];
+  }
+  const walk = (items: NavNode[], parents: NavNode[] = []): NavNode[] | null => {
+    for (const node of items) {
+      const nextParents = [...parents, node];
+      if (node.menu_id === menuId || node.id === menuId) {
+        return nextParents;
+      }
+      if (node.children?.length) {
+        const found = walk(node.children, nextParents);
+        if (found) {
+          return found;
+        }
+      }
+    }
+    return null;
+  };
+  return walk(menuTree.value, []) || [];
+}
+
+const breadcrumb = computed(() => {
+  const crumbs: Array<{ label: string; to?: string }> = [];
+  const menuId = activeMenuId.value;
+  const menuPath = findMenuPath(menuTree.value, menuId);
+  if (menuPath.length) {
+    menuPath.forEach((node) => {
+      const label = node.title || node.name || node.label || 'Menu';
+      const id = node.menu_id ?? node.id;
+      if (id) {
+        crumbs.push({ label, to: `/m/${id}` });
+      }
+    });
+  }
+  if (route.name === 'action') {
+    const label = session.currentAction?.name || `Action ${route.params.actionId ?? ''}`.trim();
+    crumbs.push({ label });
+  }
+  if (route.name === 'record') {
+    const recordLabel = `Record ${route.params.id ?? ''}`.trim();
+    crumbs.push({ label: recordLabel });
+  }
+  if (!crumbs.length) {
+    crumbs.push({ label: 'Workspace' });
+  }
+  return crumbs;
 });
 
 const showRefresh = computed(() => import.meta.env.DEV || localStorage.getItem('DEBUG_INTENT') === '1');
@@ -274,6 +336,36 @@ async function logout() {
 .headline {
   margin: 4px 0 0;
   font-size: 24px;
+}
+
+.breadcrumb {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 0;
+}
+
+.crumb {
+  background: transparent;
+  border: none;
+  padding: 4px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--muted);
+  cursor: pointer;
+}
+
+.crumb.active {
+  background: rgba(47, 58, 95, 0.12);
+  color: var(--ink);
+  font-weight: 600;
+}
+
+.crumb:disabled {
+  cursor: default;
+  opacity: 0.6;
 }
 
 .meta {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -5,7 +5,10 @@
         <h2>{{ title }}</h2>
         <p class="meta">Model: {{ model || 'N/A' }}</p>
       </div>
-      <button @click="onReload" :disabled="loading">Reload</button>
+      <div class="actions">
+        <span class="pill" :class="status">{{ statusLabel }}</span>
+        <button @click="onReload" :disabled="loading">Reload</button>
+      </div>
     </header>
 
     <section class="summary">
@@ -16,6 +19,10 @@
       <div>
         <p class="label">Records</p>
         <p class="value">{{ records.length || '0' }}</p>
+      </div>
+      <div>
+        <p class="label">Sort</p>
+        <p class="value">{{ sortLabel || 'default' }}</p>
       </div>
     </section>
 
@@ -56,6 +63,7 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue';
 import StatusPanel from '../components/StatusPanel.vue';
 
 const props = defineProps<{
@@ -69,7 +77,15 @@ const props = defineProps<{
   records: Array<Record<string, unknown>>;
   onReload: () => void;
   onRowClick: (row: Record<string, unknown>) => void;
+  sortLabel?: string;
 }>();
+
+const statusLabel = computed(() => {
+  if (props.status === 'loading') return 'Loading';
+  if (props.status === 'error') return 'Error';
+  if (props.status === 'empty') return 'Empty';
+  return 'Ready';
+});
 
 function formatValue(value: unknown) {
   if (Array.isArray(value)) {
@@ -95,6 +111,12 @@ function handleRow(row: Record<string, unknown>) {
 .header {
   display: flex;
   justify-content: space-between;
+  align-items: center;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
   align-items: center;
 }
 
@@ -149,6 +171,36 @@ td {
 tr:hover {
   background: #f1f5f9;
   cursor: pointer;
+}
+
+.pill {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: #e2e8f0;
+  color: #1e293b;
+}
+
+.pill.ok {
+  background: #dcfce7;
+  color: #14532d;
+}
+
+.pill.error {
+  background: #fee2e2;
+  color: #991b1b;
+}
+
+.pill.loading {
+  background: #e0f2fe;
+  color: #075985;
+}
+
+.pill.empty {
+  background: #fef3c7;
+  color: #92400e;
 }
 
 button {

--- a/frontend/apps/web/src/utils/guards.ts
+++ b/frontend/apps/web/src/utils/guards.ts
@@ -1,0 +1,17 @@
+export function asArray<T>(value: T[] | null | undefined): T[] {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  return [];
+}
+
+export function safeIncludes<T>(arr: T[] | null | undefined, value: T): boolean {
+  return asArray(arr).includes(value);
+}
+
+export function getGroups(obj: { groups?: string[]; group_xmlids?: string[] } | null | undefined): string[] {
+  if (!obj) {
+    return [];
+  }
+  return asArray(obj.groups ?? obj.group_xmlids);
+}

--- a/scripts/verify/fe_guard_groups_smoke.js
+++ b/scripts/verify/fe_guard_groups_smoke.js
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+'use strict';
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function safeIncludes(arr, value) {
+  return asArray(arr).includes(value);
+}
+
+function getGroups(obj) {
+  if (!obj) return [];
+  return asArray(obj.groups ?? obj.group_xmlids);
+}
+
+function assertEqual(label, actual, expected) {
+  const ok = JSON.stringify(actual) === JSON.stringify(expected);
+  if (!ok) {
+    throw new Error(`${label} expected=${JSON.stringify(expected)} actual=${JSON.stringify(actual)}`);
+  }
+  console.log(`PASS: ${label}`);
+}
+
+function main() {
+  assertEqual('asArray(undefined)', asArray(undefined), []);
+  assertEqual('asArray(null)', asArray(null), []);
+  assertEqual('asArray([1])', asArray([1]), [1]);
+  assertEqual('safeIncludes(undefined,false)', safeIncludes(undefined, 'x'), false);
+  assertEqual('safeIncludes([a],a)', safeIncludes(['a'], 'a'), true);
+  assertEqual('getGroups(undefined)', getGroups(undefined), []);
+  assertEqual('getGroups(groups)', getGroups({ groups: ['g1'] }), ['g1']);
+  assertEqual('getGroups(group_xmlids)', getGroups({ group_xmlids: ['g2'] }), ['g2']);
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(`FAIL: ${err.message}`);
+  process.exit(1);
+}

--- a/scripts/verify/fe_recordview_hud_smoke.js
+++ b/scripts/verify/fe_recordview_hud_smoke.js
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8070';
+const DB_NAME = process.env.E2E_DB || process.env.DB_NAME || process.env.DB || '';
+const LOGIN = process.env.E2E_LOGIN || 'admin';
+const PASSWORD = process.env.E2E_PASSWORD || process.env.ADMIN_PASSWD || 'admin';
+const MODEL = process.env.MVP_MODEL || 'project.project';
+const ROOT_XMLID = process.env.ROOT_XMLID || 'smart_construction_core.menu_sc_root';
+const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR || 'artifacts';
+
+const now = new Date();
+const ts = now.toISOString().replace(/[-:]/g, '').slice(0, 15);
+const outDir = path.join(ARTIFACTS_DIR, 'codex', 'portal-shell-v0_7-ui', ts);
+
+function log(msg) {
+  console.log(`[fe_recordview_hud_smoke] ${msg}`);
+}
+
+function writeJson(file, obj) {
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(obj, null, 2));
+}
+
+function writeSummary(lines) {
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(path.join(outDir, 'summary.md'), lines.join('\n'));
+}
+
+function requestJson(url, payload, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const body = JSON.stringify(payload);
+    const opts = {
+      method: 'POST',
+      hostname: u.hostname,
+      port: u.port || (u.protocol === 'https:' ? 443 : 80),
+      path: u.pathname + u.search,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        ...headers,
+      },
+    };
+    const client = u.protocol === 'https:' ? https : http;
+    const req = client.request(opts, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        let parsed = {};
+        try {
+          parsed = JSON.parse(data || '{}');
+        } catch {
+          parsed = { raw: data };
+        }
+        resolve({ status: res.statusCode || 0, body: parsed });
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function unwrap(body) {
+  if (body && typeof body === 'object' && 'data' in body) {
+    return body.data || {};
+  }
+  return body || {};
+}
+
+async function main() {
+  if (!DB_NAME) {
+    throw new Error('DB_NAME is required (set DB_NAME or E2E_DB)');
+  }
+
+  const intentUrl = `${BASE_URL}/api/v1/intent`;
+  const summary = [];
+
+  log(`login: ${LOGIN} db=${DB_NAME}`);
+  const loginPayload = { intent: 'login', params: { db: DB_NAME, login: LOGIN, password: PASSWORD } };
+  const loginResp = await requestJson(intentUrl, loginPayload, { 'X-Anonymous-Intent': '1' });
+  if (loginResp.status >= 400 || !loginResp.body.ok) {
+    writeJson(path.join(outDir, 'login.log'), loginResp);
+    throw new Error(`login failed: status=${loginResp.status}`);
+  }
+  const token = (loginResp.body.data || {}).token;
+  if (!token) {
+    throw new Error('login response missing token');
+  }
+
+  const authHeader = {
+    Authorization: `Bearer ${token}`,
+    'X-Odoo-DB': DB_NAME,
+  };
+
+  log('app.init');
+  const initPayload = { intent: 'app.init', params: { db: DB_NAME, scene: 'web', with_preload: false, root_xmlid: ROOT_XMLID } };
+  const initResp = await requestJson(intentUrl, initPayload, authHeader);
+  if (initResp.status >= 400 || !initResp.body.ok) {
+    writeJson(path.join(outDir, 'init.log'), initResp);
+    throw new Error(`app.init failed: status=${initResp.status}`);
+  }
+
+  log('api.data.list');
+  const listPayload = { intent: 'api.data', params: { op: 'list', model: MODEL, fields: ['id', 'name'], limit: 1 } };
+  const listResp = await requestJson(intentUrl, listPayload, authHeader);
+  writeJson(path.join(outDir, 'list.log'), listResp);
+  if (listResp.status >= 400 || !listResp.body.ok) {
+    throw new Error(`list failed: status=${listResp.status}`);
+  }
+  const listData = unwrap(listResp.body);
+  const firstRecord = (listData.records || [])[0];
+  if (!firstRecord || !firstRecord.id) {
+    throw new Error('list returned no record');
+  }
+
+  const recordId = firstRecord.id;
+  const newName = `${firstRecord.name || 'Record'} (v0.7 UI)`;
+
+  log('api.data.write');
+  const writeStart = Date.now();
+  const writePayload = { intent: 'api.data.write', params: { model: MODEL, id: recordId, values: { name: newName } } };
+  const writeResp = await requestJson(intentUrl, writePayload, authHeader);
+  writeJson(path.join(outDir, 'write.log'), writeResp);
+  if (writeResp.status >= 400 || !writeResp.body.ok) {
+    throw new Error(`write failed: status=${writeResp.status}`);
+  }
+  const latencyMs = Date.now() - writeStart;
+  const writeMeta = writeResp.body.meta || {};
+
+  const hudFieldsOk = Boolean(writeMeta.trace_id && writeMeta.write_mode);
+  const footerMetaOk = Boolean(recordId && latencyMs >= 0);
+
+  summary.push(`hud_fields_ok: ${hudFieldsOk ? 'true' : 'false'}`);
+  summary.push(`footer_meta_ok: ${footerMetaOk ? 'true' : 'false'}`);
+  summary.push(`trace_id: ${writeMeta.trace_id || ''}`);
+  summary.push(`write_mode: ${writeMeta.write_mode || ''}`);
+  summary.push(`record_id: ${recordId}`);
+  summary.push(`latency_ms: ${latencyMs}`);
+
+  writeSummary(summary);
+
+  if (!hudFieldsOk || !footerMetaOk) {
+    throw new Error('hud/footer assertions failed');
+  }
+
+  log('PASS hud_fields_ok=true footer_meta_ok=true');
+  log(`artifacts: ${outDir}`);
+}
+
+main().catch((err) => {
+  console.error(`[fe_recordview_hud_smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});


### PR DESCRIPTION
Title:
Portal Shell v0.7 UI: verification-grade UX hardening + UI gate

Body:
## Summary
Phase 7 hardens the custom frontend as a verification-grade UI surface. No contract changes. Adds crash guards, layout/breadcrumb, HUD meta, and a system-bound UI gate.

## Scope
- AppShell: breadcrumb + header meta
- MenuTree: parent highlight + expand animation
- ListPage: status/sort pills + improved summary
- RecordView: status pill, success banner, footer meta, HUD (dev/?hud=1)
- Guards: crash-proof groups handling

## Verification Plane
Container plane only (system-bound).

## Gate Sequence
1. make verify.portal.view_state
2. make verify.portal.guard_groups
3. make verify.portal.fe_smoke.container
4. make verify.portal.v0_6.container
5. make verify.portal.recordview_hud_smoke.container
6. make verify.portal.ui.v0_7.container

## Gate Command (latest PASS)
make verify.portal.ui.v0_7.container \
  DB_NAME=sc_demo \
  MVP_MODEL=project.project \
  ROOT_XMLID=smart_construction_core.menu_sc_root \
  E2E_LOGIN=<REVOKED_LEGACY_USERNAME> \
  E2E_PASSWORD='***' \
  ARTIFACTS_DIR=artifacts/codex/portal-shell-v0_7-ui/20260203T081924

## Artifacts (PASS)
- v0.6 write regression: artifacts/codex/portal-shell-v0_6/20260203T081920/
- HUD smoke: artifacts/codex/portal-shell-v0_7-ui/20260203T081924/

## Notes
- Release notes: docs/ops/releases/frontend_v0_7_ui_notes.md
- Manual UX checklist retained for screenshots.

Commits
- 3b6d8e4 fix(ui): add guards to prevent groups crashes
- ccd4d89 feat(ui): harden shell layout and record UX
- 68d4229 test(ui): add v0.7 UI gate and notes
- 641defd docs(ui): refresh v0.7 gate evidence
- c938201 docs(ui): record v0.7 UI gate pass