### PR TITLE
Portal v0.9.5: scene list profile + default sort for projects.list (r2)

### DIFF
--- a/addons/smart_construction_scene/data/sc_scene_orchestration.xml
+++ b/addons/smart_construction_scene/data/sc_scene_orchestration.xml
@@ -134,7 +134,36 @@
                 'target': {
                     'menu_xmlid': 'smart_construction_demo.menu_sc_project_list_showcase',
                     'action_xmlid': 'smart_construction_demo.action_sc_project_list_showcase'
-                }
+                },
+                'list_profile': {
+                    'columns': [
+                        'name',
+                        'project_code',
+                        'partner_id',
+                        'user_id',
+                        'stage_id',
+                        'write_date'
+                    ],
+                    'hidden_columns': [
+                        'message_needaction',
+                        'message_unread',
+                        'is_favorite',
+                        'display_name',
+                        '__last_update'
+                    ],
+                    'column_labels': {
+                        'name': '项目名称',
+                        'project_code': '项目编号',
+                        'partner_id': '客户',
+                        'user_id': '负责人',
+                        'stage_id': '状态',
+                        'write_date': '更新时间'
+                    },
+                    'row_primary': 'name',
+                    'row_secondary': 'partner_id'
+                },
+                'filters': [],
+                'default_sort': 'write_date desc'
             }"/>
         </record>
 

--- a/addons/smart_construction_scene/scene_registry.py
+++ b/addons/smart_construction_scene/scene_registry.py
@@ -1,6 +1,37 @@
 # -*- coding: utf-8 -*-
 
 SCENE_VERSION = "v2"
+PROJECTS_DEFAULT_SORT = "write_date desc"
+
+
+def _projects_list_profile():
+    return {
+        "columns": [
+            "name",
+            "project_code",
+            "partner_id",
+            "user_id",
+            "stage_id",
+            "write_date",
+        ],
+        "hidden_columns": [
+            "message_needaction",
+            "message_unread",
+            "is_favorite",
+            "display_name",
+            "__last_update",
+        ],
+        "column_labels": {
+            "name": "项目名称",
+            "project_code": "项目编号",
+            "partner_id": "客户",
+            "user_id": "负责人",
+            "stage_id": "状态",
+            "write_date": "更新时间",
+        },
+        "row_primary": "name",
+        "row_secondary": "partner_id",
+    }
 
 
 def get_scene_version():
@@ -59,6 +90,17 @@ def _normalize_scene(scene):
                     payload = tile.get("payload") if isinstance(tile.get("payload"), dict) else {}
                     payload.setdefault("scene_key", "projects.ledger")
                     tile["payload"] = payload
+    scene = _apply_scene_defaults(scene)
+    return scene
+
+
+def _apply_scene_defaults(scene):
+    code = scene.get("code") or scene.get("key") or ""
+    if code in ("projects.list", "projects.ledger"):
+        if not scene.get("list_profile"):
+            scene["list_profile"] = _projects_list_profile()
+        if not scene.get("default_sort"):
+            scene["default_sort"] = PROJECTS_DEFAULT_SORT
     return scene
 
 
@@ -153,6 +195,9 @@ def load_scene_configs(env):
                 "menu_xmlid": "smart_construction_demo.menu_sc_project_list_showcase",
                 "action_xmlid": "smart_construction_demo.action_sc_project_list_showcase",
             },
+            "list_profile": _projects_list_profile(),
+            "filters": [],
+            "default_sort": PROJECTS_DEFAULT_SORT,
         },
         {
             "code": "projects.intake",
@@ -170,35 +215,9 @@ def load_scene_configs(env):
                 "menu_xmlid": "smart_construction_core.menu_sc_project_project",
                 "action_xmlid": "smart_construction_core.action_sc_project_kanban_lifecycle",
             },
-            "list_profile": {
-                "columns": [
-                    "name",
-                    "project_code",
-                    "partner_id",
-                    "user_id",
-                    "stage_id",
-                    "write_date",
-                ],
-                "hidden_columns": [
-                    "message_needaction",
-                    "message_unread",
-                    "is_favorite",
-                    "display_name",
-                    "__last_update",
-                ],
-                "column_labels": {
-                    "name": "项目名称",
-                    "project_code": "项目编号",
-                    "partner_id": "客户",
-                    "user_id": "负责人",
-                    "stage_id": "状态",
-                    "write_date": "更新时间",
-                },
-                "row_primary": "name",
-                "row_secondary": "partner_id",
-            },
+            "list_profile": _projects_list_profile(),
             "filters": [],
-            "default_sort": "write_date desc",
+            "default_sort": PROJECTS_DEFAULT_SORT,
         },
     ]
     if not db_scenes:

--- a/scripts/verify/fe_scene_default_sort_smoke.js
+++ b/scripts/verify/fe_scene_default_sort_smoke.js
@@ -124,17 +124,27 @@ async function main() {
 
   const data = initResp.body.data || {};
   const scenes = Array.isArray(data.scenes) ? data.scenes : [];
-  const ledger = scenes.find((item) => (item && (item.code === 'projects.ledger' || item.key === 'projects.ledger')));
+  const getScene = (key) => scenes.find((item) => item && (item.code === key || item.key === key));
+  const ledger = getScene('projects.ledger');
+  const list = getScene('projects.list');
   if (!ledger) {
     throw new Error('scene projects.ledger missing');
   }
-  const defaultSort = ledger.default_sort || '';
+  if (!list) {
+    throw new Error('scene projects.list missing');
+  }
+  const ledgerSort = ledger.default_sort || '';
+  const listSort = list.default_sort || '';
 
-  summary.push(`default_sort: ${defaultSort || '-'}`);
+  summary.push(`ledger_default_sort: ${ledgerSort || '-'}`);
+  summary.push(`list_default_sort: ${listSort || '-'}`);
   writeSummary(summary);
 
-  if (!defaultSort) {
-    throw new Error('default_sort missing');
+  if (!ledgerSort.trim()) {
+    throw new Error('projects.ledger default_sort missing');
+  }
+  if (!listSort.trim()) {
+    throw new Error('projects.list default_sort missing');
   }
 
   log('PASS default_sort');

--- a/scripts/verify/fe_scene_list_profile_smoke.js
+++ b/scripts/verify/fe_scene_list_profile_smoke.js
@@ -124,25 +124,43 @@ async function main() {
 
   const data = initResp.body.data || {};
   const scenes = Array.isArray(data.scenes) ? data.scenes : [];
-  const ledger = scenes.find((item) => (item && (item.code === 'projects.ledger' || item.key === 'projects.ledger')));
+  const getScene = (key) => scenes.find((item) => item && (item.code === key || item.key === key));
+  const ledger = getScene('projects.ledger');
+  const list = getScene('projects.list');
   if (!ledger) {
     throw new Error('scene projects.ledger missing');
   }
-  const profile = ledger.list_profile || {};
-  const columns = profile.columns || [];
-  const hidden = profile.hidden_columns || [];
+  if (!list) {
+    throw new Error('scene projects.list missing');
+  }
+  const ledgerProfile = ledger.list_profile || {};
+  const listProfile = list.list_profile || {};
+  const ledgerColumns = ledgerProfile.columns || [];
+  const listColumns = listProfile.columns || [];
+  const ledgerHidden = ledgerProfile.hidden_columns || [];
+  const listHidden = listProfile.hidden_columns || [];
 
-  summary.push(`scene_found: ${Boolean(ledger)}`);
-  summary.push(`columns_count: ${columns.length}`);
-  summary.push(`hidden_count: ${hidden.length}`);
-  summary.push(`default_sort: ${ledger.default_sort || '-'}`);
+  summary.push(`ledger_found: ${Boolean(ledger)}`);
+  summary.push(`ledger_columns: ${ledgerColumns.length}`);
+  summary.push(`ledger_hidden: ${ledgerHidden.length}`);
+  summary.push(`ledger_default_sort: ${ledger.default_sort || '-'}`);
+  summary.push(`list_found: ${Boolean(list)}`);
+  summary.push(`list_columns: ${listColumns.length}`);
+  summary.push(`list_hidden: ${listHidden.length}`);
+  summary.push(`list_default_sort: ${list.default_sort || '-'}`);
   writeSummary(summary);
 
-  if (!columns.length) {
-    throw new Error('list_profile.columns missing');
+  if (!ledgerColumns.length) {
+    throw new Error('projects.ledger list_profile.columns missing');
   }
-  if (!hidden.includes('message_needaction')) {
-    throw new Error('list_profile.hidden_columns missing message_needaction');
+  if (!listColumns.length) {
+    throw new Error('projects.list list_profile.columns missing');
+  }
+  if (!ledgerHidden.includes('message_needaction')) {
+    throw new Error('projects.ledger list_profile.hidden_columns missing message_needaction');
+  }
+  if (!listHidden.includes('message_needaction')) {
+    throw new Error('projects.list list_profile.hidden_columns missing message_needaction');
   }
 
   log('PASS list_profile');


### PR DESCRIPTION
## Summary
- Apply list_profile + default_sort defaults to projects.list (DB payload + code normalization).
- Normalize list_profile/default_sort for projects scenes (list/ledger).
- Extend scene smokes to validate projects.list + projects.ledger.

## Verification (system-bound)
- DB_NAME=sc_demo E2E_LOGIN=<REVOKED_LEGACY_USERNAME> E2E_PASSWORD='<REVOKED_LEGACY_SECRET>' make verify.portal.scene_list_profile_smoke.container
- DB_NAME=sc_demo E2E_LOGIN=<REVOKED_LEGACY_USERNAME> E2E_PASSWORD='<REVOKED_LEGACY_SECRET>' make verify.portal.scene_default_sort_smoke.container

## Evidence
- /mnt/artifacts/codex/portal-shell-v0_9-2/20260206T022605
- /mnt/artifacts/codex/portal-shell-v0_9-2/20260206T022621