### PR TITLE
[split] smart core entry target residual slice

### DIFF
--- a/addons/smart_core/controllers/platform_menu_api.py
+++ b/addons/smart_core/controllers/platform_menu_api.py
@@ -1,0 +1,258 @@
+# -*- coding: utf-8 -*-
+import json
+
+from odoo import http
+from odoo.http import request
+from odoo.exceptions import AccessDenied
+
+from odoo.addons.smart_core.core.trace import get_trace_id
+from odoo.addons.smart_core.delivery.menu_fact_service import MenuFactService
+from odoo.addons.smart_core.delivery.menu_delivery_convergence_service import MenuDeliveryConvergenceService
+from odoo.addons.smart_core.delivery.menu_target_interpreter_service import MenuTargetInterpreterService
+from odoo.addons.smart_core.security.auth import get_user_from_token
+from odoo.addons.smart_core.utils.extension_hooks import call_extension_hook_first
+from odoo.addons.smart_core.core.exceptions import (
+    AUTH_REQUIRED,
+    BAD_REQUEST,
+    DEFAULT_API_VERSION,
+    DEFAULT_CONTRACT_VERSION,
+    build_error_envelope,
+)
+
+
+def _meta(trace_id: str) -> dict:
+    return {
+        "trace_id": trace_id,
+        "api_version": DEFAULT_API_VERSION,
+        "contract_version": DEFAULT_CONTRACT_VERSION,
+    }
+
+
+def _error_resp(code: str, message: str, trace_id: str, details: dict | None = None):
+    return build_error_envelope(
+        code=code,
+        message=message,
+        trace_id=trace_id,
+        details=details,
+        api_version=DEFAULT_API_VERSION,
+        contract_version=DEFAULT_CONTRACT_VERSION,
+    )
+
+
+def _json_response(payload: dict, status: int = 200):
+    return request.make_response(
+        json.dumps(payload, ensure_ascii=False, default=str),
+        headers=[('Content-Type', 'application/json; charset=utf-8')],
+        status=status,
+    )
+
+
+def _resolve_request_env():
+    user = get_user_from_token()
+    return request.env(user=user)
+
+
+def _merge_scene_entry(entries: list[dict], *, scene_key: str, model: str, view_mode: str) -> None:
+    normalized_scene_key = str(scene_key or "").strip()
+    normalized_model = str(model or "").strip()
+    normalized_view_mode = str(view_mode or "").strip().lower()
+    if not (normalized_scene_key and normalized_model and normalized_view_mode):
+        return
+    for row in entries:
+        if not isinstance(row, dict):
+            continue
+        target = row.get("target") if isinstance(row.get("target"), dict) else {}
+        existing_scene_key = str(row.get("code") or row.get("scene_key") or "").strip()
+        existing_model = str(target.get("model") or "").strip()
+        existing_view_mode = str(target.get("view_mode") or target.get("view_type") or "").strip().lower()
+        if existing_model == normalized_model and existing_view_mode == normalized_view_mode:
+            return
+        if existing_scene_key == normalized_scene_key and existing_model == normalized_model:
+            return
+    entries.append(
+        {
+            "code": normalized_scene_key,
+            "target": {
+                "model": normalized_model,
+                "view_type": normalized_view_mode,
+            },
+        }
+    )
+
+
+def _resolve_navigation_scene_map(env, scene_map: dict | None = None) -> dict:
+    resolved = {
+        "menu_id_to_scene": {},
+        "action_id_to_scene": {},
+        "entries": [],
+    }
+    payload = scene_map if isinstance(scene_map, dict) else {}
+    if isinstance(payload.get("menu_id_to_scene"), dict):
+        resolved["menu_id_to_scene"].update({str(k): str(v) for k, v in payload["menu_id_to_scene"].items() if str(k).strip() and str(v).strip()})
+    if isinstance(payload.get("action_id_to_scene"), dict):
+        resolved["action_id_to_scene"].update({str(k): str(v) for k, v in payload["action_id_to_scene"].items() if str(k).strip() and str(v).strip()})
+    if isinstance(payload.get("entries"), list):
+        resolved["entries"] = [dict(row) for row in payload["entries"] if isinstance(row, dict)]
+
+    extension_maps = call_extension_hook_first(env, "smart_core_nav_scene_maps", env)
+    if not isinstance(extension_maps, dict):
+        return resolved if any(resolved.values()) else {}
+
+    menu_scene_map = extension_maps.get("menu_scene_map") if isinstance(extension_maps.get("menu_scene_map"), dict) else {}
+    action_scene_map = extension_maps.get("action_xmlid_scene_map") if isinstance(extension_maps.get("action_xmlid_scene_map"), dict) else {}
+    model_view_scene_map = extension_maps.get("model_view_scene_map") if isinstance(extension_maps.get("model_view_scene_map"), dict) else {}
+
+    for xmlid, scene_key in menu_scene_map.items():
+        rec = env.ref(str(xmlid or "").strip(), raise_if_not_found=False) if env else None
+        if rec and getattr(rec, "id", None):
+            resolved["menu_id_to_scene"].setdefault(str(int(rec.id)), str(scene_key))
+
+    for xmlid, scene_key in action_scene_map.items():
+        rec = env.ref(str(xmlid or "").strip(), raise_if_not_found=False) if env else None
+        if rec and getattr(rec, "id", None):
+            resolved["action_id_to_scene"].setdefault(str(int(rec.id)), str(scene_key))
+
+    for key, scene_key in model_view_scene_map.items():
+        if not (isinstance(key, (list, tuple)) and len(key) == 2):
+            continue
+        _merge_scene_entry(
+            resolved["entries"],
+            scene_key=str(scene_key or ""),
+            model=str(key[0] or ""),
+            view_mode=str(key[1] or ""),
+        )
+
+    return resolved if any(resolved.values()) else {}
+
+
+def _fact_node(node: dict) -> dict:
+    children = node.get("children") if isinstance(node.get("children"), list) else []
+    menu_id = node.get("menu_id")
+    return {
+        "menu_id": menu_id,
+        "key": f"menu:{menu_id}" if isinstance(menu_id, int) else "menu:unknown",
+        "name": str(node.get("name") or ""),
+        "parent_id": node.get("parent_id"),
+        "complete_name": str(node.get("complete_name") or ""),
+        "sequence": node.get("sequence"),
+        "groups": node.get("groups") if isinstance(node.get("groups"), list) else [],
+        "web_icon": str(node.get("web_icon") or ""),
+        "has_children": bool(children),
+        "action_raw": str(node.get("action_raw") or ""),
+        "action_type": str(node.get("action_type") or ""),
+        "action_id": node.get("action_id"),
+        "action_exists": bool(node.get("action_exists")),
+        "action_meta": node.get("action_meta") if isinstance(node.get("action_meta"), dict) else {},
+        "children": [_fact_node(child) for child in children],
+    }
+
+
+def _flat_fact_node(node: dict) -> dict:
+    menu_id = node.get("menu_id")
+    child_ids = node.get("child_ids") if isinstance(node.get("child_ids"), list) else []
+    return {
+        "menu_id": menu_id,
+        "key": f"menu:{menu_id}" if isinstance(menu_id, int) else "menu:unknown",
+        "name": str(node.get("name") or ""),
+        "parent_id": node.get("parent_id"),
+        "complete_name": str(node.get("complete_name") or ""),
+        "sequence": node.get("sequence"),
+        "groups": node.get("groups") if isinstance(node.get("groups"), list) else [],
+        "web_icon": str(node.get("web_icon") or ""),
+        "has_children": bool(child_ids),
+        "action_raw": str(node.get("action_raw") or ""),
+        "action_type": str(node.get("action_type") or ""),
+        "action_id": node.get("action_id"),
+        "action_exists": bool(node.get("action_exists")),
+        "action_meta": node.get("action_meta") if isinstance(node.get("action_meta"), dict) else {},
+        "child_ids": child_ids,
+    }
+
+
+def _is_admin_user(env) -> bool:
+    try:
+        return bool(env.user.has_group('base.group_system'))
+    except Exception:
+        return False
+
+
+class PlatformMenuAPI(http.Controller):
+    @http.route('/api/menu/tree', type='http', auth='public', csrf=False, cors='*', methods=['POST'])
+    def api_menu_tree(self, **kwargs):
+        del kwargs
+        trace_id = get_trace_id(request.httprequest.headers)
+        try:
+            env = _resolve_request_env()
+        except AccessDenied as exc:
+            return _json_response(
+                _error_resp(AUTH_REQUIRED, str(exc) or '登录态无效，请重新登录。', trace_id),
+                status=401,
+            )
+        facts = MenuFactService(env).export_visible_menu_facts()
+        if not facts.flat:
+            return _json_response(_error_resp(BAD_REQUEST, '未找到平台菜单根节点。', trace_id), status=400)
+        nav_fact = {
+            "flat": [_flat_fact_node(node) for node in facts.flat],
+            "tree": [_fact_node(node) for node in facts.tree],
+        }
+        nav_explained = MenuTargetInterpreterService(env).interpret(
+            nav_fact,
+            scene_map=_resolve_navigation_scene_map(env),
+            policy={},
+        )
+        nav_fact_filtered, _, convergence = MenuDeliveryConvergenceService().apply(
+            nav_fact,
+            nav_explained,
+            is_admin=_is_admin_user(env),
+        )
+        return _json_response({'ok': True, 'nav_fact': nav_fact_filtered, 'meta': {**_meta(trace_id), 'delivery_convergence': convergence}})
+
+    @http.route('/api/user_menus', type='http', auth='public', csrf=False, cors='*', methods=['POST'])
+    def api_user_menus(self, **kwargs):
+        return self.api_menu_tree(**kwargs)
+
+    @http.route('/api/menu/navigation', type='http', auth='public', csrf=False, cors='*', methods=['POST'])
+    def api_menu_navigation(self, **kwargs):
+        payload = kwargs if isinstance(kwargs, dict) else {}
+        if not payload:
+            json_payload = request.httprequest.get_json(silent=True)
+            payload = json_payload if isinstance(json_payload, dict) else {}
+        trace_id = get_trace_id(request.httprequest.headers)
+        try:
+            env = _resolve_request_env()
+        except AccessDenied as exc:
+            return _json_response(
+                _error_resp(AUTH_REQUIRED, str(exc) or '登录态无效，请重新登录。', trace_id),
+                status=401,
+            )
+        facts = MenuFactService(env).export_visible_menu_facts()
+        if not facts.flat:
+            return _json_response(_error_resp(BAD_REQUEST, '未找到平台菜单根节点。', trace_id), status=400)
+
+        nav_fact = {
+            "flat": [_flat_fact_node(node) for node in facts.flat],
+            "tree": [_fact_node(node) for node in facts.tree],
+        }
+        scene_map = _resolve_navigation_scene_map(
+            env,
+            payload.get("scene_map") if isinstance(payload.get("scene_map"), dict) else {},
+        )
+        policy = payload.get("policy") if isinstance(payload.get("policy"), dict) else {}
+        nav_explained = MenuTargetInterpreterService(env).interpret(
+            nav_fact,
+            scene_map=scene_map,
+            policy=policy,
+        )
+        nav_fact_filtered, nav_explained_filtered, convergence = MenuDeliveryConvergenceService().apply(
+            nav_fact,
+            nav_explained,
+            is_admin=_is_admin_user(env),
+        )
+        return _json_response(
+            {
+                'ok': True,
+                'nav_fact': nav_fact_filtered,
+                'nav_explained': nav_explained_filtered,
+                'meta': {**_meta(trace_id), 'delivery_convergence': convergence},
+            }
+        )

--- a/addons/smart_core/delivery/menu_target_interpreter_service.py
+++ b/addons/smart_core/delivery/menu_target_interpreter_service.py
@@ -1,0 +1,552 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _text(value) -> str:
+    return str(value or "").strip()
+
+
+def _to_int(value) -> int | None:
+    try:
+        parsed = int(value)
+    except Exception:
+        return None
+    return parsed if parsed > 0 else None
+
+
+def _build_entry_target(
+    *,
+    menu_id=None,
+    action_id=None,
+    target_type: str = "",
+    delivery_mode: str = "",
+    route: str | None = None,
+    target: dict | None = None,
+) -> dict:
+    payload = target if isinstance(target, dict) else {}
+    scene_key = _text(payload.get("scene_key"))
+    normalized_route = _text(route)
+    entry_target: dict = {}
+
+    if scene_key:
+        entry_target = {
+            "type": "scene",
+            "scene_key": scene_key,
+        }
+        if normalized_route:
+            entry_target["route"] = normalized_route
+        return entry_target
+
+    compatibility_refs = {}
+    normalized_menu_id = _to_int(menu_id)
+    normalized_action_id = _to_int(payload.get("action_id")) or _to_int(action_id)
+    if normalized_menu_id:
+        compatibility_refs["menu_id"] = normalized_menu_id
+    if normalized_action_id:
+        compatibility_refs["action_id"] = normalized_action_id
+    if _text(target_type):
+        compatibility_refs["target_type"] = _text(target_type)
+    if _text(delivery_mode):
+        compatibility_refs["delivery_mode"] = _text(delivery_mode)
+
+    if compatibility_refs:
+        entry_target = {
+            "type": "compatibility",
+            "compatibility_refs": compatibility_refs,
+        }
+        if normalized_route:
+            entry_target["route"] = normalized_route
+
+    return entry_target
+
+
+TARGET_TYPES = {
+    "directory",
+    "scene",
+    "action",
+    "native",
+    "url",
+    "unavailable",
+}
+
+DELIVERY_MODES = {
+    "custom_scene",
+    "custom_action",
+    "native_bridge",
+    "external_url",
+    "none",
+}
+
+SUPPORTED_CUSTOM_ACTION_VIEW_MODES = {
+    "tree",
+    "list",
+    "form",
+    "kanban",
+}
+
+NATIVE_BRIDGE_ACTION_TYPES = {
+    "ir.actions.act_window",
+    "ir.actions.server",
+    "ir.actions.client",
+}
+
+UNAVAILABLE_REASON_CODES = {
+    "TARGET_MISSING",
+    "ACTION_INVALID",
+    "SCENE_UNRESOLVED",
+    "DIRECTORY_ONLY",
+    "DELIVERY_UNSUPPORTED",
+    "PERMISSION_DENIED",
+}
+
+
+class MenuTargetInterpreterService:
+    """Interpreter layer: menu_fact -> navigation target (facts remain unchanged)."""
+
+    def __init__(self, env=None):
+        self.env = env
+
+    def interpret(self, nav_fact: dict, *, scene_map: dict | None = None, policy: dict | None = None) -> dict:
+        resolver = self._build_scene_resolver(scene_map=scene_map, policy=policy)
+        flat = nav_fact.get("flat") if isinstance(nav_fact, dict) and isinstance(nav_fact.get("flat"), list) else []
+        tree = nav_fact.get("tree") if isinstance(nav_fact, dict) and isinstance(nav_fact.get("tree"), list) else []
+        return {
+            "flat": [self._explain_node(node, resolver=resolver) for node in flat if isinstance(node, dict)],
+            "tree": [self._explain_tree(node, resolver=resolver) for node in tree if isinstance(node, dict)],
+        }
+
+    def _build_scene_resolver(self, *, scene_map: dict | None, policy: dict | None) -> dict:
+        del policy
+        menu_id_to_scene: dict[int, str] = {}
+        action_id_to_scene: dict[int, str] = {}
+        scene_key_to_route: dict[str, str] = {}
+        model_view_to_scene: dict[tuple[str, str], str] = {}
+
+        payload = scene_map if isinstance(scene_map, dict) else {}
+        self._merge_explicit_scene_map(payload, menu_id_to_scene, action_id_to_scene, scene_key_to_route, model_view_to_scene)
+        self._merge_scene_registry_mapping(menu_id_to_scene, action_id_to_scene, scene_key_to_route, model_view_to_scene)
+        return {
+            "menu_id": menu_id_to_scene,
+            "action_id": action_id_to_scene,
+            "scene_route": scene_key_to_route,
+            "model_view": model_view_to_scene,
+        }
+
+    def _normalize_view_mode(self, raw: str | None) -> str | None:
+        if not raw:
+            return None
+        value = _text(raw).lower()
+        if value in {"tree", "list", "kanban"}:
+            return "list"
+        if value == "form":
+            return "form"
+        return value or None
+
+    def _merge_explicit_scene_map(
+        self,
+        payload: dict,
+        menu_id_to_scene: dict[int, str],
+        action_id_to_scene: dict[int, str],
+        scene_key_to_route: dict[str, str],
+        model_view_to_scene: dict[tuple[str, str], str],
+    ) -> None:
+        menu_map = payload.get("menu_id_to_scene") if isinstance(payload.get("menu_id_to_scene"), dict) else {}
+        action_map = payload.get("action_id_to_scene") if isinstance(payload.get("action_id_to_scene"), dict) else {}
+        scene_rows = payload.get("entries") if isinstance(payload.get("entries"), list) else []
+
+        for key, value in menu_map.items():
+            menu_id = _to_int(key)
+            scene_key = _text(value)
+            if menu_id and scene_key:
+                menu_id_to_scene.setdefault(menu_id, scene_key)
+
+        for key, value in action_map.items():
+            action_id = _to_int(key)
+            scene_key = _text(value)
+            if action_id and scene_key:
+                action_id_to_scene.setdefault(action_id, scene_key)
+
+        for row in scene_rows:
+            if not isinstance(row, dict):
+                continue
+            scene_key = _text(row.get("scene_key") or row.get("code"))
+            if not scene_key:
+                continue
+            target = row.get("target") if isinstance(row.get("target"), dict) else {}
+            route = _text(target.get("route"))
+            if route:
+                scene_key_to_route.setdefault(scene_key, route)
+            menu_id = _to_int(row.get("menu_id")) or _to_int(target.get("menu_id"))
+            action_id = _to_int(row.get("action_id")) or _to_int(target.get("action_id"))
+            model_name = _text(target.get("model"))
+            view_mode = self._normalize_view_mode(target.get("view_mode") or target.get("view_type"))
+            if menu_id:
+                menu_id_to_scene.setdefault(menu_id, scene_key)
+            if action_id:
+                action_id_to_scene.setdefault(action_id, scene_key)
+            if model_name and view_mode:
+                model_view_to_scene.setdefault((model_name, view_mode), scene_key)
+
+    def _merge_scene_registry_mapping(
+        self,
+        menu_id_to_scene: dict[int, str],
+        action_id_to_scene: dict[int, str],
+        scene_key_to_route: dict[str, str],
+        model_view_to_scene: dict[tuple[str, str], str],
+    ) -> None:
+        for row in self._load_scene_registry_entries():
+            scene_key = _text(row.get("code") or row.get("scene_key"))
+            if not scene_key:
+                continue
+            target = row.get("target") if isinstance(row.get("target"), dict) else {}
+            route = _text(target.get("route"))
+            if route:
+                scene_key_to_route.setdefault(scene_key, route)
+            menu_id = _to_int(target.get("menu_id"))
+            action_id = _to_int(target.get("action_id"))
+            model_name = _text(target.get("model"))
+            view_mode = self._normalize_view_mode(target.get("view_mode") or target.get("view_type"))
+
+            menu_xmlid = _text(target.get("menu_xmlid"))
+            action_xmlid = _text(target.get("action_xmlid"))
+            if not menu_id and menu_xmlid:
+                menu_id = self._resolve_xmlid_to_res_id(menu_xmlid, expected_model="ir.ui.menu")
+            if not action_id and action_xmlid:
+                action_id = self._resolve_xmlid_to_res_id(action_xmlid, expected_model_prefix="ir.actions.")
+
+            if menu_id:
+                menu_id_to_scene.setdefault(menu_id, scene_key)
+            if action_id:
+                action_id_to_scene.setdefault(action_id, scene_key)
+            if model_name and view_mode:
+                model_view_to_scene.setdefault((model_name, view_mode), scene_key)
+
+    def _load_scene_registry_entries(self) -> list[dict]:
+        try:
+            from odoo.addons.smart_scene.core.scene_registry_engine import load_scene_registry_content_entries
+
+            rows = load_scene_registry_content_entries(Path(__file__))
+            return rows if isinstance(rows, list) else []
+        except Exception:
+            return []
+
+    def _resolve_xmlid_to_res_id(
+        self,
+        xmlid: str,
+        *,
+        expected_model: str | None = None,
+        expected_model_prefix: str | None = None,
+    ) -> int | None:
+        if self.env is None:
+            return None
+        value = _text(xmlid)
+        if not value or "." not in value:
+            return None
+        module, name = value.split(".", 1)
+        if not module or not name:
+            return None
+        rec = self.env["ir.model.data"].sudo().search(
+            [
+                ("module", "=", module),
+                ("name", "=", name),
+            ],
+            limit=1,
+        )
+        if not rec:
+            return None
+        model_name = _text(rec.model)
+        if expected_model and model_name != expected_model:
+            return None
+        if expected_model_prefix and not model_name.startswith(expected_model_prefix):
+            return None
+        return _to_int(rec.res_id)
+
+    def _resolve_scene_key(self, *, menu_id, action_id, resolver: dict) -> str:
+        menu_map = resolver.get("menu_id") if isinstance(resolver.get("menu_id"), dict) else {}
+        action_map = resolver.get("action_id") if isinstance(resolver.get("action_id"), dict) else {}
+        resolved = menu_map.get(menu_id)
+        if _text(resolved):
+            return _text(resolved)
+        return _text(action_map.get(action_id))
+
+    def _resolve_scene_route(self, *, scene_key: str, resolver: dict) -> str:
+        route_map = resolver.get("scene_route") if isinstance(resolver.get("scene_route"), dict) else {}
+        return _text(route_map.get(scene_key))
+
+    def _resolve_scene_key_from_model_view(self, *, res_model: str, view_modes: list[str], resolver: dict) -> str:
+        model_view_map = resolver.get("model_view") if isinstance(resolver.get("model_view"), dict) else {}
+        normalized_model = _text(res_model)
+        if not normalized_model:
+            return ""
+        for view_mode in view_modes:
+            normalized_view = self._normalize_view_mode(view_mode)
+            if not normalized_view:
+                continue
+            resolved = model_view_map.get((normalized_model, normalized_view))
+            if _text(resolved):
+                return _text(resolved)
+        return ""
+
+    def _resolve_custom_action_target(self, *, node: dict, action_id, resolver: dict) -> dict:
+        action_type = _text(node.get("action_type") or node.get("action_model"))
+        if action_type != "ir.actions.act_window":
+            return {}
+        if not isinstance(action_id, int) or action_id <= 0:
+            return {}
+        if not bool(node.get("action_exists")):
+            return {}
+        action_meta = node.get("action_meta") if isinstance(node.get("action_meta"), dict) else {}
+        res_model = _text(action_meta.get("res_model"))
+        view_mode_raw = _text(action_meta.get("view_mode"))
+        if not res_model or not view_mode_raw:
+            return {}
+        view_modes = [
+            token
+            for token in (_text(part) for part in view_mode_raw.split(","))
+            if token
+        ]
+        if not view_modes:
+            return {}
+        if any(token not in SUPPORTED_CUSTOM_ACTION_VIEW_MODES for token in view_modes):
+            return {}
+        resolved_scene_key = self._resolve_scene_key_from_model_view(
+            res_model=res_model,
+            view_modes=view_modes,
+            resolver=resolver,
+        )
+        if resolved_scene_key:
+            target = {
+                "scene_key": resolved_scene_key,
+            }
+            resolved_scene_route = self._resolve_scene_route(scene_key=resolved_scene_key, resolver=resolver)
+            if resolved_scene_route:
+                target["route"] = resolved_scene_route
+            target["action_id"] = action_id
+            return target
+        target = {
+            "action_id": action_id,
+            "res_model": res_model,
+            "view_mode": ",".join(view_modes),
+        }
+        view_id = _to_int(action_meta.get("view_id"))
+        if view_id:
+            target["view_id"] = view_id
+        return target
+
+    def _resolve_native_bridge_target(self, *, node: dict, action_id) -> dict:
+        action_type = _text(node.get("action_type") or node.get("action_model"))
+        if action_type not in NATIVE_BRIDGE_ACTION_TYPES:
+            return {}
+        if not isinstance(action_id, int) or action_id <= 0:
+            return {}
+        if not bool(node.get("action_exists")):
+            return {}
+        return {
+            "action_id": action_id,
+            "action_type": action_type,
+        }
+
+    def _resolve_url_target(self, *, node: dict, action_id) -> dict:
+        action_type = _text(node.get("action_type") or node.get("action_model"))
+        if action_type != "ir.actions.act_url":
+            return {}
+        if not isinstance(action_id, int) or action_id <= 0:
+            return {}
+        if not bool(node.get("action_exists")):
+            return {}
+        target = {
+            "action_id": action_id,
+        }
+        url_value = ""
+        if self.env is not None:
+            rec = self.env["ir.actions.act_url"].sudo().browse([action_id]).exists()
+            if rec:
+                url_value = _text(rec[0].url)
+        if url_value:
+            target["url"] = url_value
+        return target
+
+    def _resolve_unavailable_reason(self, *, node: dict, has_children: bool, action_raw: str) -> str:
+        if has_children and not action_raw:
+            return "DIRECTORY_ONLY"
+        action_parse_error = _text(node.get("action_parse_error"))
+        if action_parse_error:
+            return "ACTION_INVALID"
+        action_type = _text(node.get("action_type") or node.get("action_model"))
+        action_exists = bool(node.get("action_exists"))
+        if action_raw and not action_exists:
+            return "ACTION_INVALID"
+        if action_raw and action_type and action_type not in NATIVE_BRIDGE_ACTION_TYPES and action_type != "ir.actions.act_url":
+            return "DELIVERY_UNSUPPORTED"
+        if action_raw:
+            return "SCENE_UNRESOLVED"
+        return "TARGET_MISSING"
+
+    def _is_directory_only(self, *, has_children: bool, target_type: str, action_raw: str) -> bool:
+        if not has_children:
+            return False
+        if target_type in {"scene", "action", "native", "url"}:
+            return False
+        return not _text(action_raw)
+
+    def _build_route(self, *, target_type: str, target: dict, menu_id) -> str | None:
+        suffix = f"?menu_id={menu_id}" if isinstance(menu_id, int) and menu_id > 0 else ""
+        if target_type == "scene":
+            explicit_route = _text(target.get("route"))
+            if explicit_route:
+                return explicit_route
+            scene_key = _text(target.get("scene_key"))
+            return f"/s/{scene_key}" if scene_key else None
+        if target_type == "action":
+            action_id = _to_int(target.get("action_id"))
+            return f"/a/{action_id}{suffix}" if action_id else None
+        if target_type == "native":
+            action_id = _to_int(target.get("action_id"))
+            return f"/native/action/{action_id}{suffix}" if action_id else None
+        if target_type == "url":
+            return _text(target.get("url")) or None
+        return None
+
+    def _build_active_match(self, *, menu_id, target_type: str, target: dict, route: str | None, action_id) -> dict:
+        scene_key = _text(target.get("scene_key")) if isinstance(target, dict) else ""
+        target_action_id = _to_int(target.get("action_id")) if isinstance(target, dict) else None
+        effective_action_id = target_action_id or (action_id if isinstance(action_id, int) else None)
+        route_prefix = None
+        if target_type == "scene" and scene_key:
+            route_prefix = f"/s/{scene_key}"
+        elif target_type == "action" and effective_action_id:
+            route_prefix = f"/a/{effective_action_id}"
+        elif target_type == "native" and effective_action_id:
+            route_prefix = f"/native/action/{effective_action_id}"
+        elif target_type == "url" and route:
+            route_prefix = route
+        return {
+            "menu_id": menu_id,
+            "scene_key": scene_key or None,
+            "action_id": effective_action_id,
+            "route_prefix": route_prefix,
+        }
+
+    def _explain_tree(self, node: dict, *, resolver: dict) -> dict:
+        children = node.get("children") if isinstance(node.get("children"), list) else []
+        explained = self._explain_node(node, resolver=resolver)
+        explained["children"] = [self._explain_tree(child, resolver=resolver) for child in children if isinstance(child, dict)]
+        return explained
+
+    def _explain_node(self, node: dict, *, resolver: dict) -> dict:
+        menu_id = node.get("menu_id")
+        has_children = bool(node.get("has_children")) or bool(node.get("children") or node.get("child_ids"))
+        action_raw = str(node.get("action_raw") or "").strip()
+        action_type = str(node.get("action_type") or "").strip()
+        action_id = node.get("action_id")
+        is_clickable = bool(action_raw)
+
+        target_type = "unavailable"
+        delivery_mode = "none"
+        route = None
+        target = {}
+        availability_status = "blocked"
+        reason_code = "TARGET_MISSING"
+        resolved_scene_key = self._resolve_scene_key(menu_id=menu_id, action_id=action_id, resolver=resolver)
+        custom_action_target = self._resolve_custom_action_target(node=node, action_id=action_id, resolver=resolver)
+        native_bridge_target = self._resolve_native_bridge_target(node=node, action_id=action_id)
+        url_target = self._resolve_url_target(node=node, action_id=action_id)
+
+        if resolved_scene_key:
+            target_type = "scene"
+            delivery_mode = "custom_scene"
+            is_clickable = True
+            availability_status = "ok"
+            reason_code = ""
+            target = {
+                "scene_key": resolved_scene_key,
+            }
+            resolved_scene_route = self._resolve_scene_route(scene_key=resolved_scene_key, resolver=resolver)
+            if resolved_scene_route:
+                target["route"] = resolved_scene_route
+        elif custom_action_target:
+            target_type = "scene" if _text(custom_action_target.get("scene_key")) else "action"
+            delivery_mode = "custom_scene" if target_type == "scene" else "custom_action"
+            is_clickable = True
+            availability_status = "ok"
+            reason_code = ""
+            target = custom_action_target
+        elif url_target:
+            target_type = "url"
+            delivery_mode = "external_url"
+            is_clickable = True
+            availability_status = "ok"
+            reason_code = ""
+            target = url_target
+        elif native_bridge_target:
+            target_type = "native"
+            delivery_mode = "native_bridge"
+            is_clickable = True
+            availability_status = "ok"
+            reason_code = ""
+            target = native_bridge_target
+        elif has_children and not action_raw:
+            target_type = "directory"
+            delivery_mode = "none"
+            is_clickable = False
+            availability_status = "ok"
+            reason_code = "DIRECTORY_ONLY"
+        else:
+            reason_code = self._resolve_unavailable_reason(node=node, has_children=has_children, action_raw=action_raw)
+
+        if reason_code and reason_code not in UNAVAILABLE_REASON_CODES:
+            reason_code = "TARGET_MISSING"
+
+        if self._is_directory_only(has_children=has_children, target_type=target_type, action_raw=action_raw):
+            target_type = "directory"
+            delivery_mode = "none"
+            is_clickable = False
+            availability_status = "ok"
+            reason_code = "DIRECTORY_ONLY"
+            target = {}
+
+        route = self._build_route(target_type=target_type, target=target, menu_id=menu_id)
+        active_match = self._build_active_match(
+            menu_id=menu_id,
+            target_type=target_type,
+            target=target,
+            route=route,
+            action_id=action_id,
+        )
+        entry_target = _build_entry_target(
+            menu_id=menu_id,
+            action_id=action_id,
+            target_type=target_type,
+            delivery_mode=delivery_mode,
+            route=route,
+            target=target,
+        )
+
+        if target_type not in TARGET_TYPES:
+            target_type = "unavailable"
+        if delivery_mode not in DELIVERY_MODES:
+            delivery_mode = "none"
+
+        return {
+            "menu_id": menu_id,
+            "key": str(node.get("key") or f"menu:{menu_id}"),
+            "name": str(node.get("name") or ""),
+            "is_visible": True,
+            "is_clickable": bool(is_clickable),
+            "target_type": target_type,
+            "delivery_mode": delivery_mode,
+            "route": route,
+            "target": target,
+            "entry_target": entry_target,
+            "active_match": active_match,
+            "availability_status": availability_status,
+            "reason_code": reason_code,
+            "source": {
+                "action_raw": action_raw,
+                "action_type": action_type,
+                "action_id": action_id,
+            },
+            "children": [],
+        }

--- a/addons/smart_core/governance/scene_normalizer.py
+++ b/addons/smart_core/governance/scene_normalizer.py
@@ -82,6 +82,44 @@ def _normalize_view_mode(raw: str | None) -> str | None:
     return val
 
 
+def _build_entry_target(*, scene_key: str = "", route: str = "", menu_id=None, action_id=None, model: str = "", record_id=None) -> dict:
+    normalized_scene_key = str(scene_key or "").strip()
+    normalized_route = str(route or "").strip()
+    if not normalized_scene_key and normalized_route.startswith("/s/"):
+        normalized_scene_key = normalized_route.replace("/s/", "", 1).strip("/")
+    if not normalized_scene_key:
+        return {}
+    target = {
+        "type": "scene",
+        "scene_key": normalized_scene_key,
+    }
+    if normalized_route:
+        target["route"] = normalized_route
+    compatibility = {}
+    if isinstance(menu_id, int) and menu_id > 0:
+        compatibility["menu_id"] = menu_id
+    if isinstance(action_id, int) and action_id > 0:
+        compatibility["action_id"] = action_id
+    normalized_model = str(model or "").strip()
+    if normalized_model:
+        compatibility["model"] = normalized_model
+    if isinstance(record_id, int) and record_id > 0:
+        compatibility["record_id"] = record_id
+    if normalized_model and isinstance(record_id, int) and record_id > 0:
+        record_entry = {
+            "model": normalized_model,
+            "record_id": record_id,
+        }
+        if isinstance(action_id, int) and action_id > 0:
+            record_entry["action_id"] = action_id
+        if isinstance(menu_id, int) and menu_id > 0:
+            record_entry["menu_id"] = menu_id
+        target["record_entry"] = record_entry
+    if compatibility:
+        target["compatibility_refs"] = compatibility
+    return target
+
+
 def _append_inferred_scene_warnings(nodes, scene_keys: set, warnings: list):
     if warnings is None:
         return
@@ -252,33 +290,21 @@ def _normalize_scene_targets(env, scenes, nav_targets, resolve_errors):
             target.pop("menuXmlid", None)
         if target.get("action_id") or target.get("model") or (target.get("route") and not route_is_missing_fallback):
             scene["target"] = target
-            continue
-        nav = nav_targets.get(scene_key) or {}
-        resolved = {}
-        if nav.get("action_id"):
-            resolved["action_id"] = nav.get("action_id")
-        elif nav.get("model"):
-            resolved["model"] = nav.get("model")
-            if nav.get("view_mode"):
-                resolved["view_mode"] = nav.get("view_mode")
-        if nav.get("menu_id"):
-            resolved["menu_id"] = nav.get("menu_id")
-        if resolved:
-            scene["target"] = resolved
         else:
-            semantic_fallback = f"/s/{scene_key}"
-            if route_is_missing_fallback:
-                scene["target"] = {"route": semantic_fallback}
-                _append_resolve_error(
-                    resolve_errors,
-                    scene_key=scene_key,
-                    kind="target",
-                    code="MISSING_TARGET",
-                    ref=semantic_fallback,
-                    field="target",
-                    message="target missing; semantic fallback route applied",
-                )
+            nav = nav_targets.get(scene_key) or {}
+            resolved = {}
+            if nav.get("action_id"):
+                resolved["action_id"] = nav.get("action_id")
+            elif nav.get("model"):
+                resolved["model"] = nav.get("model")
+                if nav.get("view_mode"):
+                    resolved["view_mode"] = nav.get("view_mode")
+            if nav.get("menu_id"):
+                resolved["menu_id"] = nav.get("menu_id")
+            if resolved:
+                scene["target"] = resolved
             else:
+                semantic_fallback = f"/s/{scene_key}"
                 scene["target"] = {"route": semantic_fallback}
                 _append_resolve_error(
                     resolve_errors,
@@ -289,6 +315,18 @@ def _normalize_scene_targets(env, scenes, nav_targets, resolve_errors):
                     field="target",
                     message="target missing; semantic fallback route applied",
                 )
+        final_target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+        entry_target = _build_entry_target(
+            scene_key=scene_key,
+            route=str(final_target.get("route") or "").strip(),
+            menu_id=final_target.get("menu_id") if isinstance(final_target.get("menu_id"), int) else None,
+            action_id=final_target.get("action_id") if isinstance(final_target.get("action_id"), int) else None,
+            model=str(final_target.get("model") or "").strip(),
+            record_id=final_target.get("record_id") if isinstance(final_target.get("record_id"), int) else None,
+        )
+        if entry_target:
+            final_target["entry_target"] = entry_target
+            scene["target"] = final_target
     return scenes
 
 

--- a/addons/smart_core/identity/identity_resolver.py
+++ b/addons/smart_core/identity/identity_resolver.py
@@ -30,7 +30,7 @@ ROLE_SURFACE_MAP = {
 }
 
 ROLE_GROUPS_EXPLICIT = {
-    "executive": {"base.group_system"},
+    "executive": set(),
     "pm": set(),
     "finance": set(),
 }
@@ -167,6 +167,99 @@ class IdentityResolver:
                 indexed[xmlid] = node
         return indexed
 
+    def _extract_scene_key_from_route(self, route: str) -> str:
+        normalized_route = str(route or "").strip()
+        if not normalized_route.startswith("/s/"):
+            return ""
+        candidate = normalized_route.split("?", 1)[0].strip()
+        return candidate.replace("/s/", "", 1).strip()
+
+    def _collect_nav_scene_candidates(self, nodes, scene_keys: set) -> List[str]:
+        available_scene_keys = {str(item or "").strip() for item in (scene_keys or set()) if str(item or "").strip()}
+        collected: List[str] = []
+        seen = set()
+
+        def _push(scene_key: str):
+            normalized = str(scene_key or "").strip()
+            if not normalized or normalized in seen:
+                return
+            if available_scene_keys and normalized not in available_scene_keys:
+                return
+            seen.add(normalized)
+            collected.append(normalized)
+
+        for node in self._walk_nav_nodes(nodes):
+            meta = node.get("meta") if isinstance(node.get("meta"), dict) else {}
+            target = node.get("target") if isinstance(node.get("target"), dict) else {}
+            entry_target = node.get("entry_target") if isinstance(node.get("entry_target"), dict) else {}
+            for candidate in (
+                meta.get("scene_key"),
+                target.get("scene_key"),
+                entry_target.get("scene_key"),
+                self._extract_scene_key_from_route(meta.get("route") or ""),
+                self._extract_scene_key_from_route(target.get("route") or ""),
+                self._extract_scene_key_from_route(entry_target.get("route") or ""),
+            ):
+                _push(candidate)
+        return collected
+
+    def _merge_scene_candidates(self, base_candidates: List[str], nav_tree: list, scene_keys: set) -> List[str]:
+        merged: List[str] = []
+        seen = set()
+
+        def _push(scene_key: str):
+            normalized = str(scene_key or "").strip()
+            if not normalized or normalized in seen:
+                return
+            seen.add(normalized)
+            merged.append(normalized)
+
+        available_scene_keys = sorted({str(item or "").strip() for item in (scene_keys or set()) if str(item or "").strip()})
+        for scene_key in base_candidates or []:
+            _push(scene_key)
+        for scene_key in self._collect_nav_scene_candidates(nav_tree, scene_keys):
+            _push(scene_key)
+        for scene_key in available_scene_keys:
+            _push(scene_key)
+        return merged
+
+    def _build_entry_target(self, *, scene_key: str = "", route: str = "", menu_id=None, action_id=None, model: str = "", record_id=None) -> dict:
+        normalized_scene_key = str(scene_key or "").strip()
+        normalized_route = str(route or "").strip()
+        if not normalized_scene_key and normalized_route.startswith("/s/"):
+            normalized_scene_key = normalized_route.replace("/s/", "", 1).strip("/")
+        if not normalized_scene_key:
+            return {}
+        target = {
+            "type": "scene",
+            "scene_key": normalized_scene_key,
+        }
+        if normalized_route:
+            target["route"] = normalized_route
+        compatibility = {}
+        if isinstance(menu_id, int) and menu_id > 0:
+            compatibility["menu_id"] = menu_id
+        if isinstance(action_id, int) and action_id > 0:
+            compatibility["action_id"] = action_id
+        normalized_model = str(model or "").strip()
+        if normalized_model:
+            compatibility["model"] = normalized_model
+        if isinstance(record_id, int) and record_id > 0:
+            compatibility["record_id"] = record_id
+        if normalized_model and isinstance(record_id, int) and record_id > 0:
+            record_entry = {
+                "model": normalized_model,
+                "record_id": record_id,
+            }
+            if isinstance(action_id, int) and action_id > 0:
+                record_entry["action_id"] = action_id
+            if isinstance(menu_id, int) and menu_id > 0:
+                record_entry["menu_id"] = menu_id
+            target["record_entry"] = record_entry
+        if compatibility:
+            target["compatibility_refs"] = compatibility
+        return target
+
     def build_role_surface(
         self,
         user_xmlids: set,
@@ -177,7 +270,11 @@ class IdentityResolver:
         role_code, role_evidence = self.resolve_role_code_with_evidence(user_xmlids)
         role_meta = self._role_surface_map.get(role_code) or self._role_surface_map.get("owner") or {}
         role_meta = self._merge_role_meta(role_code, role_meta, role_surface_overrides)
-        scene_candidates = list(role_meta.get("landing_scene_candidates") or [])
+        scene_candidates = self._merge_scene_candidates(
+            list(role_meta.get("landing_scene_candidates") or []),
+            nav_tree,
+            scene_keys,
+        )
         menu_candidates = list(role_meta.get("menu_xmlids") or [])
         menu_blocklist_xmlids = list(role_meta.get("menu_blocklist_xmlids") or [])
         landing_scene_key = self._pick_landing_scene(scene_candidates, scene_keys)
@@ -191,18 +288,27 @@ class IdentityResolver:
             landing_menu_xmlid = xmlid
             landing_menu_id = node.get("menu_id") or node.get("id")
             break
-        return {
+        landing_path = f"/s/{landing_scene_key}"
+        role_surface = {
             "role_code": role_code,
             "role_label": role_meta.get("label") or role_code,
             "role_evidence": role_evidence,
             "landing_scene_key": landing_scene_key,
             "landing_menu_xmlid": landing_menu_xmlid,
             "landing_menu_id": landing_menu_id,
-            "landing_path": f"/s/{landing_scene_key}",
+            "landing_path": landing_path,
             "scene_candidates": scene_candidates,
             "menu_xmlids": menu_candidates,
             "menu_blocklist_xmlids": menu_blocklist_xmlids,
         }
+        landing_entry_target = self._build_entry_target(
+            scene_key=landing_scene_key,
+            route=landing_path,
+            menu_id=landing_menu_id if isinstance(landing_menu_id, int) else None,
+        )
+        if landing_entry_target:
+            role_surface["landing_entry_target"] = landing_entry_target
+        return role_surface
 
     def build_role_surface_map_payload(self) -> Dict[str, dict]:
         payload = {}
@@ -285,16 +391,35 @@ class IdentityResolver:
                 menu_id = node.get("menu_id") or node.get("id")
                 if menu_id:
                     scene_key = ""
+                    model = ""
+                    record_id = None
+                    action_id = None
                     if isinstance(node.get("meta"), dict):
-                        scene_key = str((node.get("meta") or {}).get("scene_key") or "").strip()
+                        meta = node.get("meta") or {}
+                        scene_key = str(meta.get("scene_key") or "").strip()
+                        model = str(meta.get("model") or "").strip()
+                        record_id = meta.get("record_id") if isinstance(meta.get("record_id"), int) else None
+                        action_id = meta.get("action_id") if isinstance(meta.get("action_id"), int) else None
                     if not scene_key:
                         scene_key = str(node.get("scene_key") or "").strip()
-                    return {
+                    route = f"/s/{scene_key}" if scene_key else "/workbench"
+                    default_route = {
                         "menu_id": menu_id,
                         "scene_key": scene_key or None,
-                        "route": f"/workbench?scene={scene_key}" if scene_key else "/workbench",
+                        "route": route,
                         "reason": "menu_fallback",
                     }
+                    entry_target = self._build_entry_target(
+                        scene_key=scene_key,
+                        route=route,
+                        menu_id=menu_id if isinstance(menu_id, int) else None,
+                        action_id=action_id,
+                        model=model,
+                        record_id=record_id,
+                    )
+                    if entry_target:
+                        default_route["entry_target"] = entry_target
+                    return default_route
             return None
 
         default_route = dfs(nav_tree)

--- a/addons/smart_core/tests/test_identity_resolver_entry_target.py
+++ b/addons/smart_core/tests/test_identity_resolver_entry_target.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+SMART_CORE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(SMART_CORE_DIR)]
+utils_pkg = sys.modules.setdefault("odoo.addons.smart_core.utils", types.ModuleType("odoo.addons.smart_core.utils"))
+utils_pkg.__path__ = [str(SMART_CORE_DIR / "utils")]
+extension_hooks = types.ModuleType("odoo.addons.smart_core.utils.extension_hooks")
+extension_hooks.call_extension_hook_first = lambda *args, **kwargs: None
+sys.modules["odoo.addons.smart_core.utils.extension_hooks"] = extension_hooks
+
+target = _load_module(
+    "odoo.addons.smart_core.identity.identity_resolver",
+    SMART_CORE_DIR / "identity" / "identity_resolver.py",
+)
+
+
+class TestIdentityResolverEntryTarget(unittest.TestCase):
+    def test_build_role_surface_exposes_landing_entry_target(self):
+        resolver = target.IdentityResolver()
+        role_surface = resolver.build_role_surface(set(), [], {"workspace.home"})
+
+        self.assertEqual(role_surface.get("landing_scene_key"), "workspace.home")
+        self.assertEqual(((role_surface.get("landing_entry_target") or {}).get("type")), "scene")
+        self.assertEqual(((role_surface.get("landing_entry_target") or {}).get("scene_key")), "workspace.home")
+        self.assertEqual(((role_surface.get("landing_entry_target") or {}).get("route")), "/s/workspace.home")
+
+    def test_build_role_surface_merges_visible_nav_scene_candidates(self):
+        resolver = target.IdentityResolver()
+        role_surface = resolver.build_role_surface(
+            set(),
+            [
+                {
+                    "menu_id": 314,
+                    "children": [],
+                    "meta": {
+                        "scene_key": "projects.ledger",
+                        "route": "/s/projects.ledger?menu_id=314",
+                    },
+                },
+                {
+                    "menu_id": 317,
+                    "children": [],
+                    "entry_target": {
+                        "type": "scene",
+                        "scene_key": "cost.project_budget",
+                        "route": "/s/cost.project_budget?menu_id=317",
+                    },
+                },
+            ],
+            {"workspace.home", "projects.ledger", "cost.project_budget"},
+        )
+
+        self.assertEqual(role_surface.get("landing_scene_key"), "workspace.home")
+        self.assertEqual(
+            role_surface.get("scene_candidates"),
+            ["portal.dashboard", "workspace.home", "projects.ledger", "cost.project_budget"],
+        )
+
+    def test_build_role_surface_appends_available_scene_keys_when_nav_lacks_scene_identity(self):
+        resolver = target.IdentityResolver()
+        role_surface = resolver.build_role_surface(
+            set(),
+            [
+                {
+                    "menu_id": 317,
+                    "children": [],
+                    "meta": {
+                        "action_id": 485,
+                    },
+                },
+            ],
+            {"workspace.home", "projects.ledger", "cost.project_budget"},
+        )
+
+        self.assertEqual(
+            role_surface.get("scene_candidates"),
+            ["portal.dashboard", "workspace.home", "cost.project_budget", "projects.ledger"],
+        )
+
+    def test_infer_default_route_from_nav_prefers_scene_entry_target(self):
+        resolver = target.IdentityResolver()
+        default_route = resolver.infer_default_route_from_nav([
+            {
+                "menu_id": 202,
+                "children": [],
+                "meta": {"scene_key": "projects.list", "action_id": 502, "model": "project.project", "record_id": 42},
+            }
+        ])
+
+        self.assertEqual(default_route.get("scene_key"), "projects.list")
+        self.assertEqual(default_route.get("route"), "/s/projects.list")
+        self.assertEqual(((default_route.get("entry_target") or {}).get("scene_key")), "projects.list")
+        self.assertEqual(((((default_route.get("entry_target") or {}).get("compatibility_refs") or {}).get("menu_id"))), 202)
+        self.assertEqual(((((default_route.get("entry_target") or {}).get("record_entry") or {}).get("model"))), "project.project")
+        self.assertEqual(((((default_route.get("entry_target") or {}).get("record_entry") or {}).get("record_id"))), 42)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_menu_target_interpreter_entry_target.py
+++ b/addons/smart_core/tests/test_menu_target_interpreter_entry_target.py
@@ -1,0 +1,244 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+SMART_CORE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(SMART_CORE_DIR)]
+delivery_pkg = sys.modules.setdefault("odoo.addons.smart_core.delivery", types.ModuleType("odoo.addons.smart_core.delivery"))
+delivery_pkg.__path__ = [str(SMART_CORE_DIR / "delivery")]
+
+menu_target_interpreter_service = _load_module(
+    "odoo.addons.smart_core.delivery.menu_target_interpreter_service",
+    SMART_CORE_DIR / "delivery" / "menu_target_interpreter_service.py",
+)
+
+MenuTargetInterpreterService = menu_target_interpreter_service.MenuTargetInterpreterService
+
+
+class TestMenuTargetInterpreterEntryTarget(unittest.TestCase):
+    def test_scene_node_exposes_formal_entry_target(self):
+        service = MenuTargetInterpreterService(env=None)
+        nav_fact = {
+            "flat": [
+                {
+                    "menu_id": 11,
+                    "key": "menu:11",
+                    "name": "项目台账",
+                    "has_children": False,
+                    "action_raw": "ir.actions.act_window,484",
+                    "action_type": "ir.actions.act_window",
+                    "action_id": 484,
+                    "action_exists": True,
+                    "action_meta": {},
+                }
+            ],
+            "tree": [],
+        }
+
+        explained = service.interpret(
+            nav_fact,
+            scene_map={"menu_id_to_scene": {"11": "projects.list"}},
+            policy={},
+        )
+        row = explained["flat"][0]
+
+        self.assertEqual(row["target_type"], "scene")
+        self.assertEqual(row["route"], "/s/projects.list")
+        self.assertEqual(
+            row["entry_target"],
+            {
+                "type": "scene",
+                "scene_key": "projects.list",
+                "route": "/s/projects.list",
+            },
+        )
+
+    def test_native_node_exposes_compatibility_entry_target(self):
+        service = MenuTargetInterpreterService(env=None)
+        nav_fact = {
+            "flat": [
+                {
+                    "menu_id": 12,
+                    "key": "menu:12",
+                    "name": "原生动作",
+                    "has_children": False,
+                    "action_raw": "ir.actions.server,501",
+                    "action_type": "ir.actions.server",
+                    "action_id": 501,
+                    "action_exists": True,
+                    "action_meta": {},
+                }
+            ],
+            "tree": [],
+        }
+
+        explained = service.interpret(nav_fact, scene_map={}, policy={})
+        row = explained["flat"][0]
+
+        self.assertEqual(row["target_type"], "native")
+        self.assertEqual(row["route"], "/native/action/501?menu_id=12")
+        self.assertEqual(
+            row["entry_target"],
+            {
+                "type": "compatibility",
+                "route": "/native/action/501?menu_id=12",
+                "compatibility_refs": {
+                    "menu_id": 12,
+                    "action_id": 501,
+                    "target_type": "native",
+                    "delivery_mode": "native_bridge",
+                },
+            },
+        )
+
+    def test_scene_node_prefers_registry_route_when_supplied(self):
+        service = MenuTargetInterpreterService(env=None)
+        nav_fact = {
+            "flat": [
+                {
+                    "menu_id": 21,
+                    "key": "menu:21",
+                    "name": "财务中心",
+                    "has_children": False,
+                    "action_raw": "ir.actions.act_window,621",
+                    "action_type": "ir.actions.act_window",
+                    "action_id": 621,
+                    "action_exists": True,
+                    "action_meta": {},
+                }
+            ],
+            "tree": [],
+        }
+
+        explained = service.interpret(
+            nav_fact,
+            scene_map={
+                "entries": [
+                    {
+                        "code": "finance.center",
+                        "target": {
+                            "route": "/s/finance.workspace",
+                            "menu_id": 21,
+                            "action_id": 621,
+                        },
+                    }
+                ]
+            },
+            policy={},
+        )
+        row = explained["flat"][0]
+
+        self.assertEqual(row["target_type"], "scene")
+        self.assertEqual(row["route"], "/s/finance.workspace")
+        self.assertEqual(row["entry_target"]["route"], "/s/finance.workspace")
+
+    def test_custom_action_node_with_model_view_scene_map_exposes_scene_entry_target(self):
+        service = MenuTargetInterpreterService(env=None)
+        nav_fact = {
+            "flat": [
+                {
+                    "menu_id": 31,
+                    "key": "menu:31",
+                    "name": "企业信息",
+                    "has_children": False,
+                    "action_raw": "ir.actions.act_window,246",
+                    "action_type": "ir.actions.act_window",
+                    "action_id": 246,
+                    "action_exists": True,
+                    "action_meta": {
+                        "res_model": "res.company",
+                        "view_mode": "form",
+                    },
+                }
+            ],
+            "tree": [],
+        }
+
+        explained = service.interpret(
+            nav_fact,
+            scene_map={
+                "entries": [
+                    {
+                        "code": "enterprise.company",
+                        "target": {
+                            "route": "/s/enterprise.company",
+                            "model": "res.company",
+                            "view_type": "form",
+                        },
+                    }
+                ]
+            },
+            policy={},
+        )
+        row = explained["flat"][0]
+
+        self.assertEqual(row["target_type"], "scene")
+        self.assertEqual(row["delivery_mode"], "custom_scene")
+        self.assertEqual(row["route"], "/s/enterprise.company")
+        self.assertEqual(
+            row["entry_target"],
+            {
+                "type": "scene",
+                "scene_key": "enterprise.company",
+                "route": "/s/enterprise.company",
+            },
+        )
+
+    def test_scene_node_does_not_leak_source_menu_action_query_identity(self):
+        service = MenuTargetInterpreterService(env=None)
+        nav_fact = {
+            "flat": [
+                {
+                    "menu_id": 289,
+                    "key": "menu:289",
+                    "name": "脏菜单入口",
+                    "has_children": False,
+                    "action_raw": "ir.actions.act_window,486",
+                    "action_type": "ir.actions.act_window",
+                    "action_id": 486,
+                    "action_exists": True,
+                    "action_meta": {},
+                }
+            ],
+            "tree": [],
+        }
+
+        explained = service.interpret(
+            nav_fact,
+            scene_map={"menu_id_to_scene": {"289": "contract.center"}},
+            policy={},
+        )
+        row = explained["flat"][0]
+
+        self.assertEqual(row["target_type"], "scene")
+        self.assertEqual(row["route"], "/s/contract.center")
+        self.assertEqual(
+            row["entry_target"],
+            {
+                "type": "scene",
+                "scene_key": "contract.center",
+                "route": "/s/contract.center",
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_platform_menu_api_scene_map.py
+++ b/addons/smart_core/tests/test_platform_menu_api_scene_map.py
@@ -1,0 +1,169 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+SMART_CORE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+http_mod = types.ModuleType("odoo.http")
+http_mod.Controller = object
+http_mod.route = lambda *args, **kwargs: (lambda func: func)
+http_mod.request = types.SimpleNamespace()
+sys.modules["odoo.http"] = http_mod
+sys.modules["odoo"].http = http_mod
+
+exceptions_mod = types.ModuleType("odoo.exceptions")
+exceptions_mod.AccessDenied = type("AccessDenied", (Exception,), {})
+sys.modules["odoo.exceptions"] = exceptions_mod
+
+addons_pkg = sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(SMART_CORE_DIR)]
+
+trace_mod = types.ModuleType("odoo.addons.smart_core.core.trace")
+trace_mod.get_trace_id = lambda headers=None: "trace-demo"
+sys.modules["odoo.addons.smart_core.core.trace"] = trace_mod
+
+menu_fact_service_mod = types.ModuleType("odoo.addons.smart_core.delivery.menu_fact_service")
+menu_fact_service_mod.MenuFactService = object
+sys.modules["odoo.addons.smart_core.delivery.menu_fact_service"] = menu_fact_service_mod
+
+menu_delivery_convergence_mod = types.ModuleType("odoo.addons.smart_core.delivery.menu_delivery_convergence_service")
+menu_delivery_convergence_mod.MenuDeliveryConvergenceService = object
+sys.modules["odoo.addons.smart_core.delivery.menu_delivery_convergence_service"] = menu_delivery_convergence_mod
+
+menu_target_interpreter_mod = types.ModuleType("odoo.addons.smart_core.delivery.menu_target_interpreter_service")
+menu_target_interpreter_mod.MenuTargetInterpreterService = object
+sys.modules["odoo.addons.smart_core.delivery.menu_target_interpreter_service"] = menu_target_interpreter_mod
+
+auth_mod = types.ModuleType("odoo.addons.smart_core.security.auth")
+auth_mod.get_user_from_token = lambda: None
+sys.modules["odoo.addons.smart_core.security.auth"] = auth_mod
+
+core_exceptions_mod = types.ModuleType("odoo.addons.smart_core.core.exceptions")
+core_exceptions_mod.AUTH_REQUIRED = "AUTH_REQUIRED"
+core_exceptions_mod.BAD_REQUEST = "BAD_REQUEST"
+core_exceptions_mod.DEFAULT_API_VERSION = "v1"
+core_exceptions_mod.DEFAULT_CONTRACT_VERSION = "v1"
+core_exceptions_mod.build_error_envelope = lambda **kwargs: kwargs
+sys.modules["odoo.addons.smart_core.core.exceptions"] = core_exceptions_mod
+
+extension_hooks_mod = types.ModuleType("odoo.addons.smart_core.utils.extension_hooks")
+extension_hooks_mod.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: None
+sys.modules["odoo.addons.smart_core.utils.extension_hooks"] = extension_hooks_mod
+
+platform_menu_api = _load_module(
+    "odoo.addons.smart_core.controllers.platform_menu_api",
+    SMART_CORE_DIR / "controllers" / "platform_menu_api.py",
+)
+
+
+class _DummyRef:
+    def __init__(self, record_id: int):
+        self.id = record_id
+
+
+class _DummyEnv:
+    def __init__(self, refs=None):
+        self._refs = dict(refs or {})
+
+    def ref(self, xmlid, raise_if_not_found=False):
+        _ = raise_if_not_found
+        record_id = self._refs.get(str(xmlid or "").strip())
+        if not record_id:
+            return None
+        return _DummyRef(int(record_id))
+
+
+class TestPlatformMenuAPISceneMap(unittest.TestCase):
+    def test_resolve_navigation_scene_map_merges_extension_payload(self):
+        env = _DummyEnv(
+            refs={
+                "smart_enterprise_base.menu_enterprise_company": 31,
+                "smart_enterprise_base.action_enterprise_company": 246,
+            }
+        )
+
+        platform_menu_api.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: {
+            "menu_scene_map": {
+                "smart_enterprise_base.menu_enterprise_company": "enterprise.company",
+            },
+            "action_xmlid_scene_map": {
+                "smart_enterprise_base.action_enterprise_company": "enterprise.company",
+            },
+            "model_view_scene_map": {
+                ("res.company", "form"): "enterprise.company",
+            },
+        }
+
+        resolved = platform_menu_api._resolve_navigation_scene_map(env, {})
+
+        self.assertEqual(resolved["menu_id_to_scene"]["31"], "enterprise.company")
+        self.assertEqual(resolved["action_id_to_scene"]["246"], "enterprise.company")
+        self.assertEqual(
+            resolved["entries"],
+            [
+                {
+                    "code": "enterprise.company",
+                    "target": {
+                        "model": "res.company",
+                        "view_type": "form",
+                    },
+                }
+            ],
+        )
+
+    def test_resolve_navigation_scene_map_preserves_explicit_payload(self):
+        env = _DummyEnv(
+            refs={
+                "smart_enterprise_base.menu_enterprise_company": 31,
+            }
+        )
+
+        platform_menu_api.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: {
+            "menu_scene_map": {
+                "smart_enterprise_base.menu_enterprise_company": "enterprise.company",
+            },
+            "action_xmlid_scene_map": {},
+            "model_view_scene_map": {
+                ("res.company", "form"): "enterprise.company",
+            },
+        }
+
+        resolved = platform_menu_api._resolve_navigation_scene_map(
+            env,
+            {
+                "menu_id_to_scene": {"31": "explicit.company"},
+                "entries": [
+                    {
+                        "code": "explicit.company",
+                        "target": {
+                            "model": "res.company",
+                            "view_type": "form",
+                        },
+                    }
+                ],
+            },
+        )
+
+        self.assertEqual(resolved["menu_id_to_scene"]["31"], "explicit.company")
+        self.assertEqual(resolved["entries"][0]["code"], "explicit.company")
+        self.assertEqual(len(resolved["entries"]), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_scene_normalizer_entry_target.py
+++ b/addons/smart_core/tests/test_scene_normalizer_entry_target.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+SMART_CORE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(SMART_CORE_DIR)]
+governance_pkg = sys.modules.setdefault("odoo.addons.smart_core.governance", types.ModuleType("odoo.addons.smart_core.governance"))
+governance_pkg.__path__ = [str(SMART_CORE_DIR / "governance")]
+utils_pkg = sys.modules.setdefault("odoo.addons.smart_core.utils", types.ModuleType("odoo.addons.smart_core.utils"))
+utils_pkg.__path__ = [str(SMART_CORE_DIR / "utils")]
+
+reason_codes = types.ModuleType("odoo.addons.smart_core.utils.reason_codes")
+reason_codes.REASON_OK = "OK"
+reason_codes.REASON_PERMISSION_DENIED = "PERMISSION_DENIED"
+reason_codes.failure_meta_for_reason = lambda code: {"reason_code": code}
+sys.modules["odoo.addons.smart_core.utils.reason_codes"] = reason_codes
+
+drift_engine = types.ModuleType("odoo.addons.smart_core.governance.scene_drift_engine")
+
+
+def _append_resolve_error(resolve_errors, **kwargs):
+    if isinstance(resolve_errors, list):
+        resolve_errors.append(kwargs)
+
+
+drift_engine.append_resolve_error = _append_resolve_error
+sys.modules["odoo.addons.smart_core.governance.scene_drift_engine"] = drift_engine
+
+target = _load_module(
+    "odoo.addons.smart_core.governance.scene_normalizer",
+    SMART_CORE_DIR / "governance" / "scene_normalizer.py",
+)
+
+
+class _RefRecord:
+    def __init__(self, record_id: int):
+        self.id = record_id
+
+
+class _StubEnv:
+    def __init__(self, refs: dict[str, int]):
+        self._refs = refs
+
+    def ref(self, xmlid: str, raise_if_not_found: bool = False):
+        record_id = self._refs.get(xmlid)
+        if record_id is None:
+            return None
+        return _RefRecord(record_id)
+
+
+class TestSceneNormalizerEntryTarget(unittest.TestCase):
+    def test_resolve_targets_adds_scene_entry_target(self):
+        normalizer = target.SceneNormalizer()
+        scenes = [
+            {
+                "code": "projects.list",
+                "target": {
+                    "model": "project.project",
+                    "record_id": 42,
+                    "action_xmlid": "smart_construction_core.action_sc_project_list",
+                    "menu_xmlid": "smart_construction_core.menu_sc_root",
+                },
+            }
+        ]
+        diagnostics = {
+            "normalize_warnings": [],
+            "resolve_errors": [],
+        }
+        env = _StubEnv(
+            {
+                "smart_construction_core.action_sc_project_list": 502,
+                "smart_construction_core.menu_sc_root": 202,
+            }
+        )
+
+        normalizer.resolve_targets(env, scenes, [], diagnostics)
+
+        target_payload = (scenes[0] or {}).get("target") or {}
+        self.assertEqual((target_payload.get("entry_target") or {}).get("type"), "scene")
+        self.assertEqual((target_payload.get("entry_target") or {}).get("scene_key"), "projects.list")
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("compatibility_refs") or {}).get("action_id")), 502)
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("compatibility_refs") or {}).get("menu_id")), 202)
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("record_entry") or {}).get("model")), "project.project")
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("record_entry") or {}).get("record_id")), 42)
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("record_entry") or {}).get("action_id")), 502)
+        self.assertEqual((((target_payload.get("entry_target") or {}).get("record_entry") or {}).get("menu_id")), 202)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_scene_normalizer_target_resolution.py
+++ b/addons/smart_core/tests/test_scene_normalizer_target_resolution.py
@@ -31,6 +31,10 @@ class TestSceneNormalizerTargetResolution(TransactionCase):
         expected_menu_id = self.env.ref("smart_construction_core.menu_sc_root").id
         self.assertEqual(target.get("action_id"), expected_action_id)
         self.assertEqual(target.get("menu_id"), expected_menu_id)
+        self.assertEqual(((target.get("entry_target") or {}).get("type")), "scene")
+        self.assertEqual(((target.get("entry_target") or {}).get("scene_key")), "projects.list")
+        self.assertEqual((((target.get("entry_target") or {}).get("compatibility_refs") or {}).get("action_id")), expected_action_id)
+        self.assertEqual((((target.get("entry_target") or {}).get("compatibility_refs") or {}).get("menu_id")), expected_menu_id)
         self.assertNotIn("action_xmlid", target)
         self.assertNotIn("menu_xmlid", target)
         mismatch_codes = {
@@ -39,4 +43,3 @@ class TestSceneNormalizerTargetResolution(TransactionCase):
             if isinstance(item, dict)
         }
         self.assertIn("TARGET_ID_XMLID_MISMATCH", mismatch_codes)
-

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-ENTRY-TARGET-PA86.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-ENTRY-TARGET-PA86.yaml
@@ -1,0 +1,99 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-ENTRY-TARGET-PA86
+title: Split smart_core entry-target residual slice from codex-next-round
+type: governance-optimization
+status: active
+priority: high
+mode: implement
+
+goal: >
+  Extract the smallest platform-layer residual slice from commit 56b7eba so it
+  can be reviewed and merged independently into main as a bounded child PR.
+
+user_visible_outcome:
+  - "A new child branch is created for the smart_core entry-target and normalizer slice."
+
+scope:
+  allowed_paths:
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-ENTRY-TARGET-PA86.yaml
+    - addons/smart_core/controllers/platform_menu_api.py
+    - addons/smart_core/delivery/menu_target_interpreter_service.py
+    - addons/smart_core/governance/scene_normalizer.py
+    - addons/smart_core/identity/identity_resolver.py
+    - addons/smart_core/tests/test_identity_resolver_entry_target.py
+    - addons/smart_core/tests/test_menu_target_interpreter_entry_target.py
+    - addons/smart_core/tests/test_platform_menu_api_scene_map.py
+    - addons/smart_core/tests/test_scene_normalizer_entry_target.py
+    - addons/smart_core/tests/test_scene_normalizer_target_resolution.py
+  forbidden_paths:
+    - main
+    - master
+    - release/**
+    - security/**
+    - record_rules/**
+    - addons/smart_construction_core/**
+    - addons/smart_construction_scene/**
+    - frontend/**
+    - scripts/**
+
+limits:
+  max_files: 10
+  max_candidates: 10
+  max_output_lines: 120
+  forbid_repo_wide_scan: true
+  use_new_session: true
+  carry_long_context: false
+
+role_parallel:
+  enabled: false
+  allowed_roles:
+    - executor
+  require_disjoint_writes: true
+  require_new_session_per_role: true
+  stop_on_conflict: true
+
+change_rules:
+  - only extract the smart_core entry-target and normalizer slice
+  - do not mix scene provider or construction-core files
+  - do not mix payment residual files
+  - branch must be based on origin/main
+
+context:
+  branch: feature/pr-split-verify-generated-assets
+  baseline_sha: c47d4db
+  explicit_user_authorization: true
+  usability_battlefield: backend
+
+architecture:
+  layer_target: Platform Layer
+  module: smart_core entry-target and normalizer residual slice
+  module_owner: smart_core
+  kernel_or_scenario: kernel
+  backend_sub_layer_target: scene_orchestration
+  backend_sub_layer_reason: >
+    This batch extracts platform target-resolution and scene normalizer
+    semantics without carrying domain-specific scene provider logic.
+  reason: >
+    After the first child-PR merge wave, the next clean residual slice is the
+    platform entry-target path from 56b7eba.
+
+acceptance:
+  commands:
+    - test -f agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-ENTRY-TARGET-PA86.yaml
+
+risk:
+  level: medium
+  manual_approval_required: false
+
+stop_conditions:
+  - forbidden_path_touched
+  - residual_slice_conflict
+  - slice_spills_into_non_platform_scope
+
+deliverables:
+  - bounded smart_core residual child branch
+  - commit for platform entry-target slice
+
+rollback:
+  - git restore --staged .
+
+depends_on: []


### PR DESCRIPTION
## Summary

Split the smallest platform-layer residual slice from `56b7eba` out of the residual `codex/next-round` backlog.

This PR isolates smart_core entry-target resolution, scene normalizer, and related tests without carrying construction scene providers or domain-layer semantic carriers.

## Scope

- `addons/smart_core/controllers/platform_menu_api.py`
- `addons/smart_core/delivery/menu_target_interpreter_service.py`
- `addons/smart_core/governance/scene_normalizer.py`
- `addons/smart_core/identity/identity_resolver.py`
- `addons/smart_core/tests/test_identity_resolver_entry_target.py`
- `addons/smart_core/tests/test_menu_target_interpreter_entry_target.py`
- `addons/smart_core/tests/test_platform_menu_api_scene_map.py`
- `addons/smart_core/tests/test_scene_normalizer_entry_target.py`
- `addons/smart_core/tests/test_scene_normalizer_target_resolution.py`

## Architecture Impact

- platform-layer residual slice only
- no construction scene provider files included
- no payment residual files included
