### PR TITLE
[split] runtime core scene delivery semantics

### DIFF
--- a/addons/smart_core/core/scene_ready_contract_builder.py
+++ b/addons/smart_core/core/scene_ready_contract_builder.py
@@ -88,6 +88,21 @@ def _normalize_scene(item: Dict[str, Any]) -> Dict[str, Any]:
     }
 
 
+def _scene_switch_catalog(rows: List[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    catalog: Dict[str, Dict[str, Any]] = {}
+    for row in rows or []:
+        payload = _as_dict(row)
+        scene_key = _text(payload.get("code") or payload.get("key"))
+        if not scene_key:
+            continue
+        target = _as_dict(payload.get("target"))
+        catalog[scene_key] = {
+            "label": _text(payload.get("name") or payload.get("title") or scene_key),
+            "route": _text(target.get("route")) or f"/s/{scene_key}",
+        }
+    return catalog
+
+
 def _normalize_actions(item: Dict[str, Any]) -> List[Dict[str, Any]]:
     target = item.get("target") if isinstance(item.get("target"), dict) else {}
     out: List[Dict[str, Any]] = []
@@ -506,11 +521,28 @@ def _scene_ready_entry(
     *,
     runtime_context: Dict[str, Any] | None = None,
     action_surface_strategy: Dict[str, Any] | None = None,
+    scene_catalog: Dict[str, Dict[str, Any]] | None = None,
 ) -> Dict[str, Any]:
     scene_key = _text(item.get("code") or item.get("key"))
     scene_payload = dict(item)
     runtime_ctx = runtime_context if isinstance(runtime_context, dict) else {}
     scene_provider_payload = _resolve_scene_provider_payload(scene_key, runtime_ctx)
+
+    if scene_provider_payload:
+        for field in (
+            "guidance",
+            "primary_action",
+            "next_action",
+            "fallback_strategy",
+            "delivery_handoff_v1",
+            "next_scene",
+            "next_scene_key",
+            "next_scene_route",
+        ):
+            current = scene_payload.get(field)
+            provider_value = scene_provider_payload.get(field)
+            if current in (None, {}, [], "") and provider_value not in (None, {}, [], ""):
+                scene_payload[field] = provider_value
 
     if not isinstance(scene_payload.get("actions"), list):
         provider_actions = scene_provider_payload.get("default_actions") if isinstance(scene_provider_payload.get("default_actions"), list) else []
@@ -566,7 +598,20 @@ def _scene_ready_entry(
         ui_base_contract=ui_base_contract,
         provider_registry=provider_registry,
     )
-    for field in ("surface", "view_modes", "sections", "projection", "action_surface", "runtime_policy", "scene_tier"):
+    for field in (
+        "surface",
+        "view_modes",
+        "sections",
+        "projection",
+        "action_surface",
+        "runtime_policy",
+        "scene_tier",
+        "guidance",
+        "primary_action",
+        "next_action",
+        "fallback_strategy",
+        "delivery_handoff_v1",
+    ):
         if field in compiled and compiled.get(field) not in (None, {}, []):
             continue
         source_value = scene_payload.get(field)
@@ -584,6 +629,25 @@ def _scene_ready_entry(
             compiled_action_surface["selection_mode"] = _text(seeded_action_surface.get("selection_mode"))
     if compiled_action_surface:
         compiled["action_surface"] = compiled_action_surface
+    related_scenes = _as_list(scene_payload.get("related_scenes"))
+    if related_scenes:
+        compiled["related_scenes"] = related_scenes
+    compiled_search_surface = _normalize_search_surface(_as_dict(compiled.get("search_surface")))
+    seeded_search_surface = _normalize_search_surface(_as_dict(scene_payload.get("search_surface")))
+    if not _search_surface_nonempty(compiled_search_surface) and _search_surface_nonempty(seeded_search_surface):
+        compiled["search_surface"] = seeded_search_surface
+    compiled_permission_surface = _normalize_permission_surface(_as_dict(compiled.get("permission_surface")))
+    seeded_permission_surface = _normalize_permission_surface(_as_dict(scene_payload.get("permission_surface")))
+    if not _permission_surface_nonempty(compiled_permission_surface) and _permission_surface_nonempty(seeded_permission_surface):
+        compiled["permission_surface"] = seeded_permission_surface
+    compiled_workflow_surface = _as_dict(compiled.get("workflow_surface"))
+    seeded_workflow_surface = _as_dict(scene_payload.get("workflow_surface"))
+    if not _workflow_surface_nonempty(compiled_workflow_surface) and _workflow_surface_nonempty(seeded_workflow_surface):
+        compiled["workflow_surface"] = dict(seeded_workflow_surface)
+    compiled_validation_surface = _as_dict(compiled.get("validation_surface"))
+    seeded_validation_surface = _as_dict(scene_payload.get("validation_surface"))
+    if not _validation_surface_nonempty(compiled_validation_surface) and _validation_surface_nonempty(seeded_validation_surface):
+        compiled["validation_surface"] = dict(seeded_validation_surface)
     page = dict(compiled.get("page") or {})
     zones = page.get("zones") if isinstance(page.get("zones"), list) else []
     if not zones:
@@ -651,14 +715,16 @@ def _scene_ready_entry(
                 return next_key, next_route
         return "", ""
 
-    next_scene_key = _text(item.get("next_scene") or item.get("next_scene_key"))
-    next_scene_route = _text(item.get("next_scene_route"))
-    if not next_scene_key and isinstance(item.get("runtime"), dict):
-        next_scene_key = _text(item.get("runtime", {}).get("next_scene") or item.get("runtime", {}).get("next_scene_key"))
-    if not next_scene_route and isinstance(item.get("runtime"), dict):
-        next_scene_route = _text(item.get("runtime", {}).get("next_scene_route"))
-    if not next_scene_key and isinstance(item.get("policies"), dict):
-        nav_policy = item.get("policies", {}).get("navigation_policy") if isinstance(item.get("policies", {}).get("navigation_policy"), dict) else {}
+    next_scene_key = _text(scene_payload.get("next_scene") or scene_payload.get("next_scene_key") or item.get("next_scene") or item.get("next_scene_key"))
+    next_scene_route = _text(scene_payload.get("next_scene_route") or item.get("next_scene_route"))
+    payload_runtime = scene_payload.get("runtime") if isinstance(scene_payload.get("runtime"), dict) else {}
+    if not next_scene_key and payload_runtime:
+        next_scene_key = _text(payload_runtime.get("next_scene") or payload_runtime.get("next_scene_key"))
+    if not next_scene_route and payload_runtime:
+        next_scene_route = _text(payload_runtime.get("next_scene_route"))
+    policies_payload = scene_payload.get("policies") if isinstance(scene_payload.get("policies"), dict) else item.get("policies") if isinstance(item.get("policies"), dict) else {}
+    if not next_scene_key and policies_payload:
+        nav_policy = policies_payload.get("navigation_policy") if isinstance(policies_payload.get("navigation_policy"), dict) else {}
         next_scene_key = _text(nav_policy.get("next_scene") or nav_policy.get("next_scene_key"))
         next_scene_route = next_scene_route or _text(nav_policy.get("next_scene_route"))
 
@@ -690,6 +756,31 @@ def _scene_ready_entry(
     if orchestrator_input:
         meta_payload["ui_base_orchestrator_input"] = orchestrator_input
     compiled["meta"] = meta_payload
+    compiled = apply_scene_ready_parser_semantic_bridge(compiled, ui_base_contract)
+    compiled = apply_scene_ready_entry_semantic_bridge(compiled)
+    compiled = apply_scene_ready_search_semantic_bridge(compiled)
+    compiled = apply_scene_ready_semantic_orchestration_bridge(
+        compiled,
+        scene_key=scene_key,
+        scene_catalog=scene_catalog,
+    )
+    compiled = apply_scene_ready_action_semantic_bridge(compiled)
+    compiled_list_surface = _normalize_list_surface(compiled)
+    seeded_list_surface = _normalize_list_surface(scene_payload)
+    if _list_surface_nonempty(compiled_list_surface):
+        compiled["list_surface"] = compiled_list_surface
+    elif _list_surface_nonempty(seeded_list_surface):
+        compiled["list_surface"] = seeded_list_surface
+    compiled_form_surface = _normalize_form_surface(compiled)
+    seeded_form_surface = _normalize_form_surface(scene_payload)
+    merged_form_surface = _merge_form_surface(compiled_form_surface, seeded_form_surface)
+    if _form_surface_nonempty(merged_form_surface):
+        compiled["form_surface"] = merged_form_surface
+    elif _form_surface_nonempty(seeded_form_surface):
+        compiled["form_surface"] = seeded_form_surface
+    optimization_composition = _normalize_optimization_composition(compiled)
+    if _optimization_composition_nonempty(optimization_composition):
+        compiled["optimization_composition"] = optimization_composition
     compiled = _apply_pilot_strict_contract(scene_key, item, compiled)
     return compiled
 
@@ -713,12 +804,14 @@ def build_scene_ready_contract_v1(
             continue
         scene_rows.append(item)
     scene_rows.sort(key=lambda row: _text(row.get("code") or row.get("key")))
+    scene_catalog = _scene_switch_catalog(scene_rows)
 
     entries = [
         _scene_ready_entry(
             row,
             runtime_context=runtime_context,
             action_surface_strategy=action_surface_strategy,
+            scene_catalog=scene_catalog,
         )
         for row in scene_rows
     ]

--- a/addons/smart_core/core/system_init_payload_builder.py
+++ b/addons/smart_core/core/system_init_payload_builder.py
@@ -1,8 +1,529 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from urllib.parse import urlparse
+
 
 class SystemInitPayloadBuilder:
+    BUILD_MODE_BOOT = "boot"
+    BUILD_MODE_PRELOAD = "preload"
+    BUILD_MODE_DEBUG = "debug"
+    MINIMAL_ALLOWED_KEYS = {
+        "delivery_engine_v1",
+        "edition_runtime_v1",
+        "user",
+        "nav",
+        "nav_meta",
+        "default_route",
+        "scene_ready_contract_v1",
+        "intents",
+        "feature_flags",
+        "role_surface",
+        "semantic_runtime",
+        "released_scene_semantic_surface",
+        "version",
+        "init_meta",
+    }
+    MINIMAL_NAV_META_KEYS = {
+        "nav_source",
+        "platform_minimum_surface",
+        "platform_minimum_reason",
+        "role_surface_pruned",
+        "role_surface_code",
+        "semantic_scene_key",
+        "semantic_source_view",
+        "semantic_view_type",
+    }
+    MINIMAL_EXT_FACT_KEYS = {
+        "enterprise_enablement",
+    }
+
+    @staticmethod
+    def _build_entry_target(*, scene_key: str = "", route: str = "", menu_id=None, action_id=None, model: str = "", record_id=None) -> dict:
+        normalized_scene_key = str(scene_key or "").strip()
+        if not normalized_scene_key:
+            normalized_scene_key = SystemInitPayloadBuilder._extract_scene_key_from_route(route)
+        if not normalized_scene_key:
+            return {}
+        target = {
+            "type": "scene",
+            "scene_key": normalized_scene_key,
+        }
+        normalized_route = str(route or "").strip()
+        if normalized_route:
+            target["route"] = normalized_route
+        compatibility = {}
+        if isinstance(menu_id, int) and menu_id > 0:
+            compatibility["menu_id"] = menu_id
+        if isinstance(action_id, int) and action_id > 0:
+            compatibility["action_id"] = action_id
+        normalized_model = str(model or "").strip()
+        if normalized_model:
+            compatibility["model"] = normalized_model
+        if isinstance(record_id, int) and record_id > 0:
+            compatibility["record_id"] = record_id
+        if normalized_model and isinstance(record_id, int) and record_id > 0:
+            record_entry = {
+                "model": normalized_model,
+                "record_id": record_id,
+            }
+            if isinstance(action_id, int) and action_id > 0:
+                record_entry["action_id"] = action_id
+            if isinstance(menu_id, int) and menu_id > 0:
+                record_entry["menu_id"] = menu_id
+            target["record_entry"] = record_entry
+        if compatibility:
+            target["compatibility_refs"] = compatibility
+        return target
+
+    @classmethod
+    def _normalize_default_route(cls, route_payload: dict | None) -> dict:
+        payload = dict(route_payload or {})
+        if not payload:
+            return payload
+        entry_target = cls._build_entry_target(
+            scene_key=str(payload.get("scene_key") or "").strip(),
+            route=str(payload.get("route") or "").strip(),
+            menu_id=payload.get("menu_id") if isinstance(payload.get("menu_id"), int) else None,
+            action_id=payload.get("action_id") if isinstance(payload.get("action_id"), int) else None,
+            model=str(payload.get("model") or "").strip(),
+            record_id=payload.get("record_id") if isinstance(payload.get("record_id"), int) else None,
+        )
+        if entry_target:
+            payload["entry_target"] = entry_target
+        return payload
+
+    @classmethod
+    def _normalize_role_surface(cls, role_surface: dict | None) -> dict:
+        payload = dict(role_surface or {})
+        if not payload:
+            return payload
+        entry_target = cls._build_entry_target(
+            scene_key=str(payload.get("landing_scene_key") or "").strip(),
+            route=str(payload.get("landing_path") or "").strip(),
+            menu_id=payload.get("landing_menu_id") if isinstance(payload.get("landing_menu_id"), int) else None,
+        )
+        if entry_target:
+            payload["landing_entry_target"] = entry_target
+        return payload
+
+    @classmethod
+    def _normalize_nav_tree(cls, nodes: list | None) -> list:
+        normalized = []
+        for node in nodes or []:
+            if not isinstance(node, dict):
+                continue
+            row = dict(node)
+            row["children"] = cls._normalize_nav_tree(row.get("children") if isinstance(row.get("children"), list) else [])
+            meta = dict(row.get("meta") or {})
+            entry_target = cls._build_entry_target(
+                scene_key=str(row.get("scene_key") or meta.get("scene_key") or "").strip(),
+                route=str(meta.get("route") or row.get("route") or "").strip(),
+                menu_id=row.get("menu_id") if isinstance(row.get("menu_id"), int) else None,
+                action_id=meta.get("action_id") if isinstance(meta.get("action_id"), int) else None,
+                model=str(meta.get("model") or row.get("model") or "").strip(),
+                record_id=meta.get("record_id") if isinstance(meta.get("record_id"), int) else None,
+            )
+            if entry_target:
+                meta["entry_target"] = entry_target
+            row["meta"] = meta
+            normalized.append(row)
+        return normalized
+
+    @staticmethod
+    def _extract_scene_key_from_route(route: str) -> str:
+        raw = str(route or "").strip()
+        if not raw:
+            return ""
+        try:
+            parsed = urlparse(raw)
+            path = str(parsed.path or "").strip()
+            if path.startswith("/s/"):
+                return path.replace("/s/", "", 1).strip("/")
+        except Exception:
+            return ""
+        return ""
+
+    @classmethod
+    def resolve_build_mode(cls, params: dict | None = None) -> str:
+        params = params if isinstance(params, dict) else {}
+        explicit = str(
+            params.get("_build_mode")
+            or params.get("build_mode")
+            or params.get("startup_build_mode")
+            or ""
+        ).strip().lower()
+        if explicit in {cls.BUILD_MODE_BOOT, cls.BUILD_MODE_PRELOAD, cls.BUILD_MODE_DEBUG}:
+            return explicit
+        if bool(params.get("with_preload", False)):
+            return cls.BUILD_MODE_PRELOAD
+        return cls.BUILD_MODE_BOOT
+
+    @classmethod
+    def _build_minimal_nav_meta(cls, row: dict) -> dict:
+        raw = row.get("nav_meta") if isinstance(row.get("nav_meta"), dict) else {}
+        minimal: dict = {}
+        for key in cls.MINIMAL_NAV_META_KEYS:
+            if key in raw:
+                minimal[key] = raw.get(key)
+        return minimal
+
+    @classmethod
+    def _build_minimal_init_meta(cls, row: dict, *, params: dict | None = None) -> dict:
+        params = params if isinstance(params, dict) else {}
+        preload_requested = bool(params.get("with_preload", False))
+        default_route = row.get("default_route") if isinstance(row.get("default_route"), dict) else {}
+        role_surface = row.get("role_surface") if isinstance(row.get("role_surface"), dict) else {}
+        role_entries = row.get("role_entries") if isinstance(row.get("role_entries"), list) else []
+        home_blocks = row.get("home_blocks") if isinstance(row.get("home_blocks"), list) else []
+
+        scene_subset: list[str] = []
+        landing_scene_key = str(default_route.get("scene_key") or role_surface.get("landing_scene_key") or "workspace.home").strip()
+        if landing_scene_key:
+            scene_subset.append(landing_scene_key)
+
+        fallback_scene_key = "workspace.home"
+        if fallback_scene_key not in scene_subset:
+            scene_subset.append(fallback_scene_key)
+
+        deep_scene_key = str(params.get("scene_key") or "").strip()
+        if not deep_scene_key:
+            deep_scene_key = cls._extract_scene_key_from_route(str(params.get("route") or ""))
+        if deep_scene_key and deep_scene_key not in scene_subset:
+            scene_subset.append(deep_scene_key)
+
+        role_scene_candidates = role_surface.get("scene_candidates") if isinstance(role_surface.get("scene_candidates"), list) else []
+        for candidate in role_scene_candidates:
+            scene_key = str(candidate or "").strip()
+            if not scene_key or scene_key in scene_subset:
+                continue
+            scene_subset.append(scene_key)
+
+        return {
+            "contract_mode": str(row.get("contract_mode") or "default"),
+            "preload_requested": preload_requested,
+            "scene_subset": scene_subset,
+            "scene_subset_count": len(scene_subset),
+            "page_contract_meta": {
+                "intent": "scene.page_contract",
+            },
+            "workspace_home_preload_hint": {
+                "intent": "ui.contract",
+                "scene_key": landing_scene_key or "workspace.home",
+            },
+        }
+
+    @classmethod
+    def _build_minimal_ext_facts(cls, row: dict) -> dict:
+        ext_facts = row.get("ext_facts") if isinstance(row.get("ext_facts"), dict) else {}
+        minimal: dict = {}
+        for key in cls.MINIMAL_EXT_FACT_KEYS:
+            value = ext_facts.get(key)
+            if isinstance(value, dict) and value:
+                minimal[key] = value
+        return minimal
+
+    @classmethod
+    def resolve_startup_scene_subset(cls, row: dict, *, params: dict | None = None) -> list[str]:
+        init_meta = cls._build_minimal_init_meta(row if isinstance(row, dict) else {}, params=params)
+        scene_subset = init_meta.get("scene_subset") if isinstance(init_meta.get("scene_subset"), list) else []
+        unique_subset: list[str] = []
+        for item in scene_subset:
+            key = str(item or "").strip()
+            if key and key not in unique_subset:
+                unique_subset.append(key)
+        return unique_subset
+
+    @classmethod
+    def build_startup_surface(
+        cls,
+        data: dict,
+        *,
+        params: dict | None = None,
+        build_mode: str | None = None,
+        inspect_payload: dict | None = None,
+    ) -> dict:
+        row = data if isinstance(data, dict) else {}
+        params = params if isinstance(params, dict) else {}
+        resolved_build_mode = build_mode or cls.resolve_build_mode(params)
+
+        nav = cls._normalize_nav_tree(row.get("nav") if isinstance(row.get("nav"), list) else [])
+        default_route = cls._normalize_default_route(row.get("default_route") if isinstance(row.get("default_route"), dict) else {})
+        intents = row.get("intents") if isinstance(row.get("intents"), list) else []
+        feature_flags = row.get("feature_flags") if isinstance(row.get("feature_flags"), dict) else {}
+        role_surface = cls._normalize_role_surface(row.get("role_surface") if isinstance(row.get("role_surface"), dict) else {})
+        role_entries = row.get("role_entries") if isinstance(row.get("role_entries"), list) else []
+        home_blocks = row.get("home_blocks") if isinstance(row.get("home_blocks"), list) else []
+
+        version = {
+            "contract_version": str(row.get("contract_version") or "1.0.0"),
+            "schema_version": str(row.get("schema_version") or "1.0.0"),
+            "scene_version": str(row.get("scene_version") or "v1"),
+        }
+        init_meta = cls._build_minimal_init_meta(row, params=params)
+
+        minimal = {
+            "user": row.get("user") if isinstance(row.get("user"), dict) else {},
+            "nav": nav,
+            "nav_meta": cls._build_minimal_nav_meta(row),
+            "default_route": default_route,
+            "intents": intents,
+            "feature_flags": feature_flags,
+            "role_surface": role_surface,
+            "scene_channel": str(row.get("scene_channel") or ""),
+            "scene_channel_selector": str(row.get("scene_channel_selector") or ""),
+            "scene_channel_source_ref": str(row.get("scene_channel_source_ref") or ""),
+            "scene_contract_ref": row.get("scene_contract_ref"),
+            "version": version,
+            "init_meta": init_meta,
+        }
+        pinned_param = str(params.get("scene_use_pinned") or "").strip().lower()
+        rollback_param = str(params.get("scene_rollback") or "").strip().lower()
+        pinned_requested = pinned_param in {"1", "true", "yes", "on"}
+        rollback_requested = rollback_param in {"1", "true", "yes", "on"}
+        rollback_ref = str(row.get("scene_contract_ref") or "").strip()
+        rollback_active = pinned_requested or rollback_requested or ("PINNED.json" in rollback_ref)
+        if rollback_active:
+            minimal["scene_diagnostics"] = {
+                "rollback_active": True,
+                "rollback_ref": rollback_ref or "stable/PINNED.json",
+                "schema_version": str(row.get("schema_version") or "1.0.0"),
+                "scene_version": str(row.get("scene_version") or "v1"),
+                "loaded_from": "contract",
+                "resolve_errors": [],
+                "drift": [],
+                "normalize_warnings": [],
+            }
+        minimal_ext_facts = cls._build_minimal_ext_facts(row)
+        if minimal_ext_facts:
+            minimal["ext_facts"] = minimal_ext_facts
+        if isinstance(row.get("delivery_engine_v1"), dict):
+            minimal["delivery_engine_v1"] = row.get("delivery_engine_v1")
+        if isinstance(row.get("edition_runtime_v1"), dict):
+            minimal["edition_runtime_v1"] = row.get("edition_runtime_v1")
+        if isinstance(row.get("release_navigation_v1"), dict):
+            minimal["release_navigation_v1"] = row.get("release_navigation_v1")
+        if isinstance(row.get("semantic_runtime"), dict):
+            minimal["semantic_runtime"] = cls._build_minimal_semantic_runtime(
+                row.get("semantic_runtime")
+            )
+        if isinstance(row.get("released_scene_semantic_surface"), dict):
+            minimal["released_scene_semantic_surface"] = cls._build_minimal_released_scene_semantic_surface(
+                row.get("released_scene_semantic_surface")
+            )
+        if isinstance(row.get("scene_ready_contract_v1"), dict):
+            if bool(params.get("with_preload", False)):
+                minimal["scene_ready_contract_v1"] = row.get("scene_ready_contract_v1")
+            else:
+                minimal["scene_ready_contract_v1"] = cls._build_minimal_scene_ready_contract(
+                    row.get("scene_ready_contract_v1")
+                )
+        if bool(params.get("with_preload", False)):
+            if isinstance(row.get("workspace_home"), dict):
+                minimal["workspace_home"] = row.get("workspace_home")
+        if role_entries:
+            minimal["role_entries"] = role_entries
+        if home_blocks:
+            minimal["home_blocks"] = home_blocks
+        if resolved_build_mode == cls.BUILD_MODE_DEBUG:
+            minimal["startup_inspect"] = inspect_payload if isinstance(inspect_payload, dict) else {}
+        return minimal
+
+    @classmethod
+    def _build_minimal_scene_ready_contract(cls, payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        scenes = raw.get("scenes") if isinstance(raw.get("scenes"), list) else []
+        compact_scenes: list[dict] = []
+        for item in scenes:
+            if not isinstance(item, dict):
+                continue
+            compact: dict = {}
+            for key in (
+                "scene",
+                "page",
+                "parser_semantic_surface",
+                "semantic_view",
+                "semantic_page",
+                "view_type",
+                "guidance",
+                "primary_action",
+                "next_action",
+                "fallback_strategy",
+                "delivery_handoff_v1",
+                "runtime_handoff_surface",
+                "product_delivery_surface",
+                "permission_surface",
+                "workflow_surface",
+                "actions",
+                "next_scene",
+                "next_scene_route",
+            ):
+                value = item.get(key)
+                if value not in (None, {}, []):
+                    compact[key] = value
+            compact_search = cls._compact_search_surface(item.get("search_surface"))
+            if compact_search:
+                compact["search_surface"] = compact_search
+            list_surface = item.get("list_surface") if isinstance(item.get("list_surface"), dict) else {}
+            if list_surface:
+                compact_list_surface = {}
+                for key in ("columns", "hidden_columns", "default_sort", "available_view_modes", "default_mode"):
+                    value = list_surface.get(key)
+                    if value not in (None, {}, []):
+                        compact_list_surface[key] = value
+                if compact_list_surface:
+                    compact["list_surface"] = compact_list_surface
+            form_surface = item.get("form_surface") if isinstance(item.get("form_surface"), dict) else {}
+            if form_surface:
+                compact_form_surface = {}
+                for key in ("layout", "header_actions", "stat_actions", "relation_fields", "field_behavior_map", "flags"):
+                    value = form_surface.get(key)
+                    if value not in (None, {}, []):
+                        compact_form_surface[key] = value
+                if compact_form_surface:
+                    compact["form_surface"] = compact_form_surface
+            optimization_composition = item.get("optimization_composition") if isinstance(item.get("optimization_composition"), dict) else {}
+            if optimization_composition:
+                compact_optimization_composition = {}
+                for key in ("toolbar_sections", "active_conditions", "high_frequency_filters", "advanced_filters"):
+                    value = optimization_composition.get(key)
+                    if value not in (None, {}, []):
+                        compact_optimization_composition[key] = value
+                if compact_optimization_composition:
+                    compact["optimization_composition"] = compact_optimization_composition
+            action_surface = item.get("action_surface") if isinstance(item.get("action_surface"), dict) else {}
+            if action_surface:
+                compact_action_surface = {}
+                for key in ("primary_actions", "groups", "selection_mode", "counts", "batch_capabilities"):
+                    value = action_surface.get(key)
+                    if value not in (None, {}, []):
+                        compact_action_surface[key] = value
+                if compact_action_surface:
+                    compact["action_surface"] = compact_action_surface
+            compact_validation_surface = cls._compact_validation_surface(item.get("validation_surface"))
+            if compact_validation_surface:
+                compact["validation_surface"] = compact_validation_surface
+            compact_permission_surface = cls._compact_permission_surface(item.get("permission_surface"))
+            if compact_permission_surface:
+                compact["permission_surface"] = compact_permission_surface
+            compact_workflow_surface = cls._compact_workflow_surface(item.get("workflow_surface"))
+            if compact_workflow_surface:
+                compact["workflow_surface"] = compact_workflow_surface
+            meta = item.get("meta") if isinstance(item.get("meta"), dict) else {}
+            compact_meta = {}
+            for key in ("target", "next_scene", "ui_base_contract_source", "parser_semantic_surface"):
+                value = meta.get(key)
+                if value not in (None, {}, []):
+                    compact_meta[key] = value
+            if compact_meta:
+                compact["meta"] = compact_meta
+            if compact:
+                compact_scenes.append(compact)
+
+        meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+        compact_meta = {}
+        for key in ("generated_by", "scene_count", "mode"):
+            value = meta.get(key)
+            if value not in (None, {}, []):
+                compact_meta[key] = value
+        return {
+            "contract_version": str(raw.get("contract_version") or "v1"),
+            "schema_version": str(raw.get("schema_version") or "scene_ready_contract_v1"),
+            "scene_version": str(raw.get("scene_version") or ""),
+            "source_schema_version": str(raw.get("source_schema_version") or ""),
+            "scene_channel": str(raw.get("scene_channel") or ""),
+            "active_scene_key": str(raw.get("active_scene_key") or ""),
+            "scenes": compact_scenes,
+            "meta": compact_meta,
+        }
+
+    @staticmethod
+    def _compact_search_surface(payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("default_sort", "filters", "fields", "group_by", "searchpanel", "default_state", "mode"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        return compact
+
+    @staticmethod
+    def _compact_permission_surface(payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("visible", "allowed", "reason_code", "required_capabilities"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        return compact
+
+    @staticmethod
+    def _compact_workflow_surface(payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("state_field", "states", "transitions", "highlight_states"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        return compact
+
+    @staticmethod
+    def _compact_validation_surface(payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("required_fields", "field_rules"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        return compact
+
+    @classmethod
+    def _build_minimal_semantic_runtime(cls, payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("scene_key", "view_type", "semantic_view", "semantic_page", "parser_semantic_surface"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        compact_search = cls._compact_search_surface(raw.get("search_surface"))
+        if compact_search:
+            compact["search_surface"] = compact_search
+        compact_permission = cls._compact_permission_surface(raw.get("permission_surface"))
+        if compact_permission:
+            compact["permission_surface"] = compact_permission
+        compact_workflow = cls._compact_workflow_surface(raw.get("workflow_surface"))
+        if compact_workflow:
+            compact["workflow_surface"] = compact_workflow
+        compact_validation = cls._compact_validation_surface(raw.get("validation_surface"))
+        if compact_validation:
+            compact["validation_surface"] = compact_validation
+        return compact
+
+    @classmethod
+    def _build_minimal_released_scene_semantic_surface(cls, payload: dict | None) -> dict:
+        raw = payload if isinstance(payload, dict) else {}
+        compact = {}
+        for key in ("scene_key", "parser_semantic_surface", "page_surface"):
+            value = raw.get(key)
+            if value not in (None, {}, []):
+                compact[key] = value
+        compact_search = cls._compact_search_surface(raw.get("search_surface"))
+        if compact_search:
+            compact["search_surface"] = compact_search
+        compact_permission = cls._compact_permission_surface(raw.get("permission_surface"))
+        if compact_permission:
+            compact["permission_surface"] = compact_permission
+        compact_workflow = cls._compact_workflow_surface(raw.get("workflow_surface"))
+        if compact_workflow:
+            compact["workflow_surface"] = compact_workflow
+        compact_validation = cls._compact_validation_surface(raw.get("validation_surface"))
+        if compact_validation:
+            compact["validation_surface"] = compact_validation
+        return compact
+
+    @classmethod
+    def slim_to_minimal_surface(cls, data: dict, *, params: dict | None = None) -> dict:
+        return cls.build_startup_surface(data, params=params)
     @staticmethod
     def build_base(
         *,
@@ -21,9 +542,9 @@ class SystemInitPayloadBuilder:
     ) -> dict:
         return {
             "user": user_dict,
-            "nav": nav_tree,
+            "nav": SystemInitPayloadBuilder._normalize_nav_tree(nav_tree),
             "nav_meta": nav_meta,
-            "default_route": default_route,
+            "default_route": SystemInitPayloadBuilder._normalize_default_route(default_route),
             "intents": intents,
             "feature_flags": feature_flags,
             "capabilities": capabilities,

--- a/addons/smart_core/core/ui_base_contract_asset_repository.py
+++ b/addons/smart_core/core/ui_base_contract_asset_repository.py
@@ -148,6 +148,36 @@ def _resolve_scene_action_id(env, scene: dict) -> int:
         return 0
 
 
+def _is_canonical_scene_root(scene: dict) -> bool:
+    payload = scene if isinstance(scene, dict) else {}
+    scene_key = _text(payload.get("code") or payload.get("key"))
+    if not scene_key:
+        return False
+    target = payload.get("target") if isinstance(payload.get("target"), dict) else {}
+    route = _text(target.get("route"))
+    action_xmlid = _text(target.get("action_xmlid"))
+    model = _text(target.get("model"))
+    record_id = _safe_int(target.get("record_id"), 0)
+    action_id = _safe_int(target.get("action_id"), 0)
+    return (
+        route == f"/s/{scene_key}"
+        and action_id <= 0
+        and not action_xmlid
+        and not model
+        and record_id <= 0
+    )
+
+
+def _asset_is_stale_for_scene(asset: dict | None, scene: dict) -> bool:
+    payload = asset if isinstance(asset, dict) else {}
+    if not payload:
+        return False
+    if not _is_canonical_scene_root(scene):
+        return False
+    source_ref = _text(payload.get("source_ref"))
+    return source_ref.startswith("action:")
+
+
 def _minimal_ui_base_contract(scene_key: str) -> dict:
     return {
         "model": "res.partner",
@@ -355,7 +385,9 @@ def bind_scene_assets(
         for row in rows:
             scene_key = _text(row.get("code") or row.get("key"))
             entry = dict(row)
-            if scene_key and isinstance(asset_map.get(scene_key), dict):
+            asset = asset_map.get(scene_key) if scene_key else {}
+            asset_usable = isinstance(asset, dict) and asset and not _asset_is_stale_for_scene(asset, entry)
+            if scene_key and asset_usable:
                 asset = asset_map.get(scene_key) or {}
                 if not isinstance(entry.get("ui_base_contract"), dict):
                     entry["ui_base_contract"] = asset.get("payload") or {}

--- a/addons/smart_core/tests/test_scene_ready_contract_builder_semantic_consumption.py
+++ b/addons/smart_core/tests/test_scene_ready_contract_builder_semantic_consumption.py
@@ -1,0 +1,263 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+CORE_DIR = Path(__file__).resolve().parents[1] / "core"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(CORE_DIR.parent)]
+core_pkg = sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+core_pkg.__path__ = [str(CORE_DIR)]
+smart_core_pkg.core = core_pkg
+
+scene_dsl_compiler = types.ModuleType("odoo.addons.smart_core.core.scene_dsl_compiler")
+scene_dsl_compiler.scene_compile = lambda scene_payload, **_kwargs: {
+    "scene": {"key": scene_payload.get("code") or scene_payload.get("key"), "title": scene_payload.get("name")},
+    "page": {"mode": "", "route": ((scene_payload.get("target") or {}).get("route") or "")},
+    "surface": {},
+    "actions": list(scene_payload.get("actions") or []),
+    "workflow_surface": {},
+    "validation_surface": {},
+    "meta": {},
+}
+sys.modules["odoo.addons.smart_core.core.scene_dsl_compiler"] = scene_dsl_compiler
+core_pkg.scene_dsl_compiler = scene_dsl_compiler
+
+ui_base_contract_adapter = types.ModuleType("odoo.addons.smart_core.core.ui_base_contract_adapter")
+ui_base_contract_adapter.adapt_ui_base_contract = lambda payload, **_kwargs: {
+    "normalized_contract": dict(payload or {}),
+    "orchestrator_input": {"view_fact": True},
+}
+sys.modules["odoo.addons.smart_core.core.ui_base_contract_adapter"] = ui_base_contract_adapter
+core_pkg.ui_base_contract_adapter = ui_base_contract_adapter
+
+parser_bridge = _load_module(
+    "odoo.addons.smart_core.core.scene_ready_parser_semantic_bridge",
+    CORE_DIR / "scene_ready_parser_semantic_bridge.py",
+)
+entry_bridge = _load_module(
+    "odoo.addons.smart_core.core.scene_ready_entry_semantic_bridge",
+    CORE_DIR / "scene_ready_entry_semantic_bridge.py",
+)
+orchestration_bridge = _load_module(
+    "odoo.addons.smart_core.core.scene_ready_semantic_orchestration_bridge",
+    CORE_DIR / "scene_ready_semantic_orchestration_bridge.py",
+)
+core_pkg.scene_ready_parser_semantic_bridge = parser_bridge
+core_pkg.scene_ready_entry_semantic_bridge = entry_bridge
+core_pkg.scene_ready_semantic_orchestration_bridge = orchestration_bridge
+
+target = _load_module(
+    "odoo.addons.smart_core.core.scene_ready_contract_builder",
+    CORE_DIR / "scene_ready_contract_builder.py",
+)
+
+
+class TestSceneReadyContractBuilderSemanticConsumption(unittest.TestCase):
+    def test_scene_ready_promotes_provider_delivery_handoff_surface(self):
+        original = target._resolve_scene_provider_payload
+        target._resolve_scene_provider_payload = lambda _scene_key, _runtime_ctx=None: {
+            "guidance": {
+                "title": "合同中心",
+                "message": "先进入合同中心场景总览，再按工作台或监控分支继续处理合同任务。",
+            },
+            "primary_action": {
+                "label": "进入合同中心",
+                "route": "/s/contract.center",
+                "semantic": "contract_root_scene_entry",
+            },
+            "fallback_strategy": {
+                "type": "native_menu_compat",
+                "menu_xmlid": "smart_construction_core.menu_sc_contract_center",
+            },
+            "next_scene": "contracts.workspace",
+            "next_scene_route": "/s/contracts.workspace",
+            "delivery_handoff_v1": {
+                "family": "contracts",
+                "runtime_entry_type": "governed_user_flow",
+                "runtime_consumer": "family_runtime_consumer",
+                "runtime_mode": "direct",
+                "user_entry": "menu:smart_construction_core.menu_sc_contract_center",
+                "final_scene": "contract.center",
+                "primary_action": {
+                    "route": "/s/contract.center",
+                },
+                "acceptance": {
+                    "runtime_ready": True,
+                    "workflow_ready": True,
+                    "advisory_only": False,
+                },
+            },
+        }
+        try:
+            contract = target.build_scene_ready_contract_v1(
+                scenes=[
+                    {
+                        "code": "contract.center",
+                        "name": "合同中心",
+                        "layout": {"kind": "workspace"},
+                        "target": {"route": "/s/contract.center"},
+                    }
+                ],
+                role_surface={"landing_scene_key": "contract.center"},
+            )
+        finally:
+            target._resolve_scene_provider_payload = original
+        row = (contract.get("scenes") or [])[0]
+
+        self.assertEqual(((row.get("guidance") or {}).get("title")), "合同中心")
+        self.assertEqual(((row.get("primary_action") or {}).get("route")), "/s/contract.center")
+        self.assertEqual(((row.get("fallback_strategy") or {}).get("type")), "native_menu_compat")
+        self.assertEqual(row.get("next_scene"), "contracts.workspace")
+        self.assertEqual(row.get("next_scene_route"), "/s/contracts.workspace")
+        self.assertEqual(((row.get("delivery_handoff_v1") or {}).get("family")), "contracts")
+        self.assertEqual(((row.get("runtime_handoff_surface") or {}).get("final_scene")), "contract.center")
+        self.assertEqual(((row.get("product_delivery_surface") or {}).get("family")), "contracts")
+
+    def test_workspace_scene_ready_prefers_parser_semantic_view_mode(self):
+        contract = target.build_scene_ready_contract_v1(
+            scenes=[
+                {
+                    "code": "workspace.home",
+                    "name": "工作台",
+                    "layout": {"kind": "workspace"},
+                    "target": {"route": "/my-work"},
+                    "ui_base_contract": {
+                        "parser_contract": {"view_type": "form"},
+                        "view_semantics": {"source_view": "form", "capability_flags": {"is_editable": True}},
+                        "native_view": {"views": {"form": {"layout": []}, "search": {"layout": []}}},
+                        "semantic_page": {"title_node": {"text": "工作台"}},
+                    },
+                }
+            ],
+            role_surface={"landing_scene_key": "workspace.home"},
+        )
+        row = (contract.get("scenes") or [])[0]
+
+        self.assertEqual(((row.get("view_modes") or [])[0] or {}).get("key"), "form")
+        self.assertEqual(((row.get("action_surface") or {}).get("selection_mode")), "single")
+
+    def test_form_scene_ready_emits_form_surface_native_truth(self):
+        contract = target.build_scene_ready_contract_v1(
+            scenes=[
+                {
+                    "code": "projects.detail",
+                    "name": "项目详情",
+                    "layout": {"kind": "detail"},
+                    "target": {"route": "/r/project.project/3"},
+                    "ui_base_contract": {
+                        "parser_contract": {"view_type": "form"},
+                        "view_semantics": {"source_view": "form", "capability_flags": {"is_editable": True}},
+                        "views": {
+                            "form": {
+                                "layout": [{"type": "sheet", "children": [{"type": "field", "name": "name"}]}],
+                                "header_buttons": [{"key": "save", "label": "保存"}],
+                                "button_box": [{"key": "stat_tasks", "label": "任务"}],
+                                "stat_buttons": [{"key": "stat_docs", "label": "文档"}],
+                            }
+                        },
+                        "semantic_page": {
+                            "form_semantics": {
+                                "layout_section_count": 1,
+                                "has_statusbar": True,
+                                "has_notebook": False,
+                                "has_chatter": True,
+                                "has_attachments": False,
+                                "relation_fields": [{"field": "task_ids", "takeover_hint": "frontend"}],
+                                "field_behavior_map": {"name": {"readonly": False}},
+                            }
+                        },
+                    },
+                }
+            ],
+            role_surface={"landing_scene_key": "projects.detail"},
+        )
+        row = (contract.get("scenes") or [])[0]
+        form_surface = row.get("form_surface") or {}
+
+        self.assertEqual((((form_surface.get("layout") or [])[0]).get("type")), "sheet")
+        self.assertEqual((((form_surface.get("header_actions") or [])[0]).get("key")), "save")
+        self.assertEqual(len(form_surface.get("stat_actions") or []), 2)
+        self.assertEqual((((form_surface.get("relation_fields") or [])[0]).get("field")), "task_ids")
+        self.assertTrue(((form_surface.get("flags") or {}).get("has_statusbar")))
+
+    def test_list_scene_ready_emits_optimization_composition_batch1(self):
+        contract = target.build_scene_ready_contract_v1(
+            scenes=[
+                {
+                    "code": "projects.list",
+                    "name": "项目列表",
+                    "layout": {"kind": "list"},
+                    "target": {"route": "/a/449"},
+                    "search_surface": {
+                        "fields": [{"name": "name", "string": "名称"}],
+                        "filters": [
+                            {"key": "activities_today", "label": "今日活动", "kind": "filter"},
+                            {"key": "mine", "label": "我的项目", "kind": "filter"},
+                            {"key": "unassigned", "label": "未分派", "kind": "filter"},
+                        ],
+                        "group_by": [{"key": "stage_id", "label": "阶段", "field": "stage_id", "kind": "group_by"}],
+                        "searchpanel": [{"name": "stage_id", "string": "阶段", "multi": True}],
+                        "default_state": {
+                            "filters": [{"key": "activities_today", "label": "今日活动", "kind": "filter"}],
+                        },
+                    },
+                    "list_surface": {
+                        "columns": [{"field": "name", "label": "名称"}],
+                        "default_sort": {"raw": "write_date desc", "display_label": "更新时间 降序"},
+                        "available_view_modes": [{"key": "tree", "label": "列表"}],
+                        "default_mode": "tree",
+                    },
+                    "related_scenes": ["projects.ledger"],
+                },
+                {
+                    "code": "projects.ledger",
+                    "name": "项目台账",
+                    "layout": {"kind": "ledger"},
+                    "target": {"route": "/s/projects.ledger"},
+                }
+            ],
+            role_surface={"landing_scene_key": "projects.list"},
+        )
+        row = next(
+            (
+                item
+                for item in (contract.get("scenes") or [])
+                if ((item.get("scene") or {}).get("key")) == "projects.list"
+            ),
+            {},
+        )
+        optimization = row.get("optimization_composition") or {}
+        switch_surface = row.get("switch_surface") or {}
+        switch_items = switch_surface.get("items") or []
+
+        self.assertEqual((((optimization.get("toolbar_sections") or [])[0]).get("key")), "search")
+        self.assertEqual((((optimization.get("toolbar_sections") or [])[1]).get("key")), "active_conditions")
+        self.assertTrue(((optimization.get("active_conditions") or {}).get("visible")))
+        self.assertEqual((((optimization.get("high_frequency_filters") or [])[0]).get("key")), "activities_today")
+        self.assertTrue(((optimization.get("advanced_filters") or {}).get("collapsible")))
+        self.assertEqual(((switch_items[0] or {}).get("key")), "projects.list")
+        self.assertEqual(((switch_items[0] or {}).get("label")), "项目列表")
+        self.assertTrue(bool((switch_items[0] or {}).get("active")))
+        self.assertEqual(((switch_items[1] or {}).get("route")), "/s/projects.ledger")
+        self.assertEqual(((switch_items[1] or {}).get("label")), "项目台账")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
+++ b/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
@@ -1,0 +1,280 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+CORE_DIR = Path(__file__).resolve().parents[1] / "core"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(CORE_DIR.parent)]
+core_pkg = sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+core_pkg.__path__ = [str(CORE_DIR)]
+smart_core_pkg.core = core_pkg
+
+target = _load_module(
+    "odoo.addons.smart_core.core.system_init_payload_builder",
+    CORE_DIR / "system_init_payload_builder.py",
+)
+
+
+class TestSystemInitPayloadBuilderSemantics(unittest.TestCase):
+    def test_build_startup_surface_preserves_runtime_semantics(self):
+        payload = target.SystemInitPayloadBuilder.build_startup_surface(
+            {
+                "user": {"id": 1},
+                "nav": [
+                    {
+                        "key": "menu:202",
+                        "menu_id": 202,
+                        "label": "项目列表",
+                        "children": [],
+                        "meta": {
+                            "scene_key": "projects.list",
+                            "action_id": 502,
+                            "model": "project.project",
+                            "record_id": 42,
+                        },
+                    }
+                ],
+                "nav_meta": {
+                    "nav_source": "scene_contract_v1",
+                    "semantic_scene_key": "workspace.home",
+                    "semantic_source_view": "kanban",
+                    "semantic_view_type": "kanban",
+                },
+                "default_route": {"scene_key": "workspace.home"},
+                "intents": [],
+                "feature_flags": {},
+                "role_surface": {"landing_scene_key": "workspace.home", "landing_path": "/s/workspace.home"},
+                "contract_version": "1.0.0",
+                "schema_version": "1.0.0",
+                "scene_version": "v1",
+                "semantic_runtime": {
+                    "scene_key": "workspace.home",
+                    "view_type": "kanban",
+                    "semantic_view": {"source_view": "kanban"},
+                    "semantic_page": {"kanban_semantics": {"lane_count": 3}},
+                    "parser_semantic_surface": {"parser_contract": {"view_type": "kanban"}},
+                    "search_surface": {
+                        "filters": [{"name": "mine", "string": "我的"}],
+                        "searchpanel": [{"name": "stage_id", "string": "阶段"}],
+                        "default_state": {
+                            "filters": [{"key": "mine", "label": "我的", "kind": "filter"}],
+                        },
+                        "mode": "faceted",
+                    },
+                    "permission_surface": {
+                        "visible": True,
+                        "allowed": False,
+                        "reason_code": "missing_capability",
+                        "required_capabilities": ["project.write"],
+                    },
+                    "workflow_surface": {
+                        "state_field": "state",
+                        "states": [{"key": "draft"}],
+                    },
+                    "validation_surface": {
+                        "required_fields": ["name"],
+                        "field_rules": [{"field": "name", "rule": "required"}],
+                    },
+                    "debug_blob": {"drop_me": True},
+                },
+                "released_scene_semantic_surface": {
+                    "scene_key": "workspace.home",
+                    "page_surface": {"view_type": "kanban", "semantic_view": {"source_view": "kanban"}},
+                    "parser_semantic_surface": {"parser_contract": {"view_type": "kanban"}},
+                    "search_surface": {"mode": "faceted", "searchpanel": [{"name": "stage_id", "string": "阶段"}]},
+                    "permission_surface": {"allowed": False, "reason_code": "missing_capability"},
+                    "workflow_surface": {"state_field": "state"},
+                    "validation_surface": {"required_fields": ["name"]},
+                    "debug_blob": {"drop_me": True},
+                },
+                "scene_ready_contract_v1": {
+                    "contract_version": "v1",
+                    "scene_channel": "portal",
+                    "scenes": [
+                        {
+                            "scene": {"key": "workspace.home"},
+                            "page": {"context": {"scene_key": "workspace.home"}},
+                            "parser_semantic_surface": {"parser_contract": {"view_type": "kanban"}},
+                            "semantic_view": {"source_view": "kanban"},
+                            "semantic_page": {"kanban_semantics": {"lane_count": 3}},
+                            "view_type": "kanban",
+                            "search_surface": {
+                                "filters": [{"name": "mine", "string": "我的"}],
+                                "searchpanel": [{"name": "stage_id", "string": "阶段"}],
+                                "default_state": {
+                                    "filters": [{"key": "mine", "label": "我的", "kind": "filter"}],
+                                },
+                                "mode": "faceted",
+                            },
+                            "list_surface": {
+                                "columns": [{"field": "name", "label": "项目名称"}],
+                                "default_sort": {"raw": "write_date desc", "display_label": "更新时间 降序"},
+                                "available_view_modes": [{"key": "tree", "label": "列表"}],
+                                "default_mode": "tree",
+                            },
+                            "form_surface": {
+                                "layout": [{"type": "sheet", "children": [{"type": "field", "name": "name"}]}],
+                                "header_actions": [{"key": "save", "label": "保存"}],
+                                "stat_actions": [{"key": "stat_tasks", "label": "任务"}],
+                                "relation_fields": [{"field": "task_ids", "takeover_hint": "frontend"}],
+                                "field_behavior_map": {"name": {"readonly": False}},
+                                "flags": {"has_statusbar": True, "layout_section_count": 1}
+                            },
+                            "optimization_composition": {
+                                "toolbar_sections": [
+                                    {"key": "search", "kind": "search", "priority": 10, "visible": True}
+                                ],
+                                "active_conditions": {
+                                    "visible": True,
+                                    "include": ["route_preset", "search_term", "sort"],
+                                    "merge_rules": {"route_preset_overrides_search_term": True}
+                                },
+                                "high_frequency_filters": [
+                                    {"key": "mine"}
+                                ],
+                                "advanced_filters": {
+                                    "visible": True,
+                                    "collapsible": True,
+                                    "default_open": False,
+                                    "source": {
+                                        "include_remaining_filters": True,
+                                        "include_searchpanel": True,
+                                        "include_saved_filters": False
+                                    }
+                                }
+                            },
+                            "action_surface": {
+                                "primary_actions": ["open"],
+                                "groups": [{"key": "list_actions", "actions": ["open"]}],
+                                "selection_mode": "multi",
+                                "counts": {"total": 1, "primary": 1, "groups": 1},
+                                "batch_capabilities": {
+                                    "can_delete": True,
+                                    "can_archive": True,
+                                    "can_activate": True,
+                                    "selection_required": True,
+                                    "native_basis": {"has_active_field": True},
+                                },
+                            },
+                            "permission_surface": {
+                                "visible": True,
+                                "allowed": False,
+                                "reason_code": "missing_capability",
+                                "required_capabilities": ["project.write"],
+                            },
+                            "workflow_surface": {
+                                "state_field": "state",
+                                "states": [{"key": "draft"}],
+                                "transitions": [{"key": "submit"}],
+                            },
+                            "validation_surface": {
+                                "required_fields": ["name"],
+                                "field_rules": [{"field": "name", "rule": "required"}],
+                            },
+                            "meta": {"target": {"route": "/my-work"}},
+                        }
+                    ],
+                    "meta": {"generated_by": "test"},
+                },
+            }
+        )
+
+        self.assertEqual((payload.get("semantic_runtime") or {}).get("view_type"), "kanban")
+        self.assertEqual(((payload.get("default_route") or {}).get("entry_target") or {}).get("scene_key"), "workspace.home")
+        self.assertEqual(((payload.get("role_surface") or {}).get("landing_entry_target") or {}).get("scene_key"), "workspace.home")
+        nav_leaf = ((payload.get("nav") or [])[0] or {})
+        self.assertEqual((((nav_leaf.get("meta") or {}).get("entry_target") or {}).get("scene_key")), "projects.list")
+        self.assertEqual(((((nav_leaf.get("meta") or {}).get("entry_target") or {}).get("compatibility_refs") or {}).get("action_id")), 502)
+        self.assertEqual(((((nav_leaf.get("meta") or {}).get("entry_target") or {}).get("record_entry") or {}).get("model")), "project.project")
+        self.assertEqual(((((nav_leaf.get("meta") or {}).get("entry_target") or {}).get("record_entry") or {}).get("record_id")), 42)
+        self.assertEqual(((payload.get("semantic_runtime") or {}).get("search_surface") or {}).get("mode"), "faceted")
+        self.assertEqual(((((payload.get("semantic_runtime") or {}).get("search_surface") or {}).get("default_state") or {}).get("filters") or [])[0].get("key"), "mine")
+        self.assertEqual(((payload.get("semantic_runtime") or {}).get("permission_surface") or {}).get("reason_code"), "missing_capability")
+        self.assertEqual(((payload.get("semantic_runtime") or {}).get("workflow_surface") or {}).get("state_field"), "state")
+        self.assertEqual((((payload.get("semantic_runtime") or {}).get("validation_surface") or {}).get("required_fields") or [])[0], "name")
+        self.assertNotIn("debug_blob", payload.get("semantic_runtime") or {})
+        self.assertEqual(((payload.get("nav_meta") or {}).get("semantic_source_view")), "kanban")
+        self.assertEqual(((payload.get("released_scene_semantic_surface") or {}).get("search_surface") or {}).get("mode"), "faceted")
+        self.assertEqual(((payload.get("released_scene_semantic_surface") or {}).get("permission_surface") or {}).get("reason_code"), "missing_capability")
+        self.assertNotIn("debug_blob", payload.get("released_scene_semantic_surface") or {})
+        scene = ((payload.get("scene_ready_contract_v1") or {}).get("scenes") or [])[0]
+        self.assertEqual(scene.get("view_type"), "kanban")
+        self.assertIn("parser_semantic_surface", scene)
+        self.assertEqual(((scene.get("search_surface") or {}).get("mode")), "faceted")
+        self.assertEqual((((scene.get("search_surface") or {}).get("searchpanel") or [])[0].get("name")), "stage_id")
+        self.assertEqual(((((scene.get("search_surface") or {}).get("default_state") or {}).get("filters") or [])[0].get("key")), "mine")
+        self.assertEqual((((scene.get("list_surface") or {}).get("columns") or [])[0].get("field")), "name")
+        self.assertEqual((((scene.get("list_surface") or {}).get("default_sort") or {}).get("display_label")), "更新时间 降序")
+        self.assertEqual((((scene.get("list_surface") or {}).get("available_view_modes") or [])[0].get("key")), "tree")
+        self.assertEqual((((scene.get("form_surface") or {}).get("header_actions") or [])[0].get("key")), "save")
+        self.assertTrue(((scene.get("form_surface") or {}).get("flags") or {}).get("has_statusbar"))
+        self.assertEqual((((scene.get("optimization_composition") or {}).get("toolbar_sections") or [])[0].get("key")), "search")
+        self.assertEqual(((((scene.get("optimization_composition") or {}).get("high_frequency_filters") or [])[0]).get("key")), "mine")
+        self.assertTrue((((scene.get("optimization_composition") or {}).get("advanced_filters") or {}).get("collapsible")))
+        self.assertTrue((((scene.get("action_surface") or {}).get("batch_capabilities") or {}).get("can_archive")))
+        self.assertTrue((((scene.get("action_surface") or {}).get("batch_capabilities") or {}).get("selection_required")))
+        self.assertEqual(((scene.get("permission_surface") or {}).get("reason_code")), "missing_capability")
+        self.assertEqual((((scene.get("permission_surface") or {}).get("required_capabilities") or [])[0]), "project.write")
+        self.assertEqual(((scene.get("workflow_surface") or {}).get("state_field")), "state")
+        self.assertEqual((((scene.get("workflow_surface") or {}).get("states") or [])[0].get("key")), "draft")
+        self.assertEqual((((scene.get("validation_surface") or {}).get("required_fields") or [])[0]), "name")
+        self.assertEqual((((scene.get("validation_surface") or {}).get("field_rules") or [])[0].get("field")), "name")
+
+    def test_minimal_scene_ready_contract_preserves_delivery_handoff_surface(self):
+        payload = target.SystemInitPayloadBuilder._build_minimal_scene_ready_contract(
+            {
+                "scenes": [
+                    {
+                        "scene": {"key": "contract.center", "title": "合同中心"},
+                        "page": {"route": "/s/contract.center"},
+                        "guidance": {"title": "合同中心", "message": "先进入合同中心场景总览。"},
+                        "primary_action": {"route": "/s/contract.center", "label": "进入合同中心"},
+                        "fallback_strategy": {"type": "native_menu_compat"},
+                        "next_scene": "contracts.workspace",
+                        "next_scene_route": "/s/contracts.workspace",
+                        "delivery_handoff_v1": {
+                            "family": "contracts",
+                            "final_scene": "contract.center",
+                        },
+                        "runtime_handoff_surface": {
+                            "family": "contracts",
+                            "final_scene": "contract.center",
+                        },
+                        "product_delivery_surface": {
+                            "family": "contracts",
+                            "delivery_mode": "direct_delivery",
+                        },
+                    }
+                ]
+            }
+        )
+
+        scene = ((payload.get("scenes") or [])[0] or {})
+        self.assertEqual(((scene.get("guidance") or {}).get("title")), "合同中心")
+        self.assertEqual(((scene.get("primary_action") or {}).get("route")), "/s/contract.center")
+        self.assertEqual(((scene.get("fallback_strategy") or {}).get("type")), "native_menu_compat")
+        self.assertEqual(scene.get("next_scene"), "contracts.workspace")
+        self.assertEqual(((scene.get("delivery_handoff_v1") or {}).get("family")), "contracts")
+        self.assertEqual(((scene.get("runtime_handoff_surface") or {}).get("family")), "contracts")
+        self.assertEqual(((scene.get("product_delivery_surface") or {}).get("delivery_mode")), "direct_delivery")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_ui_base_contract_asset_repository.py
+++ b/addons/smart_core/tests/test_ui_base_contract_asset_repository.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+CORE_DIR = Path(__file__).resolve().parents[1] / "core"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(CORE_DIR.parent)]
+core_pkg = sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+core_pkg.__path__ = [str(CORE_DIR)]
+smart_core_pkg.core = core_pkg
+
+canonicalizer = types.ModuleType("odoo.addons.smart_core.core.ui_base_contract_canonicalizer")
+canonicalizer.canonicalize_ui_base_contract = lambda payload: payload if isinstance(payload, dict) else {}
+sys.modules["odoo.addons.smart_core.core.ui_base_contract_canonicalizer"] = canonicalizer
+core_pkg.ui_base_contract_canonicalizer = canonicalizer
+
+target = _load_module(
+    "odoo.addons.smart_core.core.ui_base_contract_asset_repository",
+    CORE_DIR / "ui_base_contract_asset_repository.py",
+)
+
+
+class TestUiBaseContractAssetRepository(unittest.TestCase):
+    def test_rejects_action_asset_for_canonical_scene_root(self):
+        scene = {
+            "code": "contract.center",
+            "target": {
+                "route": "/s/contract.center",
+                "menu_xmlid": "smart_construction_core.menu_sc_contract_center",
+            },
+        }
+        asset = {
+            "id": 31,
+            "source_ref": "action:522",
+            "payload": {"model": "construction.contract"},
+        }
+
+        self.assertTrue(target._is_canonical_scene_root(scene))
+        self.assertTrue(target._asset_is_stale_for_scene(asset, scene))
+
+    def test_keeps_scene_asset_for_canonical_scene_root(self):
+        scene = {
+            "code": "contract.center",
+            "target": {
+                "route": "/s/contract.center",
+            },
+        }
+        asset = {
+            "id": 32,
+            "source_ref": "scene:contract.center:minimal",
+            "payload": {"model": "res.partner"},
+        }
+
+        self.assertFalse(target._asset_is_stale_for_scene(asset, scene))
+
+    def test_keeps_action_asset_for_action_backed_scene(self):
+        scene = {
+            "code": "contracts.workspace",
+            "target": {
+                "route": "/s/contracts.workspace",
+                "action_xmlid": "smart_construction_core.action_construction_contract_my",
+            },
+        }
+        asset = {
+            "id": 33,
+            "source_ref": "action:522",
+            "payload": {"model": "construction.contract"},
+        }
+
+        self.assertFalse(target._is_canonical_scene_root(scene))
+        self.assertFalse(target._asset_is_stale_for_scene(asset, scene))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Split the first backend runtime-only child PR out of `#577`.

This batch isolates the `smart_core` scene runtime changes needed for:

- rejecting stale ui-base assets on canonical scene roots
- preserving scene handoff/search/permission/workflow/validation surfaces for delivery roots
- preserving startup minimal surface and entry-target normalization semantics

## Scope

- `addons/smart_core/core/ui_base_contract_asset_repository.py`
- `addons/smart_core/core/scene_ready_contract_builder.py`
- `addons/smart_core/core/system_init_payload_builder.py`
- `addons/smart_core/tests/test_ui_base_contract_asset_repository.py`
- `addons/smart_core/tests/test_scene_ready_contract_builder_semantic_consumption.py`
- `addons/smart_core/tests/test_system_init_payload_builder_semantics.py`

## Architecture Impact

- narrows the oversized integration PR into a runtime-core child batch
- keeps lifecycle usability recovery on the backend semantic supply battlefield
- does not add frontend model-specific branching

## Layer Target

- Platform Layer
- Scene Runtime / Startup Surface

## Affected Modules

- `addons/smart_core`

## Verification

- cherry-pick conflict resolution completed on top of `origin/main`
- local branch contains only the six runtime/test files listed above
- environment blocker: `pytest` command unavailable in current workspace
- environment blocker: `python3 -m pytest` fails with `No module named pytest`

## Notes

- this PR is intended to merge before the frontend generic consumer split
- umbrella PR `#577` remains as the integration branch until child PRs are reviewed
