### PR TITLE
feat(scene): dataize orchestration with DB payloads

### DIFF
--- a/addons/smart_construction_scene/__manifest__.py
+++ b/addons/smart_construction_scene/__manifest__.py
@@ -7,7 +7,9 @@
     "depends": [
         "smart_construction_core",
     ],
-    "data": [],
+    "data": [
+        "data/sc_scene_orchestration.xml",
+    ],
     "installable": True,
     "application": False,
     "license": "LGPL-3",

--- a/addons/smart_construction_scene/data/sc_scene_orchestration.xml
+++ b/addons/smart_construction_scene/data/sc_scene_orchestration.xml
@@ -1,0 +1,231 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data noupdate="0">
+        <!-- Default scene: update existing record and attach version payload -->
+        <record id="smart_construction_core.sc_scene_default" model="sc.scene">
+            <field name="state">published</field>
+            <field name="version">v2</field>
+            <field name="is_default">1</field>
+        </record>
+
+        <record id="sc_scene_version_default_v2" model="sc.scene.version">
+            <field name="scene_id" ref="smart_construction_core.sc_scene_default"/>
+            <field name="version">v2</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'default',
+                'name': '默认场景',
+                'version': 'v2',
+                'layout': {'kind': 'workspace', 'sidebar': 'fixed', 'header': 'full'},
+                'target': {'route': '/workbench?scene=default'},
+                'tiles': [
+                    {
+                        'key': 'project.work',
+                        'title': '项目工作',
+                        'subtitle': '项目看板与概览入口',
+                        'icon': 'P',
+                        'payload': {
+                            'action_xmlid': 'smart_construction_core.action_sc_project_kanban_lifecycle',
+                            'menu_xmlid': 'smart_construction_core.menu_sc_project_project'
+                        },
+                        'required_capabilities': ['project.work']
+                    },
+                    {
+                        'key': 'capability.matrix',
+                        'title': '能力矩阵',
+                        'subtitle': '查看角色可用能力',
+                        'icon': 'M',
+                        'payload': {
+                            'action_xmlid': 'smart_construction_portal.action_sc_portal_capability_matrix',
+                            'menu_xmlid': 'smart_construction_portal.menu_sc_portal_capability_matrix'
+                        },
+                        'required_capabilities': ['capability.matrix']
+                    },
+                    {
+                        'key': 'contract.work',
+                        'title': '合同工作',
+                        'subtitle': '合同台账与合同清单',
+                        'icon': 'C',
+                        'payload': {
+                            'action_xmlid': 'smart_construction_core.action_construction_contract_my',
+                            'menu_xmlid': 'smart_construction_core.menu_sc_contract_income'
+                        },
+                        'required_capabilities': ['contract.work']
+                    },
+                    {
+                        'key': 'cost.work',
+                        'title': '成本工作',
+                        'subtitle': '成本台账与预算入口',
+                        'icon': 'K',
+                        'payload': {
+                            'action_xmlid': 'smart_construction_core.action_project_cost_ledger_my',
+                            'menu_xmlid': 'smart_construction_core.menu_sc_project_cost_ledger'
+                        },
+                        'required_capabilities': ['cost.work']
+                    },
+                    {
+                        'key': 'finance.work',
+                        'title': '财务工作',
+                        'subtitle': '付款申请与财务台账',
+                        'icon': 'F',
+                        'payload': {
+                            'action_xmlid': 'smart_construction_core.action_payment_request_my',
+                            'menu_xmlid': 'smart_construction_core.menu_payment_request'
+                        },
+                        'required_capabilities': ['finance.work']
+                    }
+                ]
+            }"/>
+        </record>
+
+        <record id="smart_construction_core.sc_scene_default" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_default_v2"/>
+        </record>
+
+        <!-- Smoke scene for system-bound tests -->
+        <record id="sc_scene_smoke_default" model="sc.scene">
+            <field name="sequence">20</field>
+            <field name="name">Scene Smoke Default</field>
+            <field name="code">scene_smoke_default</field>
+            <field name="layout">grid</field>
+            <field name="state">published</field>
+            <field name="version">v2</field>
+        </record>
+
+        <record id="sc_scene_version_smoke_v2" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_smoke_default"/>
+            <field name="version">v2</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'scene_smoke_default',
+                'name': 'Scene Smoke Default',
+                'version': 'v2',
+                'layout': {'kind': 'workspace', 'sidebar': 'fixed', 'header': 'full'},
+                'target': {'route': '/workbench?scene=scene_smoke_default'},
+                'tiles': []
+            }"/>
+        </record>
+
+        <record id="sc_scene_smoke_default" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_smoke_v2"/>
+        </record>
+
+        <!-- Projects list scene -->
+        <record id="sc_scene_projects_list" model="sc.scene">
+            <field name="sequence">30</field>
+            <field name="name">项目列表</field>
+            <field name="code">projects.list</field>
+            <field name="layout">grid</field>
+            <field name="state">published</field>
+            <field name="version">v2</field>
+        </record>
+
+        <record id="sc_scene_version_projects_list_v2" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_projects_list"/>
+            <field name="version">v2</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'projects.list',
+                'name': '项目列表',
+                'version': 'v2',
+                'layout': {'kind': 'list', 'sidebar': 'fixed', 'header': 'full'},
+                'target': {
+                    'menu_xmlid': 'smart_construction_demo.menu_sc_project_list_showcase',
+                    'action_xmlid': 'smart_construction_demo.action_sc_project_list_showcase'
+                }
+            }"/>
+        </record>
+
+        <record id="sc_scene_projects_list" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_projects_list_v2"/>
+        </record>
+
+        <!-- Projects intake scene -->
+        <record id="sc_scene_projects_intake" model="sc.scene">
+            <field name="sequence">40</field>
+            <field name="name">项目立项</field>
+            <field name="code">projects.intake</field>
+            <field name="layout">grid</field>
+            <field name="state">published</field>
+            <field name="version">v2</field>
+        </record>
+
+        <record id="sc_scene_version_projects_intake_v2" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_projects_intake"/>
+            <field name="version">v2</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'projects.intake',
+                'name': '项目立项',
+                'version': 'v2',
+                'layout': {'kind': 'record', 'sidebar': 'fixed', 'header': 'full'},
+                'target': {
+                    'menu_xmlid': 'smart_construction_core.menu_sc_project_initiation'
+                }
+            }"/>
+        </record>
+
+        <record id="sc_scene_projects_intake" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_projects_intake_v2"/>
+        </record>
+
+        <!-- Projects ledger scene -->
+        <record id="sc_scene_projects_ledger" model="sc.scene">
+            <field name="sequence">50</field>
+            <field name="name">项目台账（试点）</field>
+            <field name="code">projects.ledger</field>
+            <field name="layout">grid</field>
+            <field name="state">published</field>
+            <field name="version">v2</field>
+        </record>
+
+        <record id="sc_scene_version_projects_ledger_v2" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_projects_ledger"/>
+            <field name="version">v2</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'projects.ledger',
+                'name': '项目台账（试点）',
+                'version': 'v2',
+                'layout': {'kind': 'ledger', 'sidebar': 'fixed', 'header': 'full'},
+                'target': {
+                    'menu_xmlid': 'smart_construction_core.menu_sc_project_project',
+                    'action_xmlid': 'smart_construction_core.action_sc_project_kanban_lifecycle'
+                },
+                'list_profile': {
+                    'columns': [
+                        'name',
+                        'project_code',
+                        'partner_id',
+                        'user_id',
+                        'stage_id',
+                        'write_date'
+                    ],
+                    'hidden_columns': [
+                        'message_needaction',
+                        'message_unread',
+                        'is_favorite',
+                        'display_name',
+                        '__last_update'
+                    ],
+                    'column_labels': {
+                        'name': '项目名称',
+                        'project_code': '项目编号',
+                        'partner_id': '客户',
+                        'user_id': '负责人',
+                        'stage_id': '状态',
+                        'write_date': '更新时间'
+                    },
+                    'row_primary': 'name',
+                    'row_secondary': 'partner_id'
+                },
+                'filters': [],
+                'default_sort': 'write_date desc'
+            }"/>
+        </record>
+
+        <record id="sc_scene_projects_ledger" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_projects_ledger_v2"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
## Summary
- Move scene orchestration to DB payloads via sc.scene.version records.
- Seed default/scene_smoke_default/projects.list/intake/ledger scenes with layout/target/list_profile/tiles.
- Prefer DB scenes in smart_construction_scene with fallback to code configs.

## Verification (system-bound)
- `E2E_LOGIN=<REVOKED_LEGACY_USERNAME> E2E_PASSWORD=<REVOKED_LEGACY_SECRET> make verify.portal.ui.v0_8.semantic.container`
  - PASS artifacts:
    - `/mnt/artifacts/codex/portal-shell-v0_8-semantic/20260206T015109`
    - `/mnt/artifacts/codex/portal-shell-v0_8-6/20260206T015114`
    - `/mnt/artifacts/codex/portal-shell-v0_9-1-1/20260206T015117`
    - `/mnt/artifacts/codex/portal-shell-v0_9-2/20260206T015130`

## Notes
- DB scenes are now the primary source; code configs remain as fallback for safety.
- Payloads carry action/menu xmlids, resolved at system.init.