### PR TITLE
[split] smart core scene-ready orchestration residual slice

### DIFF
--- a/addons/smart_core/core/page_contracts_builder.py
+++ b/addons/smart_core/core/page_contracts_builder.py
@@ -5,6 +5,10 @@ from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 import re
 from typing import Any, Dict
+from odoo.addons.smart_core.core.page_contract_semantic_orchestration_bridge import (
+    apply_page_contract_semantic_orchestration_bridge,
+)
+from odoo.addons.smart_core.core.page_contract_parser_semantic_bridge import apply_page_contract_parser_semantic_bridge
 
 def _load_semantics_registry() -> Dict[str, Any]:
     registry_path = Path(__file__).with_name("orchestration_semantics.py")
@@ -311,6 +315,19 @@ def _zone_from_tag(tag: str) -> Dict[str, str]:
     return {"key": "primary", "title": "主体内容", "zone_type": "primary", "display_mode": "stack"}
 
 
+def _zone_for_section(page_key: str, section_key: str, tag: str) -> Dict[str, str]:
+    provider = _load_data_provider()
+    if provider:
+        fn = getattr(provider, "build_zone_for_section", None)
+        if callable(fn):
+            payload = fn(page_key, section_key, tag)
+            if isinstance(payload, dict) and payload:
+                return payload
+    payload = _zone_from_tag(tag)
+    payload["description"] = ""
+    return payload
+
+
 def _semantic_from_section(page_key: str, section_key: str, tag: str) -> Dict[str, Any]:
     provider = _load_data_provider()
     if provider:
@@ -365,6 +382,28 @@ def _action_templates(section_key: str) -> list[Dict[str, Any]]:
     if any(token in key for token in ("table", "list", "records")):
         return [{"key": "open_list", "label": "查看明细", "intent": "ui.contract"}]
     return []
+
+
+def _action_templates_for_page(page_key: str, section_key: str) -> list[Dict[str, Any]]:
+    provider = _load_data_provider()
+    if provider:
+        fn = getattr(provider, "build_action_templates_for_page", None)
+        if callable(fn):
+            payload = fn(page_key, section_key)
+            if isinstance(payload, list):
+                return payload
+    return _action_templates(section_key)
+
+
+def _block_title(page_key: str, section_key: str) -> str:
+    provider = _load_data_provider()
+    if provider:
+        fn = getattr(provider, "build_block_title", None)
+        if callable(fn):
+            value = str(fn(page_key, section_key) or "").strip()
+            if value:
+                return value
+    return str(section_key or "").strip()
 
 
 def _action_target(action_key: str, page_key: str) -> Dict[str, Any]:
@@ -426,7 +465,7 @@ def _default_page_actions(page_key: str, profile_overrides: Dict[str, Any] | Non
         fn = getattr(provider, "build_default_page_actions", None)
         if callable(fn):
             payload = fn(page_key)
-            if isinstance(payload, list) and payload:
+            if isinstance(payload, list):
                 return payload
     key = str(page_key or "").strip().lower()
     if key == "home":
@@ -496,14 +535,14 @@ def _build_page_orchestration_v1(
         enabled = bool(section.get("enabled") is True)
         order_raw = section.get("order")
         order = int(order_raw) if isinstance(order_raw, int) and order_raw > 0 else idx + 1
-        zone_cfg = _zone_from_tag(tag)
+        zone_cfg = _zone_for_section(page_key, section_key, tag)
         zone_key = zone_cfg["key"]
         zone = zone_buckets.get(zone_key)
         if zone is None:
             zone = {
                 "key": zone_key,
-                "title": zone_cfg["title"],
-                "description": f"{page_key}::{zone_key}",
+                "title": zone_cfg.get("title", ""),
+                "description": zone_cfg.get("description", ""),
                 "zone_type": zone_cfg["zone_type"],
                 "display_mode": zone_cfg["display_mode"],
                 "priority": 100 - (len(zone_buckets) * 10),
@@ -519,7 +558,7 @@ def _build_page_orchestration_v1(
             {
                 "key": f"{page_key}.{section_key}",
                 "block_type": semantic["block_type"],
-                "title": section_key,
+                "title": _block_title(page_key, section_key),
                 "priority": max(1, 100 - order),
                 "importance": semantic["importance"],
                 "tone": semantic["tone"],
@@ -530,7 +569,7 @@ def _build_page_orchestration_v1(
                 "refreshable": True,
                 "collapsible": bool(tag == "details"),
                 "visibility": {"roles": audience, "capabilities": [], "expr": None},
-                "actions": _action_templates(section_key),
+                "actions": _action_templates_for_page(page_key, section_key),
                 "payload": {"tag": tag, "enabled": enabled, "open": bool(section.get("open") is True)},
             }
         )
@@ -820,6 +859,58 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "params_label": "Params",
                 },
             },
+            "capability_matrix": {
+                "schema_version": "v1",
+                "sections": [
+                    {"key": "hero", "enabled": True, "order": 1, "tag": "header"},
+                    {"key": "summary", "enabled": True, "order": 2, "tag": "section"},
+                    {"key": "matrix", "enabled": True, "order": 3, "tag": "section"},
+                ],
+                "texts": {
+                    "title": "能力矩阵",
+                    "hero_subtitle": "按能力分组查看当前账号的可用能力、受限能力与目标入口。",
+                    "summary_groups": "能力组数",
+                    "summary_total": "能力总数",
+                    "summary_allow": "可用能力",
+                    "summary_blocked": "受限 / 待开放",
+                    "empty_title": "暂无能力入口",
+                    "empty_message": "当前账号暂无可展示的能力矩阵条目。",
+                    "item_desc_missing": "后端未提供能力说明",
+                    "target_missing": "后端未提供跳转目标",
+                    "deny_reason_prefix": "原因：",
+                    "state_allow": "可用",
+                    "state_deny": "受限",
+                    "state_readonly": "只读",
+                    "state_pending": "待开放",
+                    "state_coming_soon": "建设中",
+                    "error_fallback": "能力矩阵加载失败",
+                },
+            },
+            "release_operator": {
+                "schema_version": "v1",
+                "sections": [
+                    {"key": "hero", "enabled": True, "order": 1, "tag": "header"},
+                    {"key": "release_state", "enabled": True, "order": 2, "tag": "section"},
+                    {"key": "candidate_snapshots", "enabled": True, "order": 3, "tag": "section"},
+                    {"key": "pending_approvals", "enabled": True, "order": 4, "tag": "section"},
+                    {"key": "rollback", "enabled": True, "order": 5, "tag": "section"},
+                ],
+                "texts": {
+                    "title": "发布控制台",
+                    "description": "查看当前发布状态、候选快照、待审批动作与回滚目标。",
+                    "error_title": "加载失败",
+                    "action_retry": "重试",
+                    "section_release_state": "当前发布状态",
+                    "section_candidate": "可 Promote 候选",
+                    "section_pending": "待审批动作",
+                    "section_rollback": "回滚",
+                    "hint_candidate": "仅展示当前 edition 下 candidate / approved snapshot。",
+                    "hint_pending_count_prefix": "当前数量：",
+                    "hint_rollback": "仅当当前 active released snapshot 存在 rollback target 时可执行。",
+                    "empty_candidate": "当前没有可 Promote 的候选快照。",
+                    "empty_pending": "当前没有待审批动作。",
+                },
+            },
             "workbench": {
                 "schema_version": "v1",
                 "sections": [
@@ -859,13 +950,13 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "reason_act_unsupported_type": "动作类型暂不支持",
                     "reason_contract_context_missing": "契约上下文缺失",
                     "reason_capability_missing": "缺少能力权限",
-                    "reason_unknown": "未知原因",
-                    "message_nav_menu_no_action": "当前菜单是目录，暂时没有可进入的子菜单。",
-                    "message_act_no_model": "当前动作对应的是自定义工作区，未绑定数据模型。",
-                    "message_act_unsupported_type": "当前动作类型暂未在门户壳层支持。",
-                    "message_contract_context_missing": "页面缺少契约必需上下文（例如 action_id）。",
-                    "message_capability_missing": "当前账号尚未开通该能力。",
-                    "message_default": "你可以返回工作台或打开菜单继续操作。",
+                    "reason_unknown": "页面入口未返回可识别原因",
+                    "message_nav_menu_no_action": "当前入口是目录菜单，本身不承载可打开页面。请改为进入下一级菜单。",
+                    "message_act_no_model": "当前入口未绑定可直接承接的数据模型，请改走专用页面或已注册场景。",
+                    "message_act_unsupported_type": "当前入口类型暂未接入门户前端承接，请改走原生页面或已注册场景。",
+                    "message_contract_context_missing": "当前入口缺少页面契约所需上下文，请补齐 action_id、menu_id 或 scene 参数后重试。",
+                    "message_capability_missing": "当前账号尚未开通该入口所需能力，请联系管理员确认授权范围。",
+                    "message_default": "请返回工作台、重新选择菜单，或刷新后重试。",
                 },
             },
             "my_work": {
@@ -879,7 +970,7 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                 "texts": {
                     "title": "我的工作",
                     "loading_title": "加载我的工作中...",
-                    "hero_subtitle": "聚合待办并直接处理，默认从“待我处理”开工。",
+                    "hero_subtitle": "聚合待办、提醒与辅助入口，默认先从“待我处理”开始。",
                     "action_refresh": "刷新",
                     "context_preset_prefix": "推荐视图：",
                     "action_clear_preset": "清除推荐",
@@ -957,7 +1048,7 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "action_apply_preset": "应用常用筛选",
                     "action_clear_saved_preset": "清除预设",
                     "filter_empty_title": "当前筛选条件没有匹配结果",
-                    "filter_empty_desc": "建议先恢复推荐视图，或一键清空筛选后重试。",
+                    "filter_empty_desc": "当前筛选未命中任何待办，建议恢复推荐视图，或清空筛选后重试。",
                     "action_restore_recommended_view": "恢复推荐视图",
                     "action_clear_filters": "清空筛选",
                     "batch_selected_prefix": "已选 ",
@@ -977,12 +1068,12 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "pager_middle_sep": " / ",
                     "pager_middle_suffix": " 页",
                     "pager_next": "下一页",
-                    "empty_desc": "状态良好。你可以返回工作台查看整体态势，或进入风险驾驶舱继续巡检。",
+                    "empty_desc": "当前没有待处理事项。你可以返回工作台查看其他入口，或进入风险驾驶舱继续巡检。",
                     "error_request_failed": "请求失败",
                     "feedback_save_preset_failed": "保存常用筛选失败",
                     "feedback_apply_preset_failed": "应用常用筛选失败",
                     "feedback_clear_preset_failed": "清除常用筛选失败",
-                    "visibility_notice_suffix": "，请联系管理员开通对应权限。",
+                    "visibility_notice_suffix": "，当前视图仅展示你有权访问的事项。",
                     "partial_data_hidden": "部分数据未显示",
                     "model_label_sc_workflow_workitem": "流程待办",
                     "model_label_tier_review": "审批复核",
@@ -999,8 +1090,8 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "feedback_apply_preset_ok": "已应用常用筛选",
                     "feedback_clear_preset_ok": "已清除常用筛选",
                     "feedback_filters_reset": "筛选条件已重置",
-                    "feedback_suggest_action_ok_prefix": "已执行建议动作：",
-                    "feedback_suggest_action_failed_prefix": "建议动作执行失败：",
+                    "feedback_suggest_action_ok_prefix": "已执行系统建议动作：",
+                    "feedback_suggest_action_failed_prefix": "系统建议动作执行失败：",
                     "feedback_none_retryable": "当前没有可重试失败项",
                     "feedback_none_non_retryable": "当前没有不可重试失败项",
                     "feedback_none_failed_selectable": "当前没有失败项可选择",
@@ -1034,7 +1125,7 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "confirm_batch_complete_suffix": " 条待办？",
                     "error_complete_todo_failed": "完成待办失败",
                     "error_batch_complete_failed": "批量完成待办失败",
-                    "enter_error_message_fallback": "功能入口暂时不可用",
+                    "enter_error_message_fallback": "当前入口暂时无法继续处理，请稍后重试。",
                     "feedback_reason_group_no_retry_prefix": "原因组 ",
                     "feedback_reason_group_no_retry_suffix": " 没有可重试项",
                     "feedback_selected_reason_retryable_prefix": "已选中 ",
@@ -1080,7 +1171,11 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     {"key": "status_forbidden", "enabled": True, "order": 3, "tag": "section"},
                 ],
                 "texts": {
+                    "scene_view_switch_label": "视图切换",
                     "loading_title": "正在加载场景...",
+                    "status_idle_diag_title": "场景已加载，但没有可渲染目标",
+                    "status_idle_diag_scene_prefix": "场景",
+                    "status_idle_diag_hint": "当前场景尚未解析出可渲染目标，请检查 scene target、action/menu 映射以及 scene-ready 渲染供给。",
                     "validation_surface_title": "场景校验",
                     "error_fallback": "场景加载失败",
                     "forbidden_title": "能力未开通",
@@ -1094,8 +1189,18 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "forbidden_hint_license_prefix": "当前 License：",
                     "forbidden_hint_license_suffix": "，可联系管理员评估升级或开通。",
                     "forbidden_hint_default": "可联系管理员开通对应能力。",
-                    "error_scene_target_unsupported": "scene target unsupported",
-                    "error_scene_resolve_failed": "scene resolve failed",
+                    "error_scene_render_target_missing": "场景缺少可渲染目标，请检查 scene target 与页面承接关系。",
+                    "error_scene_target_unsupported": "当前场景目标暂不支持前端承接，请改走已注册页面或原生入口。",
+                    "error_scene_resolve_failed": "场景解析失败，请稍后重试。",
+                    "runtime_diag_title_readonly": "当前场景处于只读运行态",
+                    "runtime_diag_title_empty": "当前场景处于空态",
+                    "runtime_diag_title_restricted": "当前场景访问受限",
+                    "runtime_diag_title_default": "场景运行态提示",
+                    "runtime_diag_status_prefix": "运行态状态",
+                    "runtime_diag_state_prefix": "当前记录状态",
+                    "runtime_diag_missing_required_prefix": "缺失必填项数量",
+                    "runtime_diag_transition_prefix": "可用流转数量",
+                    "runtime_diag_alignment_mismatch": "场景 contract diagnostics 与前端消费状态未完全对齐，请优先检查后端 diagnostics 供给。",
                 },
             },
             "action": {
@@ -1113,16 +1218,18 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     {"key": "dev_context", "enabled": True, "order": 10, "tag": "div"},
                 ],
                 "texts": {
-                    "error_fallback": "操作暂不可用",
+                    "error_fallback": "当前操作暂时不可用，请刷新后重试。",
                     "status_loading": "加载中",
                     "status_error": "加载失败",
                     "status_empty": "暂无数据",
                     "status_ready": "已就绪",
+                    "label.view_switch": "视图切换",
                     "label.quick_filters": "快速筛选",
                     "label.saved_filters": "已保存筛选",
                     "label.group_view": "分组查看",
                     "label.quick_actions": "快捷操作",
                     "label.contract_summary": "契约摘要",
+                    "strict_contract_missing_title": "契约缺口提示",
                     "intent_title_risk": "风险驾驶舱：先处理严重与逾期风险",
                     "intent_summary_risk": "优先完成分派、关闭或发起审批，避免风险停留在“仅可见”状态。",
                     "intent_action_risk_todo": "待我处理风险",
@@ -1323,7 +1430,8 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
                     "view_node_unsupported_title": "View node unsupported",
                     "view_node_unsupported_message": "Layout nodes are present but renderer support is incomplete.",
                     "banner_saved": "Saved. Changes have been applied.",
-                    "summary_status_stage": "项目状态与阶段",
+                    "summary_status_stage": "项目执行阶段",
+                    "summary_document_status": "单据状态",
                     "summary_risk": "关键风险摘要",
                     "summary_finance": "资金/产值指标",
                     "next_actions_title": "下一步动作",
@@ -1489,11 +1597,13 @@ def build_page_contracts(_data: Dict[str, Any]) -> Dict[str, Any]:
             continue
         if isinstance(page.get("page_orchestration_v1"), dict):
             continue
-        page["page_orchestration_v1"] = _build_page_orchestration_v1(
+        page_orchestration = _build_page_orchestration_v1(
             str(key),
             page,
             role_code,
             role_source_code=role_source_code,
             profile_overrides=profile_overrides,
         )
+        page_orchestration = apply_page_contract_parser_semantic_bridge(page_orchestration, safe_data)
+        page["page_orchestration_v1"] = apply_page_contract_semantic_orchestration_bridge(page_orchestration)
     return payload

--- a/addons/smart_core/core/scene_contract_builder.py
+++ b/addons/smart_core/core/scene_contract_builder.py
@@ -1,0 +1,408 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from odoo.addons.smart_core.core.scene_contract_parser_semantic_bridge import (
+    apply_scene_contract_parser_semantic_bridge,
+)
+from odoo.addons.smart_core.core.released_scene_semantic_surface_bridge import (
+    apply_released_scene_semantic_surface_bridge,
+)
+from odoo.addons.smart_core.core.scene_contract_semantic_orchestration_bridge import (
+    apply_scene_contract_semantic_orchestration_bridge,
+)
+
+
+SCENE_CONTRACT_STANDARD_VERSION = "scene_contract_standard_v1"
+
+_PRODUCT_TITLE_BY_KEY = {
+    "fr1": "FR-1 项目立项",
+    "fr2": "FR-2 项目推进",
+    "fr3": "FR-3 成本记录",
+    "fr4": "FR-4 付款记录",
+    "fr5": "FR-5 结算结果",
+    "my_work": "我的工作",
+}
+
+_ROUTE_ONLY_ACTIONS = {
+    "projects.intake": {
+        "primary_actions": [
+            {
+                "key": "quick_project_create",
+                "label": "快速创建（推荐）",
+                "target": {"type": "route", "route": "/s/projects.intake?intake_mode=quick", "scene_key": "projects.intake"},
+            }
+        ],
+        "secondary_actions": [
+            {
+                "key": "standard_project_intake",
+                "label": "标准立项",
+                "target": {"type": "route", "route": "/s/projects.intake", "scene_key": "projects.intake"},
+            }
+        ],
+    },
+}
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _clone_list(rows: Any) -> list[dict[str, Any]]:
+    return [deepcopy(row) for row in _list(rows) if isinstance(row, dict)]
+
+
+def _resolve_product_title(product_key: str) -> str:
+    return _PRODUCT_TITLE_BY_KEY.get(_text(product_key), _text(product_key) or "Released Scene")
+
+
+def _resolve_contract_title(*, title: str, scene_label: str, product_key: str, scene_key: str) -> str:
+    return title or scene_label or _resolve_product_title(product_key) or scene_key
+
+
+def _normalize_block_rows(blocks: Any, *, zone_key: str = "primary") -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for index, item in enumerate(_list(blocks), start=1):
+        if not isinstance(item, dict):
+            continue
+        key = _text(item.get("key") or item.get("block_key") or f"{zone_key}.block.{index}")
+        if not key:
+            continue
+        rows.append(
+            {
+                "key": key,
+                "title": _text(item.get("title") or key),
+                "state": _text(item.get("state") or "ready"),
+                "block_type": _text(item.get("block_type") or item.get("type") or "runtime_block"),
+                "source": _text(item.get("source") or "runtime_entry"),
+            }
+        )
+    return rows
+
+
+def _normalize_zones(*, block_rows: list[dict[str, Any]], layout: str) -> list[dict[str, Any]]:
+    if not block_rows:
+        return []
+    return [
+        {
+            "key": "primary",
+            "title": "Primary",
+            "layout": layout,
+            "block_keys": [_text(row.get("key")) for row in block_rows if _text(row.get("key"))],
+        }
+    ]
+
+
+def _normalize_next_action(payload: Any) -> dict[str, Any]:
+    row = _dict(payload)
+    if not row:
+        return {}
+    params = _dict(row.get("params"))
+    target = _dict(row.get("target"))
+    normalized = {
+        "key": _text(row.get("key")),
+        "label": _text(row.get("label") or row.get("title")),
+        "intent": _text(row.get("intent")),
+        "params": params,
+        "reason_code": _text(row.get("reason_code")),
+        "target": {
+            "type": _text(target.get("type") or ("intent" if _text(row.get("intent")) else "")),
+            "route": _text(target.get("route")),
+            "scene_key": _text(target.get("scene_key")),
+        },
+    }
+    if not normalized["key"] and normalized["intent"]:
+        normalized["key"] = normalized["intent"].replace(".", "_")
+    if not normalized["label"] and normalized["intent"]:
+        normalized["label"] = normalized["intent"]
+    if not any(normalized.values()):
+        return {}
+    return normalized
+
+
+def _normalize_action_rows(rows: Any) -> list[dict[str, Any]]:
+    out: list[dict[str, Any]] = []
+    for item in _list(rows):
+        if not isinstance(item, dict):
+            continue
+        key = _text(item.get("key"))
+        label = _text(item.get("label") or item.get("title") or key)
+        target = _dict(item.get("target"))
+        out.append(
+            {
+                "key": key,
+                "label": label,
+                "intent": _text(item.get("intent")),
+                "params": _dict(item.get("params")),
+                "target": {
+                    "type": _text(target.get("type")),
+                    "route": _text(target.get("route")),
+                    "scene_key": _text(target.get("scene_key")),
+                },
+            }
+        )
+    return out
+
+
+def build_release_surface_scene_contract(
+    *,
+    scene_key: str,
+    title: str,
+    product_key: str,
+    capability: str,
+    route: str,
+    status: str,
+    state_tone: str,
+    reason_code: str,
+    message: str,
+    layout: str,
+    blocks: Any = None,
+    primary_actions: Any = None,
+    secondary_actions: Any = None,
+    next_action: Any = None,
+    trace_id: str = "",
+    policy_match: bool = True,
+    released: bool = True,
+    diagnostics_ref: str = "",
+    target_name: str = "same_tab",
+) -> dict[str, Any]:
+    block_rows = _normalize_block_rows(blocks, zone_key="primary")
+    zones = _normalize_zones(block_rows=block_rows, layout=layout)
+    return {
+        "contract_version": SCENE_CONTRACT_STANDARD_VERSION,
+        "identity": {
+            "scene_key": _text(scene_key),
+            "title": _text(title),
+            "product_key": _text(product_key),
+            "capability": _text(capability),
+            "version": "v1",
+        },
+        "target": {
+            "route": _text(route),
+            "openable": bool(_text(route)),
+            "target": _text(target_name) or "same_tab",
+        },
+        "state": {
+            "status": _text(status) or "ready",
+            "state_tone": _text(state_tone) or "stable",
+            "reason_code": _text(reason_code) or "RELEASED_SURFACE_READY",
+            "message": _text(message) or _text(title),
+        },
+        "page": {
+            "layout": _text(layout) or "stack",
+            "zones": zones,
+            "blocks": block_rows,
+        },
+        "actions": {
+            "primary_actions": _normalize_action_rows(primary_actions),
+            "secondary_actions": _normalize_action_rows(secondary_actions),
+            "next_action": _normalize_next_action(next_action),
+        },
+        "governance": {
+            "contract_version": SCENE_CONTRACT_STANDARD_VERSION,
+            "trace_id": _text(trace_id),
+            "policy_match": bool(policy_match),
+            "released": bool(released),
+            "diagnostics_ref": _text(diagnostics_ref) or "released_scene_contract",
+        },
+    }
+
+
+def build_release_surface_scene_contract_from_delivery_entry(entry: dict[str, Any], *, trace_id: str = "") -> dict[str, Any]:
+    row = _dict(entry)
+    scene_key = _text(row.get("scene_key"))
+    route = _text(row.get("route"))
+    product_key = _text(row.get("product_key"))
+    capability = _text(row.get("capability_key"))
+    label = _text(row.get("label")) or _resolve_product_title(product_key)
+    route_actions = _ROUTE_ONLY_ACTIONS.get(scene_key, {})
+    requires_project_context = bool(row.get("requires_project_context", False))
+    message = "当前发布入口已冻结到产品面" if not requires_project_context else "当前发布入口需要项目上下文后继续"
+    layout = "entry_cards" if scene_key == "projects.intake" else "entry_shell"
+    contract = build_release_surface_scene_contract(
+        scene_key=scene_key,
+        title=label,
+        product_key=product_key,
+        capability=capability,
+        route=route,
+        status=_text(row.get("state") or "present"),
+        state_tone="stable",
+        reason_code="DELIVERY_ENGINE_RELEASED_SCENE",
+        message=message,
+        layout=layout,
+        blocks=row.get("blocks") or [],
+        primary_actions=route_actions.get("primary_actions") or [],
+        secondary_actions=route_actions.get("secondary_actions") or [],
+        next_action=row.get("next_action") or {},
+        trace_id=trace_id,
+        policy_match=True,
+        released=True,
+        diagnostics_ref="delivery_engine_v1.scenes",
+    )
+    identity = _dict(contract.get("identity"))
+    if row.get("description"):
+        identity["description"] = _text(row.get("description"))
+    if row.get("scope"):
+        identity["scope"] = _text(row.get("scope"))
+    if identity:
+        contract["identity"] = identity
+    return contract
+
+
+def build_release_surface_scene_contract_from_runtime_entry(
+    payload: dict[str, Any],
+    *,
+    product_key: str,
+    capability: str,
+    route: str,
+    diagnostics_ref: str,
+    trace_id: str = "",
+) -> dict[str, Any]:
+    row = _dict(payload)
+    title = _resolve_contract_title(
+        title=_text(row.get("title")),
+        scene_label=_text(row.get("scene_label")),
+        product_key=product_key,
+        scene_key=_text(row.get("scene_key")),
+    )
+    next_action = row.get("suggested_action") if isinstance(row.get("suggested_action"), dict) else {}
+    contract = build_release_surface_scene_contract(
+        scene_key=_text(row.get("scene_key")),
+        title=title,
+        product_key=product_key,
+        capability=capability,
+        route=route,
+        status="ready",
+        state_tone="stable",
+        reason_code=_text(_dict(next_action).get("reason_code")) or "RELEASED_RUNTIME_ENTRY_READY",
+        message=_text(row.get("state_fallback_text")) or title,
+        layout="workspace_stack",
+        blocks=row.get("blocks") or [],
+        primary_actions=[],
+        secondary_actions=[],
+        next_action=next_action,
+        trace_id=trace_id,
+        policy_match=True,
+        released=True,
+        diagnostics_ref=diagnostics_ref,
+    )
+    identity = _dict(contract.get("identity"))
+    if row.get("description"):
+        identity["description"] = _text(row.get("description"))
+    if row.get("scope"):
+        identity["scope"] = _text(row.get("scope"))
+    if identity:
+        contract["identity"] = identity
+    contract = apply_scene_contract_parser_semantic_bridge(contract, row)
+    return apply_scene_contract_semantic_orchestration_bridge(contract)
+
+
+def build_release_surface_scene_contract_from_page_contract(
+    page_contract: dict[str, Any],
+    *,
+    scene_key: str,
+    title: str,
+    product_key: str,
+    capability: str,
+    route: str,
+    diagnostics_ref: str,
+    trace_id: str = "",
+) -> dict[str, Any]:
+    page_row = _dict(page_contract)
+    orchestration = _dict(page_row.get("page_orchestration_v1"))
+    page_meta = _dict(orchestration.get("page"))
+    zones = _list(orchestration.get("zones"))
+    action_schema = _dict(orchestration.get("action_schema"))
+    actions = _dict(action_schema.get("actions"))
+    primary_actions = []
+    for key in ("open_my_work",):
+        action = _dict(actions.get(key))
+        if not action:
+            continue
+        primary_actions.append(
+            {
+                "key": key,
+                "label": _text(action.get("label")) or key,
+                "intent": _text(action.get("intent")),
+                "params": _dict(action.get("params")),
+            }
+        )
+    block_rows = []
+    for zone in zones:
+        if not isinstance(zone, dict):
+            continue
+        for block in _list(zone.get("blocks")):
+            if not isinstance(block, dict):
+                continue
+            block_rows.append(
+                {
+                    "key": _text(block.get("key")),
+                    "title": _text(block.get("title") or block.get("key")),
+                    "state": "ready",
+                    "block_type": _text(block.get("block_type") or "page_block"),
+                    "source": "page_contract",
+                }
+            )
+    normalized_title = _resolve_contract_title(
+        title=_text(page_meta.get("title")) or title,
+        scene_label=title,
+        product_key=product_key,
+        scene_key=scene_key,
+    )
+    contract = build_release_surface_scene_contract(
+        scene_key=scene_key,
+        title=normalized_title,
+        product_key=product_key,
+        capability=capability,
+        route=route,
+        status="ready",
+        state_tone="stable",
+        reason_code="PAGE_CONTRACT_RELEASE_READY",
+        message=normalized_title,
+        layout=_text(page_meta.get("layout_mode")) or "workspace",
+        blocks=block_rows,
+        primary_actions=primary_actions,
+        secondary_actions=[],
+        next_action={},
+        trace_id=trace_id,
+        policy_match=True,
+        released=True,
+        diagnostics_ref=diagnostics_ref,
+    )
+    surface_source = _dict(orchestration.get("meta")).get("parser_semantic_surface")
+    source_payload = surface_source if isinstance(surface_source, dict) else page_row
+    contract = apply_scene_contract_parser_semantic_bridge(contract, source_payload)
+    return apply_scene_contract_semantic_orchestration_bridge(contract)
+
+
+def attach_release_surface_scene_contract(
+    payload: dict[str, Any],
+    *,
+    product_key: str,
+    capability: str,
+    route: str,
+    diagnostics_ref: str,
+    trace_id: str = "",
+) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        return payload
+    scene_contract = build_release_surface_scene_contract_from_runtime_entry(
+        payload,
+        product_key=product_key,
+        capability=capability,
+        route=route,
+        diagnostics_ref=diagnostics_ref,
+        trace_id=trace_id,
+    )
+    payload["scene_contract_standard_v1"] = scene_contract
+    return apply_released_scene_semantic_surface_bridge(payload, scene_contract)

--- a/addons/smart_core/core/scene_merge_resolver.py
+++ b/addons/smart_core/core/scene_merge_resolver.py
@@ -17,6 +17,25 @@ def _as_list(value: Any) -> List[Any]:
     return list(value) if isinstance(value, list) else []
 
 
+def _merge_search_default_state(
+    search_surface: Dict[str, Any],
+    *,
+    default_filters: List[Any] | None = None,
+    default_group_by: List[Any] | None = None,
+    default_searchpanel: List[Any] | None = None,
+) -> None:
+    state = _as_dict(search_surface.get("default_state"))
+    out = dict(state)
+    if isinstance(default_filters, list) and default_filters:
+        out["filters"] = list(default_filters)
+    if isinstance(default_group_by, list) and default_group_by:
+        out["group_by"] = list(default_group_by)
+    if isinstance(default_searchpanel, list) and default_searchpanel:
+        out["searchpanel"] = list(default_searchpanel)
+    if out:
+        search_surface["default_state"] = out
+
+
 @dataclass
 class MergeContext:
     scene_key: str
@@ -109,11 +128,32 @@ def apply_policy(compiled_ast: Dict[str, Any], policies: Dict[str, Any], runtime
         if _as_list(search_surface.get("filters")):
             _record_conflict(_as_dict(out.get("meta")), layer="policy", field="search_surface.filters", from_layer="base")
         search_surface["filters"] = default_filters
+    default_sort = _text(search_policy.get("default_sort"))
+    if default_sort:
+        if _text(search_surface.get("default_sort")):
+            _record_conflict(_as_dict(out.get("meta")), layer="policy", field="search_surface.default_sort", from_layer="base")
+        search_surface["default_sort"] = default_sort
     default_group_by = _as_list(search_policy.get("default_group_by"))
     if default_group_by:
         if _as_list(search_surface.get("group_by")):
             _record_conflict(_as_dict(out.get("meta")), layer="policy", field="search_surface.group_by", from_layer="base")
         search_surface["group_by"] = default_group_by
+    default_searchpanel = _as_list(search_policy.get("default_searchpanel"))
+    if default_searchpanel:
+        if _as_list(search_surface.get("searchpanel")):
+            _record_conflict(_as_dict(out.get("meta")), layer="policy", field="search_surface.searchpanel", from_layer="base")
+        search_surface["searchpanel"] = default_searchpanel
+    _merge_search_default_state(
+        search_surface,
+        default_filters=default_filters,
+        default_group_by=default_group_by,
+        default_searchpanel=default_searchpanel,
+    )
+    default_mode = _text(search_policy.get("default_mode"))
+    if default_mode:
+        if _text(search_surface.get("mode")):
+            _record_conflict(_as_dict(out.get("meta")), layer="policy", field="search_surface.mode", from_layer="base")
+        search_surface["mode"] = default_mode
     out["search_surface"] = search_surface
 
     workflow_surface = _as_dict(out.get("workflow_surface"))
@@ -162,6 +202,33 @@ def apply_provider_merge(compiled_ast: Dict[str, Any], providers: List[Dict[str,
         resolved = _resolve_provider_payload(payload, ctx, out)
         if not resolved:
             continue
+        scene_payload = _as_dict(out.get("scene"))
+        resolved_scene = _as_dict(resolved.get("scene"))
+        if resolved_scene:
+            if _text(resolved_scene.get("page")) and _text(scene_payload.get("page")) != _text(resolved_scene.get("page")):
+                _record_conflict(_as_dict(out.get("meta")), layer="provider", field="scene.page", from_layer="base")
+            scene_layout = _as_dict(scene_payload.get("layout"))
+            resolved_layout = _as_dict(resolved_scene.get("layout"))
+            if resolved_layout:
+                scene_layout.update(resolved_layout)
+                scene_payload["layout"] = scene_layout
+            for field in ("page", "title", "page_type", "layout_mode", "render_mode"):
+                value = resolved_scene.get(field)
+                if value not in (None, "", {}, []):
+                    scene_payload[field] = value
+            out["scene"] = scene_payload
+
+        page_payload = _as_dict(out.get("page"))
+        resolved_page = _as_dict(resolved.get("page"))
+        if resolved_page:
+            for field in ("key", "title", "route", "page_type", "layout_mode", "render_mode", "scene_key"):
+                value = resolved_page.get(field)
+                if value not in (None, "", {}, []):
+                    page_payload[field] = value
+            resolved_zones = _as_list(resolved_page.get("zones"))
+            if resolved_zones:
+                page_payload["zones"] = resolved_zones
+            out["page"] = page_payload
         if _as_list(resolved.get("blocks")):
             out["blocks"] = _as_list(out.get("blocks")) + _as_list(resolved.get("blocks"))
         if _as_list(resolved.get("actions")):
@@ -169,7 +236,7 @@ def apply_provider_merge(compiled_ast: Dict[str, Any], providers: List[Dict[str,
 
         search_surface = _as_dict(out.get("search_surface"))
         resolved_search = _as_dict(resolved.get("search_surface"))
-        for field in ("filters", "group_by", "fields"):
+        for field in ("filters", "default_sort", "group_by", "fields", "searchpanel", "mode"):
             if field in resolved_search and field in search_surface and search_surface.get(field) != resolved_search.get(field):
                 _record_conflict(_as_dict(out.get("meta")), layer="provider", field=f"search_surface.{field}", from_layer="policy")
         search_surface.update(resolved_search)

--- a/addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py
+++ b/addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> List[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _handoff_consume_mode(family: str) -> str:
+    token = _text(family)
+    if token in {"payment_approval", "payment_entry"}:
+        return "advisory"
+    return "direct"
+
+
+def _build_runtime_handoff_surface(payload: Dict[str, Any]) -> Dict[str, Any]:
+    handoff = _as_dict(payload.get("delivery_handoff_v1"))
+    if not handoff:
+        return {}
+
+    family = _text(handoff.get("family"))
+    primary_action = _as_dict(handoff.get("primary_action"))
+    acceptance = _as_dict(handoff.get("acceptance"))
+    return {
+        "family": family,
+        "consume_mode": _handoff_consume_mode(family),
+        "runtime_entry_type": _text(handoff.get("runtime_entry_type")) or "governed_user_flow",
+        "runtime_consumer": _text(handoff.get("runtime_consumer")) or "family_runtime_consumer",
+        "runtime_mode": _text(handoff.get("runtime_mode")) or "direct",
+        "user_entry": _text(handoff.get("user_entry")),
+        "final_scene": _text(handoff.get("final_scene")),
+        "primary_action": primary_action,
+        "required_provider": _text(handoff.get("required_provider")),
+        "fallback_policy": _as_dict(handoff.get("fallback_policy")),
+        "workflow_ready": bool(acceptance.get("workflow_ready")),
+        "runtime_ready": bool(acceptance.get("runtime_ready")),
+        "advisory_only": bool(acceptance.get("advisory_only")),
+    }
+
+
+def _build_product_delivery_surface(runtime_handoff_surface: Dict[str, Any]) -> Dict[str, Any]:
+    runtime_handoff = _as_dict(runtime_handoff_surface)
+    if not runtime_handoff:
+        return {}
+
+    consume_mode = _text(runtime_handoff.get("consume_mode")) or "direct"
+    direct_delivery = consume_mode == "direct"
+    primary_action = _as_dict(runtime_handoff.get("primary_action"))
+
+    return {
+        "family": _text(runtime_handoff.get("family")),
+        "delivery_mode": "direct_delivery" if direct_delivery else "advisory_only",
+        "entry_kind": "primary_action" if primary_action else "guidance_only",
+        "entry_action": primary_action,
+        "final_scene": _text(runtime_handoff.get("final_scene")),
+        "user_entry": _text(runtime_handoff.get("user_entry")),
+        "required_provider": _text(runtime_handoff.get("required_provider")),
+        "fallback_policy": _as_dict(runtime_handoff.get("fallback_policy")),
+        "advisory": {
+            "enabled": not direct_delivery,
+            "reason": "family_remains_advisory_in_wave_1" if not direct_delivery else "",
+        },
+        "acceptance": {
+            "runtime_ready": bool(runtime_handoff.get("runtime_ready")),
+            "workflow_ready": bool(runtime_handoff.get("workflow_ready")),
+            "advisory_only": not direct_delivery,
+        },
+    }
+
+
+def _default_view_mode_label(mode: str) -> str:
+    return {
+        "tree": "列表",
+        "kanban": "看板",
+        "pivot": "透视",
+        "graph": "图表",
+        "calendar": "日历",
+        "gantt": "甘特",
+        "activity": "活动",
+        "dashboard": "仪表板",
+        "form": "表单",
+        "search": "搜索",
+    }.get(mode, mode)
+
+
+def _semantic_view_candidates(surface: Dict[str, Any]) -> List[str]:
+    parser_contract = _as_dict(surface.get("parser_contract"))
+    view_semantics = _as_dict(surface.get("view_semantics"))
+    native_view = _as_dict(surface.get("native_view"))
+    candidates: List[str] = []
+    for raw in (parser_contract.get("view_type"), view_semantics.get("source_view")):
+        token = _text(raw)
+        if token and token not in candidates:
+            candidates.append(token)
+    native_views = _as_dict(native_view.get("views"))
+    for key in native_views.keys():
+        token = _text(key)
+        if token and token not in candidates:
+            candidates.append(token)
+    return candidates
+
+
+def _selection_mode_from_semantics(surface: Dict[str, Any]) -> str:
+    parser_contract = _as_dict(surface.get("parser_contract"))
+    view_semantics = _as_dict(surface.get("view_semantics"))
+    semantic_page = _as_dict(surface.get("semantic_page"))
+    capability_flags = _as_dict(view_semantics.get("capability_flags"))
+    view_type = _text(parser_contract.get("view_type") or view_semantics.get("source_view"))
+
+    if view_type == "form":
+        return "single"
+    if view_type in {"tree", "kanban"}:
+        if capability_flags.get("is_editable") or capability_flags.get("can_create"):
+            return "multi"
+        if semantic_page.get("list_semantics") or semantic_page.get("kanban_semantics"):
+            return "multi"
+    return "single"
+
+
+def _build_switch_surface(
+    scene_key: str,
+    related_scenes: List[Any],
+    scene_catalog: Dict[str, Dict[str, Any]],
+) -> Dict[str, Any]:
+    keys: List[str] = []
+    current_key = _text(scene_key)
+    if current_key:
+        keys.append(current_key)
+    for raw in related_scenes:
+        key = _text(raw)
+        if key and key not in keys:
+            keys.append(key)
+
+    items: List[Dict[str, Any]] = []
+    for key in keys:
+        catalog_row = _as_dict(scene_catalog.get(key))
+        route = _text(catalog_row.get("route")) or f"/s/{key}"
+        label = _text(catalog_row.get("label")) or key
+        items.append(
+            {
+                "key": key,
+                "label": label,
+                "route": route,
+                "active": key == current_key,
+                "enabled": key != current_key,
+            }
+        )
+    if len(items) <= 1:
+        return {}
+    return {
+        "current_scene_key": current_key,
+        "items": items,
+    }
+
+
+def apply_scene_ready_semantic_orchestration_bridge(
+    payload: Dict[str, Any] | None,
+    *,
+    scene_key: str = "",
+    scene_catalog: Dict[str, Dict[str, Any]] | None = None,
+) -> Dict[str, Any]:
+    out = dict(payload or {})
+    parser_surface = _as_dict(out.get("parser_semantic_surface"))
+    if not parser_surface:
+        parser_surface = _as_dict(_as_dict(out.get("meta")).get("parser_semantic_surface"))
+    if parser_surface:
+        candidates = _semantic_view_candidates(parser_surface)
+        if candidates:
+            out["view_modes"] = [
+                {"key": mode, "label": _default_view_mode_label(mode), "enabled": True}
+                for mode in candidates
+            ]
+
+        action_surface = _as_dict(out.get("action_surface"))
+        action_surface["selection_mode"] = _selection_mode_from_semantics(parser_surface)
+        out["action_surface"] = action_surface
+
+    switch_surface = _build_switch_surface(
+        _text(scene_key) or _text(_as_dict(out.get("scene")).get("key")),
+        _as_list(out.pop("related_scenes", [])),
+        _as_dict(scene_catalog),
+    )
+    if switch_surface:
+        out["switch_surface"] = switch_surface
+
+    runtime_handoff_surface = _build_runtime_handoff_surface(out)
+    if runtime_handoff_surface:
+        out["runtime_handoff_surface"] = runtime_handoff_surface
+        product_delivery_surface = _build_product_delivery_surface(runtime_handoff_surface)
+        if product_delivery_surface:
+            out["product_delivery_surface"] = product_delivery_surface
+
+    return out

--- a/addons/smart_core/handlers/system_init.py
+++ b/addons/smart_core/handlers/system_init.py
@@ -11,7 +11,6 @@ from ..core.base_handler import BaseIntentHandler
 from odoo.addons.smart_core.app_config_engine.services.contract_service import ContractService
 from odoo.addons.smart_core.app_config_engine.services.dispatchers.nav_dispatcher import NavDispatcher
 from odoo.addons.smart_core.app_config_engine.utils.misc import format_versions
-from odoo.addons.smart_core.core.extension_loader import run_extension_hooks
 from odoo.addons.smart_core.core.scene_provider import (
     load_scene_contract as provider_load_scene_contract,
     load_scenes_from_db_or_fallback as provider_load_scenes_from_db_or_fallback,
@@ -21,6 +20,7 @@ from odoo.addons.smart_core.core.scene_provider import (
 from odoo.addons.smart_core.core.capability_provider import (
     build_capability_groups as provider_build_capability_groups,
     load_capabilities_for_user as provider_load_capabilities_for_user,
+    load_capabilities_for_user_with_timings as provider_load_capabilities_for_user_with_timings,
 )
 from odoo.addons.smart_core.core.intent_surface_builder import IntentSurfaceBuilder
 from odoo.addons.smart_core.core.hash_utils import stable_fingerprint
@@ -38,17 +38,29 @@ from odoo.addons.smart_core.core.scene_runtime_orchestrator import SceneRuntimeO
 from odoo.addons.smart_core.core.system_init_runtime_context import SystemInitRuntimeContext
 from odoo.addons.smart_core.core.system_init_surface_context import SystemInitSurfaceContext
 from odoo.addons.smart_core.core.system_init_surface_builder import SystemInitSurfaceBuilder
+from odoo.addons.smart_core.core.system_init_extension_fact_merger import (
+    apply_extension_fact_contributions,
+    merge_extension_facts,
+)
+from odoo.addons.smart_core.core.system_init_scene_runtime_surface_context import SystemInitSceneRuntimeSurfaceContext
+from odoo.addons.smart_core.core.system_init_scene_runtime_surface_builder import SystemInitSceneRuntimeSurfaceBuilder
+from odoo.addons.smart_core.core.system_init_dictionary_data_helper import apply_dictionary_startup_data
+from odoo.addons.smart_core.core.intent_execution_result import IntentExecutionResult
 from odoo.addons.smart_core.core.workspace_home_contract_builder import build_workspace_home_contract
-from odoo.addons.smart_core.core.page_contracts_builder import build_page_contracts
-from odoo.addons.smart_core.core.scene_nav_contract_builder import build_scene_nav_contract
+from odoo.addons.smart_core.core.runtime_page_contract_builder import mirror_workspace_home_role_context
 from odoo.addons.smart_core.core.scene_governance_payload_builder import build_scene_governance_payload_v1
 from odoo.addons.smart_core.core.ui_base_contract_asset_event_queue import get_queue_metrics
-from odoo.addons.smart_core.core.scene_ready_contract_builder import build_scene_ready_contract_v1
-from odoo.addons.smart_core.core.ui_base_contract_asset_repository import bind_scene_assets
+from odoo.addons.smart_core.core.release_navigation_contract_builder import build_release_navigation_contract
 from odoo.addons.smart_core.core.scene_delivery_policy import (
     filter_delivery_scenes,
     resolve_delivery_policy_runtime,
 )
+from odoo.addons.smart_core.core.scene_nav_contract_builder import build_scene_nav_contract
+from odoo.addons.smart_core.core.scene_ready_contract_builder import build_scene_ready_contract_v1
+from odoo.addons.smart_core.core.ui_base_contract_asset_repository import bind_scene_assets
+from odoo.addons.smart_core.delivery.delivery_engine import DeliveryEngine
+from odoo.addons.smart_core.delivery.edition_release_snapshot_service import EditionReleaseSnapshotService
+from odoo.addons.smart_core.delivery.release_audit_trail_service import ReleaseAuditTrailService
 from odoo.addons.smart_core.adapters.odoo_nav_adapter import OdooNavAdapter
 from odoo.addons.smart_core.adapters.nav_tree_cleaner import NavTreeCleaner
 from odoo.addons.smart_core.governance.scene_drift_engine import append_resolve_error as drift_append_resolve_error
@@ -81,6 +93,14 @@ _INDUSTRY_EXTENSION_MODULES = (
 
 def _load_capabilities_for_user(env, user) -> List[dict]:
     return provider_load_capabilities_for_user(env, user)
+
+
+def _load_capabilities_for_user_with_timings(env, user) -> tuple[List[dict], dict[str, int]]:
+    return provider_load_capabilities_for_user_with_timings(env, user)
+
+
+def _bind_scene_assets(*args, **kwargs):
+    return bind_scene_assets(*args, **kwargs)
 
 
 def _is_any_module_installed(env, module_names: List[str]) -> bool:
@@ -161,35 +181,21 @@ def _build_platform_minimum_nav_contract() -> dict:
     }
 
 
-def _merge_extension_facts(data: dict) -> None:
-    ext_facts = data.get("ext_facts")
-    if not isinstance(ext_facts, dict):
-        return
-    # Transitional compatibility: keep top-level reads stable while enforcing
-    # extension hooks to write facts into a namespaced container only.
-    for ext_module, module_facts in ext_facts.items():
-        if not isinstance(module_facts, dict):
-            continue
-        for key in ("entitlements", "usage"):
-            if key in module_facts and key not in data:
-                data[key] = module_facts.get(key)
-        workspace_collections = module_facts.get("workspace_collections")
-        if isinstance(workspace_collections, dict):
-            for key in ("task_items", "payment_requests", "risk_actions", "project_actions"):
-                rows = workspace_collections.get(key)
-                if key not in data and isinstance(rows, list):
-                    data[key] = rows
-        provider_payload = module_facts.get("role_surface_override_provider")
-        if isinstance(provider_payload, dict):
-            provider_key = str(provider_payload.get("key") or "").strip() or str(ext_module or "").strip()
-            if provider_key:
-                providers = data.get("role_surface_override_providers")
-                if not isinstance(providers, dict):
-                    providers = {}
-                merged = dict(provider_payload)
-                merged.pop("key", None)
-                providers[provider_key] = merged
-                data["role_surface_override_providers"] = providers
+def _normalize_access_suggested_action(data: dict) -> dict:
+    if not isinstance(data, dict):
+        return data
+    access = data.get("access") if isinstance(data.get("access"), dict) else {}
+    if not access:
+        return data
+    reason_code = str(access.get("reason_code") or "").strip()
+    suggested_action = str(access.get("suggested_action") or "").strip()
+    if not suggested_action and reason_code:
+        suggested_action = str(failure_meta_for_reason(reason_code).get("suggested_action") or "").strip()
+    if suggested_action:
+        next_access = dict(access)
+        next_access["suggested_action"] = suggested_action
+        data["access"] = next_access
+    return data
 
 
 def _normalize_scene_validation_recovery_strategy(payload) -> dict:
@@ -325,57 +331,20 @@ def _parse_with_tokens(value) -> set[str]:
     return tokens
 
 
-def _resolve_role_source_code(data: dict) -> str:
-    role_surface = data.get("role_surface") if isinstance(data.get("role_surface"), dict) else {}
-    role_code = str(role_surface.get("role_code") or "").strip().lower()
-    return role_code or "owner"
-
-
-def _ensure_role_context_mirror(data: dict) -> None:
-    if not isinstance(data, dict):
-        return
-    role_code = _resolve_role_source_code(data)
-
-    workspace_home = data.get("workspace_home") if isinstance(data.get("workspace_home"), dict) else None
-    if isinstance(workspace_home, dict):
-        record = workspace_home.get("record") if isinstance(workspace_home.get("record"), dict) else {}
-        hero = record.get("hero") if isinstance(record.get("hero"), dict) else {}
-        hero["role_code"] = role_code
-        record["hero"] = hero
-        workspace_home["record"] = record
-
-        page_orchestration_v1 = (
-            workspace_home.get("page_orchestration_v1")
-            if isinstance(workspace_home.get("page_orchestration_v1"), dict)
-            else {}
-        )
-        page = page_orchestration_v1.get("page") if isinstance(page_orchestration_v1.get("page"), dict) else {}
-        context = page.get("context") if isinstance(page.get("context"), dict) else {}
-        context["role_code"] = role_code
-        page["context"] = context
-        page_orchestration_v1["page"] = page
-        workspace_home["page_orchestration_v1"] = page_orchestration_v1
-
-    page_contracts = data.get("page_contracts") if isinstance(data.get("page_contracts"), dict) else {}
-    pages = page_contracts.get("pages") if isinstance(page_contracts.get("pages"), dict) else {}
-    home_page = pages.get("home") if isinstance(pages.get("home"), dict) else {}
-    home_orchestration = (
-        home_page.get("page_orchestration_v1")
-        if isinstance(home_page.get("page_orchestration_v1"), dict)
-        else {}
-    )
-    home_page_meta = home_orchestration.get("meta") if isinstance(home_orchestration.get("meta"), dict) else {}
-    page = home_orchestration.get("page") if isinstance(home_orchestration.get("page"), dict) else {}
-    context = page.get("context") if isinstance(page.get("context"), dict) else {}
-    context["role_code"] = role_code
-    page["context"] = context
-    home_orchestration["page"] = page
-    home_page_meta["role_source_code"] = role_code
-    home_orchestration["meta"] = home_page_meta
-    home_page["page_orchestration_v1"] = home_orchestration
-    pages["home"] = home_page
-    page_contracts["pages"] = pages
-    data["page_contracts"] = page_contracts
+def _filter_startup_scenes_for_preload(scenes, allowed_scene_keys: list[str] | None) -> list[dict]:
+    if not isinstance(scenes, list):
+        return []
+    allowed = {str(item or "").strip() for item in (allowed_scene_keys or []) if str(item or "").strip()}
+    if not allowed:
+        return [row for row in scenes if isinstance(row, dict)]
+    filtered = []
+    for row in scenes:
+        if not isinstance(row, dict):
+            continue
+        scene_key = str(row.get("code") or row.get("key") or "").strip()
+        if scene_key in allowed:
+            filtered.append(row)
+    return filtered
 
 
 def _build_minimal_intent_surface(intents: list[str], intents_meta: dict) -> list[str]:
@@ -398,8 +367,12 @@ def _resolve_scene_channel(env, user, params: dict | None) -> tuple[str, str, st
 def _load_scene_contract(env, scene_channel: str, use_pinned: bool) -> tuple[dict | None, str]:
     return provider_load_scene_contract(env, scene_channel, use_pinned, logger=_logger)
 
-def _load_scenes_from_db_or_fallback(env, drift):
-    return provider_load_scenes_from_db_or_fallback(env, drift=drift, logger=_logger)
+def _load_scenes_from_db_or_fallback(env, drift=None, logger=None):
+    return provider_load_scenes_from_db_or_fallback(
+        env,
+        drift=drift,
+        logger=logger or _logger,
+    )
 
 def _merge_missing_scenes_from_registry(env, scenes, warnings):
     return provider_merge_missing_scenes_from_registry(env, scenes, warnings)
@@ -421,9 +394,23 @@ class SystemInitHandler(BaseIntentHandler):
     def handle(self, payload=None, ctx=None):
         payload = payload or {}
         ts0 = time.time()
+        perf0 = time.perf_counter()
         params = payload.get("params") if isinstance(payload, dict) else None
         if not isinstance(params, dict):
             params = payload if isinstance(payload, dict) else {}
+        build_mode = SystemInitPayloadBuilder.resolve_build_mode(params)
+        startup_timings_ms: dict[str, int] = {}
+        startup_subtimings_ms: dict[str, dict[str, int]] = {}
+
+        def _mark(stage: str, started_at: float) -> float:
+            startup_timings_ms[stage] = int((time.perf_counter() - started_at) * 1000)
+            return time.perf_counter()
+
+        def _mark_substage(stage: str, substage: str, started_at: float) -> float:
+            stage_timings = startup_subtimings_ms.setdefault(stage, {})
+            stage_timings[substage] = int((time.perf_counter() - started_at) * 1000)
+            return time.perf_counter()
+
         contract_mode = resolve_contract_mode(params)
         trace_id = ""
         try:
@@ -434,6 +421,7 @@ class SystemInitHandler(BaseIntentHandler):
         env = self.env
         su_env = self.su_env or api.Environment(env.cr, SUPERUSER_ID, dict(env.context or {}))
 
+        stage_ts = time.perf_counter()
         scene_channel, channel_selector, channel_source_ref = _resolve_scene_channel(env, env.user, params)
         diagnostics_collector = RequestDiagnosticsCollector()
         scene_channel_policy = SceneChannelPolicy()
@@ -447,6 +435,7 @@ class SystemInitHandler(BaseIntentHandler):
                 diagnostic_info,
                 self_params=getattr(self, "params", {}),
             )
+        stage_ts = _mark("resolve_scene_channel", stage_ts)
 
         # 如果 finalize_contract 内部不读 ORM，可用 env；若会读，推荐 su_env
         cs = ContractService(su_env)
@@ -481,6 +470,7 @@ class SystemInitHandler(BaseIntentHandler):
                 "fingerprint": "fallback-no-app-menu-config",
                 "nav_source": "fallback_minimal",
             }
+        stage_ts = _mark("build_nav", stage_ts)
 
         nav_tree_raw = nav_data.get("nav") or []
         nav_tree = NavTreeCleaner().clean(nav_tree_raw)
@@ -504,15 +494,39 @@ class SystemInitHandler(BaseIntentHandler):
         # -------- 2.5) 可用意图（最小启动集合 + 独立目录引用）--------
         intents_all, intents_meta_all = IntentSurfaceBuilder().collect(env, user)
         intents = _build_minimal_intent_surface(intents_all, intents_meta_all)
+        stage_ts = _mark("collect_intents", stage_ts)
 
         # -------- 3/4) 首页契约 + 可选预取（仅 etag，不回传整包契约）--------
-        preload_builder = SystemInitPreloadBuilder()
-        home_contract, preload_items, etags, parts_version = preload_builder.build(
-            env=env,
-            su_env=su_env,
-            params=params,
-            default_home_action=default_home_action,
-            contract_service=cs,
+        home_contract = None
+        preload_items = []
+        etags = {}
+        parts_version = {}
+        if build_mode in {SystemInitPayloadBuilder.BUILD_MODE_PRELOAD, SystemInitPayloadBuilder.BUILD_MODE_DEBUG}:
+            preload_builder = SystemInitPreloadBuilder()
+            home_contract, preload_items, etags, parts_version = preload_builder.build(
+                env=env,
+                su_env=su_env,
+                params=params,
+                default_home_action=default_home_action,
+                contract_service=cs,
+            )
+        stage_ts = _mark("build_preload_refs", stage_ts)
+
+        prepare_runtime_context_ts = time.perf_counter()
+
+        capabilities_raw, capability_load_timings_ms = _load_capabilities_for_user_with_timings(env, user)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "load_capabilities_for_user",
+            prepare_runtime_context_ts,
+        )
+        if capability_load_timings_ms:
+            startup_subtimings_ms["capability_load"] = dict(capability_load_timings_ms)
+        capabilities = normalize_capabilities(capabilities_raw)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "normalize_capabilities",
+            prepare_runtime_context_ts,
         )
 
         # -------- 5) 汇总返回（统一蛇形命名 + 导航指纹 + 动态意图）--------
@@ -528,12 +542,17 @@ class SystemInitHandler(BaseIntentHandler):
             default_route=nav_data.get("defaultRoute") or {"menu_id": None},
             intents=intents,
             feature_flags=nav_data.get("feature_flags") or {"ai_enabled": True},
-            capabilities=normalize_capabilities(_load_capabilities_for_user(env, user)),
+            capabilities=capabilities,
             scene_channel=scene_channel,
             channel_selector=channel_selector,
             channel_source_ref=channel_source_ref,
             contract_mode=contract_mode,
             contract_version=CONTRACT_VERSION,
+        )
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "build_base_call",
+            prepare_runtime_context_ts,
         )
         # Keep explicit contract_mode mapping in handler for governance coverage guard.
         data.update({"contract_mode": contract_mode})
@@ -545,20 +564,72 @@ class SystemInitHandler(BaseIntentHandler):
                 channel_source_ref=channel_source_ref,
             ),
         }
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "initialize_scene_diagnostics",
+            prepare_runtime_context_ts,
+        )
         components = SystemInitComponentsFactory.create()
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "create_components",
+            prepare_runtime_context_ts,
+        )
         scene_normalizer = components["scene_normalizer"]
         scene_drift_engine = components["scene_drift_engine"]
         auto_degrade_engine = components["auto_degrade_engine"]
         capability_surface_engine = components["capability_surface_engine"]
         contract_assembler = components["contract_assembler"]
         scene_normalizer.append_act_url_deprecations(nav_tree, scene_diagnostics["normalize_warnings"])
-        SystemInitPayloadBuilder.attach_preload(data, home_contract, etags, preload_items)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "append_act_url_deprecations",
+            prepare_runtime_context_ts,
+        )
+        if build_mode in {SystemInitPayloadBuilder.BUILD_MODE_PRELOAD, SystemInitPayloadBuilder.BUILD_MODE_DEBUG}:
+            SystemInitPayloadBuilder.attach_preload(data, home_contract, etags, preload_items)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "attach_preload_when_enabled",
+            prepare_runtime_context_ts,
+        )
 
-        # 扩展模块可附加场景/能力等（不影响主流程）
-        run_extension_hooks(env, "smart_core_extend_system_init", data, env, user)
-        _merge_extension_facts(data)
+        # 扩展模块 facts contribution（平台 merge owner）
+        apply_extension_fact_contributions(data, env, user, context=params)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "apply_extension_fact_contributions",
+            prepare_runtime_context_ts,
+        )
+        merge_extension_facts(data, include_workspace_collections=False)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "merge_extension_facts",
+            prepare_runtime_context_ts,
+        )
         data["scene_validation_recovery_strategy"] = _load_scene_validation_recovery_strategy(env, params, data)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "load_scene_validation_recovery_strategy",
+            prepare_runtime_context_ts,
+        )
         data["scene_action_surface_strategy"] = _load_scene_action_surface_strategy(env, params, data)
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "load_scene_action_surface_strategy",
+            prepare_runtime_context_ts,
+        )
+        data["scene_action_surface_strategy"] = _normalize_scene_action_surface_strategy(
+            dict(
+                action_surface_strategy=data.get("scene_action_surface_strategy")
+            ).get("action_surface_strategy")
+        )
+        prepare_runtime_context_ts = _mark_substage(
+            "prepare_runtime_context",
+            "normalize_scene_action_surface_strategy",
+            prepare_runtime_context_ts,
+        )
+        stage_ts = _mark("prepare_runtime_context", stage_ts)
 
         runtime_ctx = SystemInitRuntimeContext(
             env=env,
@@ -587,6 +658,7 @@ class SystemInitHandler(BaseIntentHandler):
         scene_channel = runtime_ctx.scene_channel
         rollback_active = runtime_ctx.rollback_active
         scene_diagnostics = runtime_ctx.scene_diagnostics
+        stage_ts = _mark("execute_scene_runtime", stage_ts)
         surface_ctx = SystemInitSurfaceContext(
             data=data,
             contract_mode=contract_mode,
@@ -600,14 +672,15 @@ class SystemInitHandler(BaseIntentHandler):
             apply_contract_governance_fn=apply_contract_governance,
         )
         data, scene_diagnostics = SystemInitSurfaceBuilder.apply(surface_ctx=surface_ctx)
+        stage_ts = _mark("apply_surface", stage_ts)
         with_tokens = _parse_with_tokens(params.get("with"))
         include_workspace_home = bool(params.get("with_preload", False)) or "workspace_home" in with_tokens
         if include_workspace_home:
             data["workspace_home"] = build_workspace_home_contract(data)
         else:
             data.pop("workspace_home", None)
-        data["page_contracts"] = build_page_contracts(data)
-        _ensure_role_context_mirror(data)
+        mirror_workspace_home_role_context(data)
+        stage_ts = _mark("build_workspace_home", stage_ts)
         role_surface = data.get("role_surface") if isinstance(data, dict) else {}
         role_pruned = False
         if isinstance(role_surface, dict) and isinstance(data.get("nav"), list):
@@ -618,86 +691,113 @@ class SystemInitHandler(BaseIntentHandler):
             if isinstance(data.get("nav_meta"), dict):
                 data["nav_meta"]["role_surface_pruned"] = role_pruned
                 data["nav_meta"]["role_surface_code"] = role_surface.get("role_code")
-
-        delivery_runtime = resolve_delivery_policy_runtime(env, params)
-        delivery_result = filter_delivery_scenes(
-            data.get("scenes") if isinstance(data, dict) else [],
-            surface=delivery_runtime.get("surface") or "default",
-            role_surface=role_surface if isinstance(role_surface, dict) else {},
-            contract_mode=contract_mode,
-            runtime_env=delivery_runtime.get("runtime_env") or "dev",
-            enabled=bool(delivery_runtime.get("enabled")),
-            env=env,
-        )
-        if isinstance(data.get("nav_meta"), dict):
-            data["nav_meta"]["delivery_policy"] = delivery_result.get("meta") or {}
-
-        # Scene-first nav contract (v1): sidebar nav source switches from native menu facts
-        # to scene orchestration contract. Keep legacy nav for rollback/diagnostics.
-        nav_contract_input = dict(data)
-        nav_contract_input["scenes"] = delivery_result.get("delivery_scenes") or []
-        nav_contract_input["delivery_policy_applied"] = bool(delivery_result.get("meta", {}).get("enabled"))
-        role_code = ""
-        if isinstance(role_surface, dict):
-            role_code = str(role_surface.get("role_code") or "").strip()
-        bind_result = bind_scene_assets(
-            env,
-            scenes=nav_contract_input.get("scenes") if isinstance(nav_contract_input.get("scenes"), list) else [],
-            role_code=role_code or None,
-            company_id=env.company.id if env.company else None,
-        )
-        nav_contract_input["scenes"] = bind_result.get("scenes") or nav_contract_input.get("scenes") or []
-        if isinstance(data.get("nav_meta"), dict):
-            data["nav_meta"]["ui_base_contract_asset_scene_count"] = int(bind_result.get("asset_scene_count") or 0)
-            data["nav_meta"]["ui_base_contract_bound_scene_count"] = int(bind_result.get("bound_scene_count") or 0)
-            data["nav_meta"]["ui_base_contract_missing_scene_count"] = int(bind_result.get("missing_scene_count") or 0)
-        data["scene_ready_contract_v1"] = build_scene_ready_contract_v1(
-            scenes=nav_contract_input.get("scenes") if isinstance(nav_contract_input.get("scenes"), list) else [],
-            role_surface=role_surface if isinstance(role_surface, dict) else {},
-            scene_version=data.get("scene_version"),
-            schema_version=data.get("schema_version"),
-            scene_channel=scene_channel,
-            action_surface_strategy=data.get("scene_action_surface_strategy") if isinstance(data.get("scene_action_surface_strategy"), dict) else {},
-            runtime_context={
-                "role_code": role_code,
-                "company_id": env.company.id if env.company else None,
-            },
-        )
-        scene_nav_contract = build_scene_nav_contract(nav_contract_input)
-        if isinstance(scene_nav_contract, dict) and isinstance(scene_nav_contract.get("nav"), list):
-            data["nav_legacy"] = data.get("nav") or []
-            data["nav_contract"] = scene_nav_contract
-            data["nav"] = scene_nav_contract.get("nav") or []
-            data["default_route"] = scene_nav_contract.get("default_route") or data.get("default_route") or {"menu_id": None}
-            if isinstance(data.get("nav_meta"), dict):
-                data["nav_meta"]["nav_source"] = scene_nav_contract.get("source") or "scene_contract_v1"
-                data["nav_meta"]["scene_ready_contract_v1"] = True
-                contract_meta = scene_nav_contract.get("meta")
-                if isinstance(contract_meta, dict):
-                    data["nav_meta"]["scene_nav_meta"] = contract_meta
+        stage_ts = _mark("prune_nav_for_role", stage_ts)
 
         platform_minimum_surface_mode = _is_platform_minimum_surface_mode(env)
-        if platform_minimum_surface_mode:
-            minimum_nav_contract = _build_platform_minimum_nav_contract()
-            data["nav_legacy"] = data.get("nav") or []
-            data["nav_contract"] = minimum_nav_contract
-            data["nav"] = minimum_nav_contract.get("nav") or []
-            minimum_default_route = {
-                "menu_id": None,
-                "scene_key": "workspace.home",
-                "route": "/",
-                "reason": "platform_minimum_surface",
-            }
-            data["default_route"] = minimum_default_route
-            if isinstance(minimum_nav_contract, dict):
-                minimum_nav_contract["default_route"] = dict(minimum_default_route)
-                nav_contract_meta = minimum_nav_contract.get("meta")
-                if isinstance(nav_contract_meta, dict):
-                    nav_contract_meta["platform_minimum_surface"] = True
-            if isinstance(data.get("nav_meta"), dict):
-                data["nav_meta"]["platform_minimum_surface"] = True
-                data["nav_meta"]["platform_minimum_reason"] = "industry_modules_absent"
-                data["nav_meta"]["nav_source"] = "platform_minimum_surface"
+        scene_runtime_surface_ctx = SystemInitSceneRuntimeSurfaceContext(
+            env=env,
+            params=params,
+            data=data,
+            role_surface=role_surface if isinstance(role_surface, dict) else {},
+            contract_mode=contract_mode,
+            scene_channel=scene_channel,
+            nav_tree=nav_tree,
+            platform_minimum_surface_mode=platform_minimum_surface_mode,
+            build_platform_minimum_nav_contract_fn=_build_platform_minimum_nav_contract,
+            resolve_delivery_policy_runtime_fn=resolve_delivery_policy_runtime,
+            filter_delivery_scenes_fn=filter_delivery_scenes,
+            startup_scene_subset_resolver_fn=SystemInitPayloadBuilder.resolve_startup_scene_subset,
+            filter_startup_scenes_for_preload_fn=_filter_startup_scenes_for_preload,
+            bind_scene_assets_fn=_bind_scene_assets,
+            build_scene_ready_contract_fn=build_scene_ready_contract_v1,
+            build_scene_nav_contract_fn=build_scene_nav_contract,
+        )
+        scene_runtime_surface_result = SystemInitSceneRuntimeSurfaceBuilder.apply(surface_ctx=scene_runtime_surface_ctx)
+        data = scene_runtime_surface_result["data"]
+        delivery_result = scene_runtime_surface_result["delivery_result"]
+        scene_nav_contract = scene_runtime_surface_result["scene_nav_contract"]
+        bind_result = scene_runtime_surface_result["bind_result"]
+        data["scene_ready_contract_v1"] = (
+            data.get("scene_ready_contract_v1")
+            if isinstance(data.get("scene_ready_contract_v1"), dict)
+            else {}
+        )
+        nav_meta = data.get("nav_meta") if isinstance(data.get("nav_meta"), dict) else {}
+        if isinstance(bind_result, dict):
+            nav_meta["ui_base_contract_asset_scene_count"] = int(bind_result.get("asset_scene_count") or 0)
+            nav_meta["ui_base_contract_bound_scene_count"] = int(bind_result.get("bound_scene_count") or 0)
+            nav_meta["ui_base_contract_missing_scene_count"] = int(bind_result.get("missing_scene_count") or 0)
+        else:
+            nav_meta.setdefault("ui_base_contract_asset_scene_count", 0)
+            nav_meta.setdefault("ui_base_contract_bound_scene_count", 0)
+            nav_meta.setdefault("ui_base_contract_missing_scene_count", 0)
+        data["nav_meta"] = nav_meta
+        stage_ts = _mark("build_scene_runtime_surface", stage_ts)
+        legacy_release_navigation = build_release_navigation_contract(data if isinstance(data, dict) else {})
+        delivery_engine = DeliveryEngine(env)
+        delivery_edition_key = str(((params or {}).get("edition_key") or "standard")).strip() or "standard"
+        delivery_payload = delivery_engine.build(
+            data=data if isinstance(data, dict) else {},
+            product_key=f"construction.{delivery_edition_key}",
+            edition_key=delivery_edition_key,
+            base_product_key="construction",
+            native_nav=nav_tree,
+        )
+        release_snapshot_service = EditionReleaseSnapshotService(env)
+        release_audit_service = ReleaseAuditTrailService(env)
+        data["delivery_engine_v1"] = delivery_payload
+        edition_diagnostics = (
+            delivery_payload.get("product_policy", {}).get("edition_diagnostics")
+            if isinstance(delivery_payload.get("product_policy"), dict)
+            else {}
+        )
+        effective_base_product_key = str(delivery_payload.get("base_product_key") or "construction").strip() or "construction"
+        effective_edition_key = str(delivery_payload.get("edition_key") or "standard").strip() or "standard"
+        effective_product_key = str(delivery_payload.get("product_key") or f"{effective_base_product_key}.{effective_edition_key}").strip()
+        requested_product_key = f"construction.{delivery_edition_key}"
+        released_snapshot_lineage = release_snapshot_service.resolve_active_snapshot_lineage(product_key=effective_product_key)
+        release_audit_trail_summary = release_audit_service.build_runtime_summary(product_key=effective_product_key)
+        runtime_diagnostics = dict(edition_diagnostics) if isinstance(edition_diagnostics, dict) else {}
+        if released_snapshot_lineage:
+            runtime_diagnostics["released_snapshot_lineage"] = released_snapshot_lineage
+            meta = delivery_payload.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+                delivery_payload["meta"] = meta
+            meta["released_snapshot_lineage"] = released_snapshot_lineage
+        if release_audit_trail_summary:
+            runtime_diagnostics["release_audit_trail_summary"] = release_audit_trail_summary
+            meta = delivery_payload.get("meta")
+            if not isinstance(meta, dict):
+                meta = {}
+                delivery_payload["meta"] = meta
+            meta["release_audit_trail_summary"] = release_audit_trail_summary
+        data["edition_runtime_v1"] = {
+            "contract_version": "v1",
+            "requested": {
+                "product_key": requested_product_key,
+                "base_product_key": "construction",
+                "edition_key": delivery_edition_key,
+            },
+            "effective": {
+                "product_key": effective_product_key,
+                "base_product_key": effective_base_product_key,
+                "edition_key": effective_edition_key,
+            },
+            "diagnostics": runtime_diagnostics,
+        }
+        data["release_navigation_v1"] = {
+            "contract_version": str(delivery_payload.get("contract_version") or "v1"),
+            "source": "delivery_engine_v1",
+            "role_code": str(delivery_payload.get("role_code") or ""),
+            "nav": delivery_payload.get("nav") if isinstance(delivery_payload.get("nav"), list) else [],
+            "meta": {
+                "product_key": str(delivery_payload.get("product_key") or ""),
+                "edition_key": str(delivery_payload.get("edition_key") or ""),
+                "delivery_engine_meta": delivery_payload.get("meta") if isinstance(delivery_payload.get("meta"), dict) else {},
+                "legacy_builder_contract_version": str(legacy_release_navigation.get("contract_version") or ""),
+            },
+        }
 
         default_route_payload = data.get("default_route") if isinstance(data.get("default_route"), dict) else {}
         landing_scene_key = str(default_route_payload.get("scene_key") or "").strip()
@@ -716,22 +816,79 @@ class SystemInitHandler(BaseIntentHandler):
             "count": len(intents_all or []),
         }
 
-        data["scene_governance_v1"] = build_scene_governance_payload_v1(
-            data=data,
-            scene_diagnostics=scene_diagnostics,
-            delivery_meta=delivery_result.get("meta") if isinstance(delivery_result, dict) else {},
-            nav_contract_meta=scene_nav_contract.get("meta") if isinstance(scene_nav_contract, dict) else {},
-            asset_queue_metrics=get_queue_metrics(env),
-        )
+        if build_mode == SystemInitPayloadBuilder.BUILD_MODE_DEBUG:
+            data["scene_governance_v1"] = build_scene_governance_payload_v1(
+                data=data,
+                scene_diagnostics=scene_diagnostics,
+                delivery_meta=delivery_result.get("meta") if isinstance(delivery_result, dict) else {},
+                nav_contract_meta=scene_nav_contract.get("meta") if isinstance(scene_nav_contract, dict) else {},
+                asset_queue_metrics=get_queue_metrics(env),
+            )
+        else:
+            data.pop("scene_governance_v1", None)
         data = _strip_ui_base_contract_for_frontend(data)
-        SystemInitPayloadBuilder.attach_layered_contract(data)
-        if contract_mode == "hud":
-            data["scene_diagnostics"] = scene_diagnostics
+        extension_snapshot: dict = {}
+        apply_extension_fact_contributions(extension_snapshot, env, user, context=params)
+        snapshot_ext = (
+            extension_snapshot.get("ext_facts")
+            if isinstance(extension_snapshot.get("ext_facts"), dict)
+            else {}
+        )
+        role_entries = []
+        home_blocks = []
+        for module_facts in snapshot_ext.values():
+            if not isinstance(module_facts, dict):
+                continue
+            candidate = module_facts.get("role_entries")
+            if isinstance(candidate, list) and candidate:
+                role_entries = candidate
+            block_candidate = module_facts.get("home_blocks")
+            if isinstance(block_candidate, list) and block_candidate:
+                home_blocks = block_candidate
+        if isinstance(role_entries, list) and role_entries:
+            data["role_entries"] = role_entries
+        if isinstance(home_blocks, list) and home_blocks:
+            data["home_blocks"] = home_blocks
+        startup_inspect = {}
+        if build_mode == SystemInitPayloadBuilder.BUILD_MODE_DEBUG:
+            startup_inspect = {
+                "nav_meta": data.get("nav_meta") if isinstance(data.get("nav_meta"), dict) else {},
+                "delivery_policy": delivery_result.get("meta") if isinstance(delivery_result, dict) else {},
+                "scene_nav_meta": scene_nav_contract.get("meta") if isinstance(scene_nav_contract, dict) else {},
+                "scene_governance_v1": data.get("scene_governance_v1") if isinstance(data.get("scene_governance_v1"), dict) else {},
+                "asset_binding": bind_result if isinstance(bind_result, dict) else {},
+                "scene_diagnostics": scene_diagnostics if isinstance(scene_diagnostics, dict) else {},
+            }
+        data = SystemInitPayloadBuilder.build_startup_surface(
+            data,
+            params=params,
+            build_mode=build_mode,
+            inspect_payload=startup_inspect,
+        )
+        try:
+            data = apply_dictionary_startup_data(env, data)
+        except Exception:
+            pass
+        data = _normalize_access_suggested_action(data)
+        data["contract_mode"] = contract_mode
+        if contract_mode == "user":
+            data.pop("scene_diagnostics", None)
+            data.pop("diagnostic", None)
+            data.pop("scene_channel_selector", None)
+            data.pop("scene_channel_source_ref", None)
+        stage_ts = _mark("finalize_startup_surface", stage_ts)
 
         # 分部 etag：加入导航
         etags["nav"] = nav_fp
 
         elapsed_ms = int((time.time() - ts0) * 1000)
+        startup_profile = {
+            "build_mode": build_mode,
+            "timings_ms": startup_timings_ms,
+            "subtimings_ms": startup_subtimings_ms,
+            "total_ms": int((time.perf_counter() - perf0) * 1000),
+            "response_key_count": len(data.keys()) if isinstance(data, dict) else 0,
+        }
         scene_trace_meta, meta_with_etag = SystemInitResponseMetaBuilder.build(
             contract_assembler=contract_assembler,
             data=data,
@@ -745,16 +902,27 @@ class SystemInitHandler(BaseIntentHandler):
             api_version=API_VERSION,
             contract_mode=contract_mode,
             nav_fp=nav_fp,
+            startup_profile=startup_profile,
         )
         if contract_mode == "hud":
-            SystemInitPayloadBuilder.attach_hud(
-                data,
-                trace_id=trace_id,
-                elapsed_ms=elapsed_ms,
-                contract_version=CONTRACT_VERSION,
-                scene_trace_meta=scene_trace_meta,
-            )
-        if diag_enabled and diagnostic_info is not None and contract_mode == "hud":
-            SystemInitPayloadBuilder.attach_diagnostic(data, diagnostic_info)
+            hud_trace = data.get("hud") if isinstance(data.get("hud"), dict) else {}
+            for trace_key in ("scene_source", "scene_contract_ref", "channel_selector", "channel_source_ref"):
+                trace_value = scene_trace_meta.get(trace_key)
+                if str(trace_value or "").strip():
+                    hud_trace[trace_key] = trace_value
+            governance_payload = scene_trace_meta.get("governance")
+            if isinstance(governance_payload, dict):
+                hud_trace["governance"] = governance_payload
+            data["hud"] = hud_trace
+            if not isinstance(data.get("scene_diagnostics"), dict) and isinstance(scene_diagnostics, dict):
+                data["scene_diagnostics"] = scene_diagnostics
+        _ = scene_trace_meta
+        _ = diag_enabled
+        _ = diagnostic_info
 
-        return {"status": "success", "data": data, "meta": meta_with_etag, "ok": True}
+        return IntentExecutionResult(
+            ok=True,
+            status="success",
+            data=data,
+            meta=meta_with_etag,
+        )

--- a/addons/smart_core/handlers/ui_contract.py
+++ b/addons/smart_core/handlers/ui_contract.py
@@ -3,9 +3,11 @@
 import json, re, hashlib, time, logging
 from collections.abc import Mapping
 from typing import Any, Dict, Optional
-from odoo import api
+from odoo import api, SUPERUSER_ID
 from odoo.tools.safe_eval import safe_eval
 from ..core.base_handler import BaseIntentHandler
+from ..core.intent_execution_result import IntentExecutionResult
+from ..core.native_view_contract_projection import inject_primary_view_projection
 
 # ✅ 直接用你的统一服务与分发器
 from odoo.addons.smart_core.app_config_engine.services.contract_service import ContractService
@@ -13,7 +15,6 @@ from odoo.addons.smart_core.app_config_engine.services.dispatchers.nav_dispatche
 from odoo.addons.smart_core.app_config_engine.services.dispatchers.menu_dispatcher import MenuDispatcher
 from odoo.addons.smart_core.app_config_engine.services.dispatchers.action_dispatcher import ActionDispatcher
 from odoo.addons.smart_core.utils.contract_governance import (
-    apply_contract_governance,
     resolve_contract_mode,
     resolve_contract_surface,
 )
@@ -174,10 +175,10 @@ class UiContractHandler(BaseIntentHandler):
             return res
 
         data, meta = (res if isinstance(res, tuple) else (res or {}, {}))
-        data = self._inject_render_hints(data or {}, p)
-        data = apply_contract_governance(
+        data = ContractService(self.env).shape_handler_delivery_data(
             data or {},
-            contract_mode,
+            payload=p,
+            contract_mode=contract_mode,
             contract_surface=contract_surface,
             source_mode=source_mode,
             inject_contract_mode=False,
@@ -193,13 +194,23 @@ class UiContractHandler(BaseIntentHandler):
         )
 
         if if_none_match and if_none_match == etag and not force_refresh:
-            return {"ok": True, "data": None,
-                    "meta": {"intent": self.INTENT_TYPE, "op": op, "etag": etag,
-                             "version": self.VERSION, "elapsed_ms": int((time.time()-t0)*1000),
-                             "contract_version": CONTRACT_VERSION, "api_version": API_VERSION,
-                             "schema_version": "1.0.0",
-                             "contract_mode": contract_mode, "contract_surface": contract_surface},
-                    "code": 304}
+            return IntentExecutionResult(
+                ok=True,
+                data=None,
+                meta={
+                    "intent": self.INTENT_TYPE,
+                    "op": op,
+                    "etag": etag,
+                    "version": self.VERSION,
+                    "elapsed_ms": int((time.time() - t0) * 1000),
+                    "contract_version": CONTRACT_VERSION,
+                    "api_version": API_VERSION,
+                    "schema_version": "1.0.0",
+                    "contract_mode": contract_mode,
+                    "contract_surface": contract_surface,
+                },
+                code=304,
+            )
 
         meta_out = dict(meta)
         payload_schema_version = meta_out.pop("schema_version", None)
@@ -211,7 +222,7 @@ class UiContractHandler(BaseIntentHandler):
                          "schema_version": "1.0.0",
                          "contract_mode": contract_mode, "contract_surface": contract_surface})
         meta_out.setdefault("response_schema_version", "1.0.0")
-        return {"ok": True, "data": data or {}, "meta": meta_out}
+        return IntentExecutionResult(ok=True, data=data or {}, meta=meta_out)
 
     def _should_block_frontend_native_op(self, *, op: str, source_mode: str, contract_surface: str) -> bool:
         if op not in FRONTEND_BLOCKED_NATIVE_OPS:
@@ -222,33 +233,57 @@ class UiContractHandler(BaseIntentHandler):
             return False
         return self.request is not None
 
-    def _inject_render_hints(self, data: Dict[str, Any], payload: Dict[str, Any]) -> Dict[str, Any]:
-        if not isinstance(data, dict):
-            return data
-        form_view = (
-            str((data.get("head") or {}).get("view_type") or data.get("view_type") or "").strip().lower() == "form"
-            or isinstance(((data.get("views") or {}).get("form")), dict)
-        )
-        if not form_view:
-            return data
-        render_profile = str(self._get_param(payload, "render_profile") or "").strip().lower()
+    def _build_dispatcher(self, ctx):
+        runtime_ctx = dict(ctx or {})
+        runtime_env = api.Environment(self.env.cr, self.env.user.id, runtime_ctx)
+        runtime_su_env = api.Environment(self.env.cr, SUPERUSER_ID, runtime_ctx)
+        return ActionDispatcher(runtime_env, runtime_su_env)
+
+    def _dispatch_model_contract(
+        self,
+        *,
+        model,
+        view_type,
+        ctx,
+        view_id=None,
+        action_id=None,
+        menu_id=None,
+        menu_xmlid="",
+        record_id=None,
+        render_profile="",
+    ):
+        payload = {
+            "subject": "model",
+            "model": model,
+            "view_type": _VIEW_INV.get(view_type, view_type),
+            "view_id": view_id,
+            "with_data": False,
+        }
+        if action_id:
+            payload["action_id"] = action_id
+        if menu_id:
+            payload["menu_id"] = menu_id
+        if menu_xmlid:
+            payload["menu_xmlid"] = menu_xmlid
+        if record_id:
+            payload["record_id"] = record_id
         if render_profile in {"create", "edit", "readonly"}:
-            data["render_profile"] = render_profile
-            return data
-        raw_record = self._get_param(payload, "record_id", "recordId", "res_id", "resId")
-        record_id = None
-        try:
-            if raw_record is not None and str(raw_record).strip():
-                record_id = int(raw_record)
-        except Exception:
-            record_id = None
-        if record_id and record_id > 0:
-            data["res_id"] = record_id
-            head = data.get("head")
-            if isinstance(head, dict) and not head.get("res_id"):
-                head["res_id"] = record_id
-                data["head"] = head
-        return data
+            payload["render_profile"] = render_profile
+        return self._build_dispatcher(ctx).dispatch(payload)
+
+    def _finalize_projected_contract(
+        self,
+        *,
+        data,
+        view_type,
+        versions,
+        subject,
+        meta=None,
+    ):
+        cs = ContractService(self.env)
+        fixed_data = cs.finalize_data(data, subject=subject, meta=meta)
+        inject_primary_view_projection(fixed_data, requested_view_type=view_type)
+        return fixed_data, {"schema_version": "view-contract-1", "version": format_versions_safe(versions)}
 
     # ---------------- op 实现 ----------------
     def _op_nav(self, ctx):
@@ -257,10 +292,9 @@ class UiContractHandler(BaseIntentHandler):
             "root_xmlid": self._get_param(self.params, "root_xmlid", "rootXmlid"),
             "root_menu_id": self._get_param(self.params, "root_menu_id", "rootMenuId"),
         })
-        # 统一服务 finalize（轻量清洗）
         cs = ContractService(self.env)
-        fixed = cs.finalize_contract({"ok": True, "data": {"nav": data.get("nav")}, "meta": {"subject": "nav", "version": format_versions_safe(versions)}})
-        return fixed.get("data") or {"nav": data.get("nav")}, {"schema_version": "nav-1"}
+        fixed_data = cs.finalize_data({"nav": data.get("nav")}, subject="nav", meta={"version": format_versions_safe(versions)})
+        return fixed_data or {"nav": data.get("nav")}, {"schema_version": "nav-1"}
 
     def _op_menu(self, p, ctx):
         raw_menu = self._get_param(p, "menu_id", "menuId", "id")
@@ -330,15 +364,70 @@ class UiContractHandler(BaseIntentHandler):
 
         view_type = (self._get_param(p, "view_type", "viewType") or "form").strip().lower()
         view_id = self._get_param(p, "view_id", "viewId")
+        raw_action = self._get_param(p, "action_id", "actionId")
+        raw_menu = self._get_param(p, "menu_id", "menuId", "id")
+        menu_xmlid = str(self._get_param(p, "menu_xmlid", "menuXmlid") or "").strip()
+        raw_record = self._get_param(p, "record_id", "recordId", "res_id", "resId")
+        scene_key = str(self._get_param(p, "scene_key", "sceneKey") or "").strip()
+        render_profile = str(
+            self._get_param(p, "render_profile", "renderProfile", "profile", "mode") or ""
+        ).strip().lower()
+        if render_profile in {"read", "view"}:
+            render_profile = "readonly"
+        if render_profile not in {"create", "edit", "readonly"}:
+            render_profile = ""
+        try:
+            action_id = int(raw_action) if raw_action not in (None, "") else None
+        except Exception:
+            action_id = None
+        try:
+            menu_id = int(raw_menu) if raw_menu not in (None, "") else None
+        except Exception:
+            menu_id = None
+        try:
+            record_id = int(raw_record) if raw_record not in (None, "") else None
+        except Exception:
+            record_id = None
 
-        # ✅ 统一服务分发：subject 固定为 'model'
-        p2 = {"subject":"model","model":model,"view_type":_VIEW_INV.get(view_type, view_type),"view_id":view_id,"with_data":False}
-        data, versions = ActionDispatcher(self.env, api.Environment(self.env.cr, self.env.user.id, ctx)).dispatch(p2)
-
-        # finalize（统一化）
-        cs = ContractService(self.env)
-        fixed = cs.finalize_contract({"ok": True, "data": data, "meta": {"subject":"model"}})
-        return fixed.get("data", {}), {"schema_version":"view-contract-1", "version": format_versions_safe(versions)}
+        data, versions = self._dispatch_model_contract(
+            model=model,
+            view_type=view_type,
+            view_id=view_id,
+            action_id=action_id,
+            menu_id=menu_id,
+            menu_xmlid=menu_xmlid,
+            record_id=record_id,
+            render_profile=render_profile,
+            ctx=ctx,
+        )
+        if isinstance(data, dict):
+            if action_id:
+                data["action_id"] = action_id
+            if menu_id:
+                data["menu_id"] = menu_id
+            if menu_xmlid:
+                data["menu_xmlid"] = menu_xmlid
+            if scene_key:
+                data["scene_key"] = scene_key
+            head = data.get("head")
+            if isinstance(head, dict):
+                if action_id:
+                    head["action_id"] = action_id
+                if menu_id:
+                    head["menu_id"] = menu_id
+                if menu_xmlid:
+                    head["menu_xmlid"] = menu_xmlid
+                if scene_key:
+                    head["scene_key"] = scene_key
+                if render_profile:
+                    head["render_profile"] = render_profile
+                data["head"] = head
+        return self._finalize_projected_contract(
+            data=data,
+            view_type=view_type,
+            versions=versions,
+            subject="model",
+        )
 
     def _op_view(self, p, ctx):
         """前端传 subject:'view' 时，等价于按模型获取视图契约（无数据）"""
@@ -351,13 +440,13 @@ class UiContractHandler(BaseIntentHandler):
         view_type = (self._get_param(p, "view_type", "viewType") or "form").strip().lower()
         view_id = self._get_param(p, "view_id", "viewId")
 
-        # ✅ 映射到统一服务的 'model' subject
-        p2 = {"subject":"model","model":model,"view_type":_VIEW_INV.get(view_type, view_type),"view_id":view_id,"with_data":False}
-        data, versions = ActionDispatcher(self.env, api.Environment(self.env.cr, self.env.user.id, ctx)).dispatch(p2)
-
-        cs = ContractService(self.env)
-        fixed = cs.finalize_contract({"ok": True, "data": data, "meta": {"subject":"model"}})
-        return fixed.get("data", {}), {"schema_version":"view-contract-1", "version": format_versions_safe(versions)}
+        data, versions = self._dispatch_model_contract(model=model, view_type=view_type, view_id=view_id, ctx=ctx)
+        return self._finalize_projected_contract(
+            data=data,
+            view_type=view_type,
+            versions=versions,
+            subject="model",
+        )
 
     def _op_action_open(self, p, ctx):
         raw_act = self._get_param(p, "action_id", "actionId")
@@ -374,7 +463,13 @@ class UiContractHandler(BaseIntentHandler):
         except Exception:
             record_id = None
         requested_view_type = (self._get_param(p, "view_type", "viewType") or "").strip().lower()
-        render_profile = str(self._get_param(p, "render_profile", "renderProfile") or "").strip().lower()
+        render_profile = str(
+            self._get_param(p, "render_profile", "renderProfile", "profile", "mode") or ""
+        ).strip().lower()
+        if render_profile in {"read", "view"}:
+            render_profile = "readonly"
+        if render_profile not in {"create", "edit", "readonly"}:
+            render_profile = ""
 
         # Detail/intake scene should prefer complete form contract surface.
         prefer_form_contract = bool(
@@ -383,37 +478,42 @@ class UiContractHandler(BaseIntentHandler):
             or render_profile in {"create", "edit", "readonly"}
         )
         if prefer_form_contract:
-            Action = self.env["ir.actions.act_window"].sudo().with_context(ctx)
+            action_ctx = dict(ctx or {})
+            action_ctx.setdefault("contract_action_id", action_id)
+            Action = self.env["ir.actions.act_window"].sudo().with_context(action_ctx)
             action = Action.browse(action_id)
             if action.exists() and action.res_model:
-                p_form = {
-                    "subject": "model",
-                    "model": action.res_model,
-                    "view_type": "form",
-                    "with_data": False,
-                }
-                data, versions = ActionDispatcher(
-                    self.env,
-                    api.Environment(self.env.cr, self.env.user.id, ctx),
-                ).dispatch(p_form)
+                data, versions = self._dispatch_model_contract(
+                    model=action.res_model,
+                    view_type="form",
+                    action_id=action_id,
+                    record_id=record_id,
+                    render_profile=render_profile,
+                    ctx=action_ctx,
+                )
                 if isinstance(data, dict):
                     data["action_id"] = action_id
                     head = data.get("head")
                     if isinstance(head, dict):
                         head.setdefault("view_type", "form")
                         head["action_id"] = action_id
+                        if not head.get("context") and action.context:
+                            head["context"] = _safe_eval_or(action.context, {})
                         data["head"] = head
-                cs = ContractService(self.env)
-                fixed = cs.finalize_contract({"ok": True, "data": data, "meta": {"subject": "action.form", "action_id": action_id}})
-                return fixed.get("data", {}), {"schema_version": "view-contract-1", "version": format_versions_safe(versions)}
+                return self._finalize_projected_contract(
+                    data=data,
+                    view_type="form",
+                    versions=versions,
+                    subject="action.form",
+                    meta={"action_id": action_id},
+                )
 
         # 统一服务的 action 分发
         p2 = {"subject":"action","action_id": action_id, "with_data": False}
-        data, versions = ActionDispatcher(self.env, api.Environment(self.env.cr, self.env.user.id, ctx)).dispatch(p2)
+        data, versions = self._build_dispatcher(ctx).dispatch(p2)
 
         cs = ContractService(self.env)
-        fixed = cs.finalize_contract({"ok": True, "data": data, "meta": {"subject":"action"}})
-        return fixed.get("data", {}), {"schema_version":"view-contract-1", "version": format_versions_safe(versions)}
+        return cs.finalize_data(data, subject="action"), {"schema_version":"view-contract-1", "version": format_versions_safe(versions)}
 
     # ---------------- 工具 ----------------
     def _read_if_none_match(self, p) -> str:

--- a/addons/smart_core/tests/test_backend_semantic_copy_supply.py
+++ b/addons/smart_core/tests/test_backend_semantic_copy_supply.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(module_name: str, relative_path: str):
+    target = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, target)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+def _ensure_stub_packages():
+    sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+    sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+    sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+    sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+    sys.modules.setdefault("odoo.exceptions", types.ModuleType("odoo.exceptions"))
+    sys.modules["odoo.exceptions"].AccessError = type("AccessError", (Exception,), {})
+
+
+_ensure_stub_packages()
+_load_module(
+    "odoo.addons.smart_core.core.scene_contract_parser_semantic_bridge",
+    "addons/smart_core/core/scene_contract_parser_semantic_bridge.py",
+)
+_load_module(
+    "odoo.addons.smart_core.core.scene_contract_semantic_orchestration_bridge",
+    "addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py",
+)
+_load_module(
+    "odoo.addons.smart_core.core.released_scene_semantic_surface_bridge",
+    "addons/smart_core/core/released_scene_semantic_surface_bridge.py",
+)
+
+
+SCENE_CONTRACT_BUILDER = _load_module(
+    "smart_core_scene_contract_builder_test",
+    "addons/smart_core/core/scene_contract_builder.py",
+)
+PRODUCT_POLICY_SERVICE = _load_module(
+    "smart_core_product_policy_service_test",
+    "addons/smart_core/delivery/product_policy_service.py",
+)
+CORE_EXTENSION = _load_module(
+    "smart_construction_core_extension_test",
+    "addons/smart_construction_core/core_extension.py",
+)
+
+
+class TestBackendSemanticCopySupply(unittest.TestCase):
+    def test_release_surface_contract_keeps_backend_description_and_scope(self):
+        contract = SCENE_CONTRACT_BUILDER.build_release_surface_scene_contract_from_delivery_entry(
+            {
+                "scene_key": "payment",
+                "label": "FR-4 付款记录",
+                "route": "/release/fr4",
+                "product_key": "fr4",
+                "capability_key": "delivery.fr4.payment_tracking",
+                "requires_project_context": True,
+                "description": "查看与记录项目付款事实。",
+                "scope": "项目执行 -> 成本 -> 付款记录 -> 付款汇总。",
+            }
+        )
+        identity = contract.get("identity") or {}
+        self.assertEqual(identity.get("description"), "查看与记录项目付款事实。")
+        self.assertEqual(identity.get("scope"), "项目执行 -> 成本 -> 付款记录 -> 付款汇总。")
+
+    def test_default_product_policy_scenes_include_user_facing_copy(self):
+        scenes = PRODUCT_POLICY_SERVICE.DEFAULT_PRODUCT_POLICY.get("scenes") or []
+        payment_scene = next((row for row in scenes if isinstance(row, dict) and row.get("scene_key") == "payment"), {})
+        self.assertTrue(payment_scene.get("description"))
+        self.assertTrue(payment_scene.get("scope"))
+
+    def test_enterprise_enablement_contract_supplies_status_label(self):
+        user = SimpleNamespace(company_id=SimpleNamespace(id=3, name="Demo Co"))
+        payload = CORE_EXTENSION._build_enterprise_enablement_contract(env=None, user=user)
+        steps = (((payload or {}).get("mainline") or {}).get("steps")) or []
+        self.assertTrue(steps)
+        self.assertTrue(all(isinstance(row, dict) and row.get("status_label") for row in steps))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_contract_governance_project_form.py
+++ b/addons/smart_core/tests/test_contract_governance_project_form.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import ast
 import unittest
+from pathlib import Path
 
 from ..utils.contract_governance import (
     apply_contract_governance,
@@ -41,6 +43,7 @@ def _sample_payload():
             "code": {"string": "项目编号(别名)", "type": "char", "required": False, "readonly": True},
             "project_type_id": {"string": "项目类型", "type": "many2one", "required": False, "readonly": False},
             "manager_id": {"string": "项目经理", "type": "many2one", "required": False, "readonly": False},
+            "owner_id": {"string": "项目负责人", "type": "many2one", "required": False, "readonly": False},
             "company_id": {"string": "公司", "type": "many2one", "required": False, "readonly": False},
             "analytic_account_id": {"string": "分析账户", "type": "many2one", "required": False, "readonly": False},
             "budget_total": {"string": "预算", "type": "monetary", "required": False, "readonly": False},
@@ -185,6 +188,128 @@ def _sample_kanban_payload():
     }
 
 
+def _sample_company_form_payload():
+    return {
+        "head": {"model": "res.company", "view_type": "tree,form"},
+        "render_profile": "create",
+        "views": {
+            "form": {
+                "layout": [
+                    {"type": "sheet", "children": [
+                        {"type": "field", "name": "name", "fieldInfo": {"label": "Company Name"}},
+                        {"type": "field", "name": "sc_short_name", "fieldInfo": {"label": "Short Name"}},
+                        {"type": "field", "name": "sc_credit_code", "fieldInfo": {"label": "Credit Code"}},
+                        {"type": "field", "name": "sc_contact_phone", "fieldInfo": {"label": "Phone"}},
+                        {"type": "field", "name": "sc_address", "fieldInfo": {"label": "Address"}},
+                        {"type": "field", "name": "sc_is_active", "fieldInfo": {"label": "Active"}},
+                        {"type": "field", "name": "currency_id", "fieldInfo": {"label": "Currency"}},
+                    ]},
+                ]
+            }
+        },
+        "fields": {
+            "name": {"string": "公司名称", "type": "char", "required": True, "readonly": False},
+            "sc_short_name": {"string": "公司简称", "type": "char", "required": False, "readonly": False},
+            "sc_credit_code": {"string": "统一社会信用代码", "type": "char", "required": False, "readonly": False},
+            "sc_contact_phone": {"string": "联系电话", "type": "char", "required": False, "readonly": False},
+            "sc_address": {"string": "地址", "type": "char", "required": False, "readonly": False},
+            "sc_is_active": {"string": "启用", "type": "boolean", "required": False, "readonly": False},
+            "currency_id": {"string": "货币", "type": "many2one", "required": False, "readonly": False},
+        },
+        "toolbar": {
+            "header": [
+                {"key": "open_companies", "label": "Companies", "kind": "open"},
+            ]
+        },
+        "buttons": [
+            {"key": "apply_defaults", "label": "Apply", "kind": "object", "level": "header"},
+            {"key": "inalterability", "label": "Data Inalterability Check", "kind": "object", "level": "header"},
+        ],
+    }
+
+
+def _sample_nested_project_form_payload():
+    payload = _sample_payload()
+    payload["views"]["form"]["layout"] = [
+        {"type": "header"},
+        {
+            "type": "sheet",
+            "name": "project_sheet",
+            "children": [
+                {
+                    "type": "group",
+                    "name": "project_head",
+                    "children": [
+                        {"type": "field", "name": "name"},
+                        {"type": "field", "name": "project_type_id"},
+                    ],
+                },
+                {
+                    "type": "notebook",
+                    "name": "project_notebook",
+                    "children": [
+                        {
+                            "type": "page",
+                            "name": "description",
+                            "string": "描述",
+                            "children": [
+                                {
+                                    "type": "group",
+                                    "name": "description_group",
+                                    "children": [
+                                        {"type": "field", "name": "privacy_visibility"},
+                                        {"type": "field", "name": "rating_status"},
+                                    ],
+                                }
+                            ],
+                        },
+                        {
+                            "type": "page",
+                            "name": "settings",
+                            "string": "设置",
+                            "children": [
+                                {
+                                    "type": "group",
+                                    "name": "settings_group",
+                                    "children": [
+                                        {"type": "field", "name": "manager_id"},
+                                        {"type": "field", "name": "company_id"},
+                                        {"type": "field", "name": "analytic_account_id"},
+                                    ],
+                                }
+                            ],
+                        },
+                    ],
+                },
+            ],
+        },
+    ]
+    return payload
+
+
+def _collect_layout_field_names(nodes):
+    ordered = []
+
+    def walk(node):
+        if isinstance(node, list):
+            for item in node:
+                walk(item)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("type") == "field":
+            name = node.get("name")
+            if name and name not in ordered:
+                ordered.append(name)
+        for key in ("children", "tabs", "pages", "nodes", "items"):
+            nested = node.get(key)
+            if isinstance(nested, list):
+                walk(nested)
+
+    walk(nodes)
+    return ordered
+
+
 class TestProjectFormGovernance(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
@@ -218,6 +343,134 @@ class TestProjectFormGovernance(unittest.TestCase):
         self.assertIn("manager_id", visible_fields)
         self.assertIn("budget_total", visible_fields)
         self.assertNotIn("create_uid", visible_fields)
+
+    def test_user_mode_preserves_native_project_form_layout_hierarchy(self):
+        data = _sample_nested_project_form_payload()
+        out = apply_contract_governance(data, "user")
+
+        layout = ((out.get("views") or {}).get("form") or {}).get("layout") or []
+        self.assertEqual(layout[0].get("type"), "header")
+        self.assertEqual(layout[1].get("type"), "sheet")
+
+        sheet_children = layout[1].get("children") or []
+        notebook = next((node for node in sheet_children if isinstance(node, dict) and node.get("type") == "notebook"), {})
+        self.assertEqual(notebook.get("name"), "project_notebook")
+
+        pages = notebook.get("children") or []
+        page_names = [node.get("name") for node in pages if isinstance(node, dict)]
+        self.assertEqual(page_names, ["description", "settings"])
+
+        description_page = next((node for node in pages if isinstance(node, dict) and node.get("name") == "description"), {})
+        settings_page = next((node for node in pages if isinstance(node, dict) and node.get("name") == "settings"), {})
+        description_group = (description_page.get("children") or [])[0]
+        settings_group = (settings_page.get("children") or [])[0]
+
+        description_fields = [node.get("name") for node in (description_group.get("children") or []) if isinstance(node, dict)]
+        settings_fields = [node.get("name") for node in (settings_group.get("children") or []) if isinstance(node, dict)]
+
+        self.assertEqual(description_fields, ["privacy_visibility", "rating_status"])
+        self.assertEqual(settings_fields, ["manager_id", "company_id", "analytic_account_id"])
+
+    def test_user_mode_backfills_visible_fields_into_layout(self):
+        data = _sample_payload()
+        # Simulate a native parser layout that kept the visible allow-list but
+        # omitted a subset of business fields from the structural tree.
+        data["views"]["form"]["layout"] = [
+            {"type": "header"},
+            {"type": "sheet"},
+            {"type": "field", "name": "name"},
+            {"type": "field", "name": "project_type_id"},
+            {"type": "field", "name": "manager_id"},
+            {"type": "field", "name": "company_id"},
+            {"type": "field", "name": "analytic_account_id"},
+            {"type": "field", "name": "phase_key"},
+            {"type": "field", "name": "last_update_status"},
+            {"type": "field", "name": "privacy_visibility"},
+            {"type": "field", "name": "rating_status"},
+            {"type": "field", "name": "rating_status_period"},
+        ]
+        out = apply_contract_governance(data, "user")
+
+        visible_fields = out.get("visible_fields") or []
+        layout = ((out.get("views") or {}).get("form") or {}).get("layout") or []
+        layout_field_names = _collect_layout_field_names(layout)
+
+        self.assertIn("owner_id", visible_fields)
+        self.assertIn("budget_total", visible_fields)
+        self.assertIn("stage_id", visible_fields)
+        self.assertIn("owner_id", layout_field_names)
+        self.assertIn("budget_total", layout_field_names)
+        self.assertIn("stage_id", layout_field_names)
+        self.assertEqual(layout[1].get("type"), "sheet")
+        sheet_children = layout[1].get("children") or []
+        backfill_group = next(
+            (node for node in sheet_children if isinstance(node, dict) and node.get("name") == "visible_fields_backfill_group"),
+            {},
+        )
+        self.assertEqual(backfill_group.get("string"), "补充业务信息")
+        backfill_children = [node for node in (backfill_group.get("children") or []) if isinstance(node, dict)]
+        backfill_fields = [node.get("name") for node in backfill_children]
+        self.assertEqual(set(backfill_fields), {"owner_id", "budget_total", "stage_id"})
+        for node in backfill_children:
+            field_info = node.get("fieldInfo") if isinstance(node.get("fieldInfo"), dict) else {}
+            self.assertEqual(field_info.get("label"), out["fields"][node.get("name")]["string"])
+            if out["fields"][node.get("name")]["type"] == "many2one":
+                self.assertEqual(field_info.get("widget"), "many2one")
+
+    def test_generic_semantic_governance_no_longer_backfills_layout(self):
+        source_path = Path(__file__).resolve().parents[1] / "utils" / "contract_governance.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        calls = []
+
+        class Finder(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):
+                if node.name != "_apply_form_render_semantics":
+                    return
+                self.generic_visit(node)
+
+            def visit_Call(self, node):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "_backfill_form_layout_from_visible_fields":
+                    calls.append(node.lineno)
+                self.generic_visit(node)
+
+        Finder().visit(tree)
+
+        self.assertEqual(calls, [])
+
+    def test_user_mode_governs_enterprise_company_create_form(self):
+        data = _sample_company_form_payload()
+        out = apply_contract_governance(data, "user")
+
+        self.assertEqual(out.get("visible_fields"), [
+            "name",
+            "sc_short_name",
+            "sc_credit_code",
+            "sc_contact_phone",
+            "sc_address",
+            "sc_is_active",
+        ])
+
+        layout = ((out.get("views") or {}).get("form") or {}).get("layout") or []
+        self.assertEqual(len(layout), 1)
+        sheet = layout[0]
+        self.assertEqual(sheet.get("type"), "sheet")
+        group = (sheet.get("children") or [])[0]
+        self.assertEqual(group.get("string"), "企业基础信息")
+        field_nodes = group.get("children") or []
+        self.assertEqual([node.get("name") for node in field_nodes], [
+            "name",
+            "sc_short_name",
+            "sc_credit_code",
+            "sc_contact_phone",
+            "sc_address",
+            "sc_is_active",
+        ])
+        self.assertEqual(field_nodes[0].get("string"), "公司名称")
+        self.assertEqual(field_nodes[1].get("string"), "公司简称")
+
+        self.assertEqual((out.get("toolbar") or {}).get("header"), [])
+        self.assertEqual(out.get("buttons"), [])
         self.assertNotIn("message_ids", visible_fields)
         form_profile = out.get("form_profile") or {}
         self.assertIsInstance(form_profile, dict)
@@ -241,10 +494,35 @@ class TestProjectFormGovernance(unittest.TestCase):
             self.assertIn("label", first_group)
             self.assertIn("actions", first_group)
             self.assertLessEqual(len(first_group.get("actions") or []), 5)
+        scene_actions = ((out.get("semantic_page") or {}).get("actions")) or {}
+        self.assertEqual(scene_actions.get("owner_layer"), "scene_orchestration")
+        self.assertIsInstance(scene_actions.get("header_actions"), list)
+        self.assertIsInstance(scene_actions.get("record_actions"), list)
+        self.assertEqual(
+            [row.get("key") for row in scene_actions.get("header_actions") or []],
+            [row.get("key") for row in buttons if isinstance(row, dict) and row.get("level") == "header"],
+        )
+        self.assertEqual(
+            [row.get("key") for row in scene_actions.get("record_actions") or []],
+            [row.get("key") for row in buttons if isinstance(row, dict) and row.get("level") in {"smart", "row"}],
+        )
+        scene_contract = out.get("scene_contract_v1") or {}
+        self.assertEqual(scene_contract.get("contract_version"), "v1")
+        self.assertEqual(scene_contract.get("owner_layer"), "scene_orchestration")
+        self.assertEqual(
+            ((scene_contract.get("semantic_page") or {}).get("actions") or {}).get("owner_layer"),
+            "scene_orchestration",
+        )
+        self.assertTrue(((scene_contract.get("actions") or {}).get("primary_actions") or []))
         lifecycle = out.get("lifecycle") or {}
         self.assertIsInstance(lifecycle, dict)
         self.assertIn("state_field", lifecycle)
         self.assertIn("allowed_transitions", lifecycle)
+        workflow_surface = out.get("workflow_surface") or {}
+        self.assertEqual(workflow_surface.get("owner_layer"), "business_fact")
+        self.assertEqual(workflow_surface.get("state_field"), lifecycle.get("state_field"))
+        self.assertIsInstance(workflow_surface.get("states"), list)
+        self.assertIsInstance(workflow_surface.get("transitions"), list)
         filters = ((out.get("search") or {}).get("filters")) or []
         self.assertLessEqual(len(filters), 8)
         self.assertEqual(out.get("render_profile"), "create")
@@ -417,6 +695,47 @@ class TestProjectFormGovernance(unittest.TestCase):
         self.assertGreaterEqual(int(surface_policies.get("actions_primary_max", 0)), 0)
         self.assertLessEqual(int(surface_policies.get("filters_primary_max", 99)), 4)
         self.assertLessEqual(int(surface_policies.get("actions_primary_max", 99)), 3)
+        self.assertIn(str(surface_policies.get("delete_mode") or ""), {"unlink", "none"})
+        batch_policy = surface_policies.get("batch_policy") or {}
+        self.assertIsInstance(batch_policy, dict)
+        self.assertIn("enabled", batch_policy)
+        self.assertIn("delete_allowed", batch_policy)
+        self.assertIn("delete_only_mode", batch_policy)
+        self.assertIsInstance(batch_policy.get("available_actions") or [], list)
+        record_open_policy = surface_policies.get("record_open_policy") or {}
+        self.assertIsInstance(record_open_policy, dict)
+        self.assertIn(
+            str(record_open_policy.get("carry_query_mode") or ""),
+            {"preserve", "clear_scene_context", "whitelist"},
+        )
+        list_profile = out.get("list_profile") or {}
+        list_semantics = ((out.get("semantic_page") or {}).get("list_semantics")) or {}
+        self.assertEqual(list_semantics.get("owner_layer"), "scene_orchestration")
+        self.assertEqual(
+            [row.get("name") for row in list_semantics.get("columns") or []],
+            list_profile.get("columns") or [],
+        )
+        self.assertEqual(list_semantics.get("row_primary"), list_profile.get("row_primary"))
+        self.assertEqual(list_semantics.get("status_field"), list_profile.get("status_field"))
+        scene_contract = out.get("scene_contract_v1") or {}
+        self.assertEqual(scene_contract.get("contract_version"), "v1")
+        scene_list_semantics = ((scene_contract.get("semantic_page") or {}).get("list_semantics")) or {}
+        self.assertEqual(scene_list_semantics.get("owner_layer"), "scene_orchestration")
+        self.assertEqual(
+            [row.get("name") for row in scene_list_semantics.get("columns") or []],
+            list_profile.get("columns") or [],
+        )
+        self.assertTrue((scene_contract.get("search_surface") or {}).get("filters"))
+        self.assertTrue((scene_contract.get("actions") or {}).get("primary_actions"))
+
+    def test_project_list_uses_project_execution_stage_label(self):
+        data = _sample_list_payload()
+
+        out = apply_project_form_domain_override(data, "user")
+
+        columns = ((out.get("semantic_page") or {}).get("list_semantics") or {}).get("columns") or []
+        lifecycle_column = next((row for row in columns if isinstance(row, dict) and row.get("name") == "lifecycle_state"), {})
+        self.assertEqual(lifecycle_column.get("label"), "项目执行阶段")
 
     def test_project_kanban_adds_profile_and_filters_fields(self):
         data = _sample_kanban_payload()
@@ -435,6 +754,67 @@ class TestProjectFormGovernance(unittest.TestCase):
         self.assertIsInstance(fields, list)
         self.assertIn("name", fields)
         self.assertNotIn("message_ids", fields)
+
+    def test_action_open_form_surface_is_not_overwritten_by_multi_view_head(self):
+        data = _sample_payload()
+        data["head"]["view_type"] = "kanban,tree,form"
+        data["view_type"] = "form"
+        data["render_profile"] = "edit"
+        data["res_id"] = 2
+        data["views"]["kanban"] = _sample_kanban_payload()["views"]["kanban"]
+
+        out = apply_contract_governance(data, "user")
+
+        visible_fields = out.get("visible_fields") or []
+        self.assertNotIn("kanban_profile", out)
+        self.assertIn("project_type_id", visible_fields)
+        self.assertIn("owner_id", visible_fields)
+        self.assertIn("company_id", visible_fields)
+        self.assertGreater(len(visible_fields), 7)
+
+    def test_ui_contract_handler_does_not_apply_governance_after_service_shape(self):
+        source_path = Path(__file__).resolve().parents[1] / "handlers" / "ui_contract.py"
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        calls = []
+
+        class Finder(ast.NodeVisitor):
+            def visit_FunctionDef(self, node):
+                if node.name == "handle":
+                    self.generic_visit(node)
+
+            def visit_Call(self, node):
+                func = node.func
+                if isinstance(func, ast.Name) and func.id == "apply_contract_governance":
+                    calls.append(node.lineno)
+                self.generic_visit(node)
+
+        Finder().visit(tree)
+
+        self.assertEqual(calls, [])
+
+    def test_governance_preserves_native_notebook_tab_labels(self):
+        data = _sample_payload()
+        data["head"]["view_type"] = "kanban,tree,form"
+        data["view_type"] = "form"
+        data["render_profile"] = "edit"
+        data["res_id"] = 2
+        data["views"]["form"]["layout"] = [
+            {
+                "type": "notebook",
+                "tabs": [
+                    {"type": "page", "title": "页签1", "label": "页签1", "string": "投标管理"},
+                    {"type": "page", "title": "Time Management", "label": "Time Management", "string": "Settings"},
+                ],
+            }
+        ]
+
+        out = apply_contract_governance(data, "user")
+        tabs = ((((out.get("views") or {}).get("form") or {}).get("layout") or [])[0] or {}).get("tabs") or []
+
+        self.assertEqual(tabs[0].get("title"), "投标管理")
+        self.assertEqual(tabs[0].get("label"), "投标管理")
+        self.assertEqual(tabs[1].get("title"), "设置")
+        self.assertEqual(tabs[1].get("label"), "设置")
 
     def test_user_mode_realigns_access_policy_after_field_governance(self):
         data = _sample_payload()

--- a/addons/smart_core/tests/test_release_operator_surface_copy_backend.py
+++ b/addons/smart_core/tests/test_release_operator_surface_copy_backend.py
@@ -1,0 +1,166 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DELIVERY_DIR = ROOT / "addons" / "smart_core" / "delivery"
+
+
+def _load_module(module_name: str, relative_path: str):
+    target = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, target)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(DELIVERY_DIR.parent)]
+delivery_pkg = sys.modules.setdefault("odoo.addons.smart_core.delivery", types.ModuleType("odoo.addons.smart_core.delivery"))
+delivery_pkg.__path__ = [str(DELIVERY_DIR)]
+smart_core_pkg.delivery = delivery_pkg
+
+approval_stub = types.ModuleType("odoo.addons.smart_core.delivery.release_approval_policy_service")
+approval_stub.ReleaseApprovalPolicyService = type(
+    "ReleaseApprovalPolicyService",
+    (),
+    {"__init__": lambda self, env: None},
+)
+sys.modules["odoo.addons.smart_core.delivery.release_approval_policy_service"] = approval_stub
+
+audit_stub = types.ModuleType("odoo.addons.smart_core.delivery.release_audit_trail_service")
+audit_stub.ReleaseAuditTrailService = type(
+    "ReleaseAuditTrailService",
+    (),
+    {"__init__": lambda self, env: None},
+)
+sys.modules["odoo.addons.smart_core.delivery.release_audit_trail_service"] = audit_stub
+
+_load_module(
+    "odoo.addons.smart_core.delivery.release_operator_contract_versions",
+    "addons/smart_core/delivery/release_operator_contract_versions.py",
+)
+_load_module(
+    "odoo.addons.smart_core.delivery.release_operator_contract_registry",
+    "addons/smart_core/delivery/release_operator_contract_registry.py",
+)
+_load_module(
+    "odoo.addons.smart_core.delivery.release_operator_read_model_service",
+    "addons/smart_core/delivery/release_operator_read_model_service.py",
+)
+TARGET = _load_module(
+    "odoo.addons.smart_core.delivery.release_operator_surface_service",
+    "addons/smart_core/delivery/release_operator_surface_service.py",
+)
+
+
+class _ApprovalPolicyService:
+    def _release_identity(self, *, product_key: str):
+        edition_key = "preview" if product_key.endswith("preview") else "standard"
+        return {
+            "product_key": product_key,
+            "base_product_key": "construction",
+            "edition_key": edition_key,
+        }
+
+    def resolve_policy(self, *, action_type: str, product_key: str):
+        return {"allowed_executor_role_codes": ["release_manager"]}
+
+    def resolve_actor_role_codes(self, user):
+        return ["release_manager"]
+
+    def roles_match(self, actor_roles, allowed_roles):
+        return bool(set(actor_roles or []).intersection(set(allowed_roles or [])))
+
+    def can_approve(self, *, action, user):
+        return True, "OK", {"source": "test"}
+
+
+class _AuditTrailService:
+    def build_audit_trail(self, *, product_key: str, action_limit: int):
+        return {
+            "active_released_snapshot": {
+                "id": 11,
+                "product_key": product_key,
+                "edition_key": "standard",
+                "version": "v11",
+                "state": "released",
+                "rollback_target_snapshot_id": 7,
+            },
+            "release_actions": [
+                {"id": 21, "action_type": "promote_snapshot", "state": "done", "approval_state": "approved"}
+            ],
+            "release_snapshots": [
+                {"id": 11, "product_key": product_key, "edition_key": "standard", "version": "v11", "state": "released"},
+                {"id": 12, "product_key": product_key, "edition_key": "standard", "version": "v12", "state": "candidate"},
+            ],
+            "runtime": {
+                "release_audit_trail_summary": {
+                    "active_snapshot_version": "v11",
+                    "latest_action_type": "promote_snapshot",
+                    "latest_action_approval_state": "approved",
+                },
+                "released_snapshot_lineage": {"active_snapshot_id": 11},
+            },
+        }
+
+
+class _RecordSet(list):
+    def sudo(self):
+        return self
+
+    def search(self, domain, order=None, limit=None):
+        return self
+
+
+class _ReleaseActionRow:
+    def to_runtime_dict(self):
+        return {
+            "id": 31,
+            "action_type": "rollback_snapshot",
+            "product_key": "construction.standard",
+            "approval_state": "pending_approval",
+            "state": "pending",
+        }
+
+
+class _Env(dict):
+    def __init__(self):
+        super().__init__()
+        self.user = object()
+        self["sc.release.action"] = _RecordSet([_ReleaseActionRow()])
+
+
+class TestReleaseOperatorSurfaceCopyBackend(unittest.TestCase):
+    def test_surface_build_includes_backend_owned_copy_payload(self):
+        service = TARGET.ReleaseOperatorSurfaceService(_Env())
+        service.read_model_service.audit_service = _AuditTrailService()
+        service.read_model_service.approval_policy_service = _ApprovalPolicyService()
+
+        payload = service.build_surface(product_key="construction.standard", action_limit=5)
+
+        self.assertEqual((payload.get("copy") or {}).get("title"), "发布控制台")
+        self.assertIn("候选快照", (payload.get("copy") or {}).get("hint_candidate", ""))
+        self.assertEqual((((payload.get("read_model_v1") or {}).get("copy") or {}).get("section_pending")), "待审批动作")
+        self.assertEqual((((payload.get("read_model_v1") or {}).get("copy") or {}).get("rollback_action_label")), "执行回滚")
+
+    def test_preview_product_copy_mentions_preview_edition(self):
+        service = TARGET.ReleaseOperatorSurfaceService(_Env())
+        service.read_model_service.audit_service = _AuditTrailService()
+        service.read_model_service.approval_policy_service = _ApprovalPolicyService()
+
+        payload = service.build_surface(product_key="construction.preview", action_limit=5)
+
+        self.assertIn("预览版", (payload.get("copy") or {}).get("description", ""))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_scene_contract_builder_semantics.py
+++ b/addons/smart_core/tests/test_scene_contract_builder_semantics.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+CORE_DIR = Path(__file__).resolve().parents[1] / "core"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(CORE_DIR.parent)]
+core_pkg = sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+core_pkg.__path__ = [str(CORE_DIR)]
+smart_core_pkg.core = core_pkg
+
+bridge_module = _load_module(
+    "odoo.addons.smart_core.core.scene_contract_parser_semantic_bridge",
+    CORE_DIR / "scene_contract_parser_semantic_bridge.py",
+)
+core_pkg.scene_contract_parser_semantic_bridge = bridge_module
+semantic_bridge_module = _load_module(
+    "odoo.addons.smart_core.core.scene_contract_semantic_orchestration_bridge",
+    CORE_DIR / "scene_contract_semantic_orchestration_bridge.py",
+)
+core_pkg.scene_contract_semantic_orchestration_bridge = semantic_bridge_module
+
+target = _load_module(
+    "odoo.addons.smart_core.core.scene_contract_builder",
+    CORE_DIR / "scene_contract_builder.py",
+)
+
+
+class TestSceneContractBuilderSemantics(unittest.TestCase):
+    def test_delivery_entry_projects_intake_actions_publish_scene_ready_routes(self):
+        payload = target.build_release_surface_scene_contract_from_delivery_entry(
+            {
+                "scene_key": "projects.intake",
+                "label": "FR-1 项目立项",
+                "route": "/s/projects.intake",
+                "product_key": "fr1",
+                "capability_key": "delivery.fr1.project_intake",
+            }
+        )
+
+        actions = payload.get("actions") or {}
+        primary = (actions.get("primary_actions") or [{}])[0]
+        secondary = (actions.get("secondary_actions") or [{}])[0]
+
+        self.assertEqual(((primary.get("target") or {}).get("route")), "/s/projects.intake?intake_mode=quick")
+        self.assertEqual(((primary.get("target") or {}).get("scene_key")), "projects.intake")
+        self.assertEqual(((secondary.get("target") or {}).get("route")), "/s/projects.intake")
+        self.assertEqual(((secondary.get("target") or {}).get("scene_key")), "projects.intake")
+
+    def test_runtime_entry_projects_parser_semantics_into_scene_contract(self):
+        payload = target.build_release_surface_scene_contract_from_runtime_entry(
+            {
+                "scene_key": "workspace.home",
+                "title": "工作台",
+                "parser_contract": {"view_type": "kanban"},
+                "view_semantics": {"source_view": "kanban", "capability_flags": {"has_menu": True}},
+                "native_view": {"views": {"kanban": {"layout": []}}},
+                "semantic_page": {"kanban_semantics": {"lane_count": 3}},
+            },
+            product_key="my_work",
+            capability="delivery.my_work.workspace",
+            route="/my-work",
+            diagnostics_ref="runtime.contract:test",
+        )
+
+        self.assertEqual((((payload.get("page") or {}).get("surface") or {}).get("view_type")), "kanban")
+        self.assertEqual(
+            (((((payload.get("page") or {}).get("surface") or {}).get("semantic_view") or {}).get("source_view"))),
+            "kanban",
+        )
+        self.assertEqual(((payload.get("page") or {}).get("layout")), "board")
+        self.assertIn("parser_semantic_surface", payload.get("governance") or {})
+
+    def test_page_contract_projects_parser_semantics_into_scene_contract(self):
+        payload = target.build_release_surface_scene_contract_from_page_contract(
+            {
+                "page_orchestration_v1": {
+                    "page": {"title": "我的工作", "layout_mode": "workspace"},
+                    "zones": [],
+                    "action_schema": {"actions": {}},
+                    "meta": {
+                        "parser_semantic_surface": {
+                            "parser_contract": {"view_type": "tree"},
+                            "view_semantics": {"source_view": "tree", "capability_flags": {"is_editable": True}},
+                            "native_view": {"views": {"tree": {"layout": []}}},
+                            "semantic_page": {"list_semantics": {"columns": [{"name": "name"}]}},
+                        }
+                    },
+                }
+            },
+            scene_key="my_work.workspace",
+            title="我的工作",
+            product_key="my_work",
+            capability="delivery.my_work.workspace",
+            route="/my-work",
+            diagnostics_ref="page.contract:test",
+        )
+
+        self.assertEqual((((payload.get("page") or {}).get("surface") or {}).get("view_type")), "tree")
+        self.assertEqual(((payload.get("page") or {}).get("layout")), "list")
+        self.assertIn("parser_semantic_surface", payload.get("governance") or {})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_scene_ready_semantic_orchestration_bridge.py
+++ b/addons/smart_core/tests/test_scene_ready_semantic_orchestration_bridge.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "core" / "scene_ready_semantic_orchestration_bridge.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("scene_ready_semantic_orchestration_bridge_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+bridge_module = _load_module()
+
+
+class TestSceneReadySemanticOrchestrationBridge(unittest.TestCase):
+    def test_bridge_overrides_legacy_view_modes_from_parser_semantics(self):
+        payload = {
+            "view_modes": [{"key": "kanban", "label": "看板", "enabled": True}],
+            "action_surface": {"selection_mode": "single"},
+            "parser_semantic_surface": {
+                "parser_contract": {"view_type": "form"},
+                "view_semantics": {"source_view": "form", "capability_flags": {"is_editable": True}},
+                "native_view": {"views": {"form": {"layout": []}, "search": {"layout": []}}},
+                "semantic_page": {"title_node": {"text": "项目"}},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+
+        self.assertEqual((bridged.get("view_modes") or [])[0]["key"], "form")
+        self.assertEqual(((bridged.get("action_surface") or {}).get("selection_mode")), "single")
+
+    def test_bridge_uses_multi_selection_for_list_like_semantics(self):
+        payload = {
+            "action_surface": {"selection_mode": "single"},
+            "parser_semantic_surface": {
+                "parser_contract": {"view_type": "tree"},
+                "view_semantics": {"source_view": "tree", "capability_flags": {"is_editable": True}},
+                "native_view": {"views": {"tree": {"layout": []}, "kanban": {"cards": []}}},
+                "semantic_page": {"list_semantics": {"columns": [{"name": "name"}]}},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+
+        self.assertEqual((bridged.get("view_modes") or [])[0]["key"], "tree")
+        self.assertEqual(((bridged.get("action_surface") or {}).get("selection_mode")), "multi")
+
+    def test_bridge_materializes_action_surface_when_missing(self):
+        payload = {
+            "parser_semantic_surface": {
+                "parser_contract": {"view_type": "tree"},
+                "view_semantics": {"source_view": "tree", "capability_flags": {"is_editable": True}},
+                "native_view": {"views": {"tree": {"layout": []}}},
+                "semantic_page": {"list_semantics": {"columns": [{"name": "name"}]}},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+
+        self.assertEqual(((bridged.get("action_surface") or {}).get("selection_mode")), "multi")
+
+    def test_bridge_normalizes_direct_runtime_handoff_surface(self):
+        payload = {
+            "scene": {"key": "projects.list"},
+            "delivery_handoff_v1": {
+                "family": "projects",
+                "runtime_entry_type": "governed_user_flow",
+                "runtime_consumer": "family_runtime_consumer",
+                "runtime_mode": "direct",
+                "user_entry": "menu:smart_construction_core.menu_sc_root",
+                "final_scene": "projects.list",
+                "primary_action": {"action_xmlid": "smart_construction_core.action_sc_project_list"},
+                "required_provider": "construction.projects_ledger_provider.v1|construction.projects_detail_provider.v1",
+                "fallback_policy": {"type": "native_action_compat"},
+                "acceptance": {"runtime_ready": True, "workflow_ready": True, "advisory_only": True},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+        handoff = bridged.get("runtime_handoff_surface") or {}
+
+        self.assertEqual(handoff.get("family"), "projects")
+        self.assertEqual(handoff.get("consume_mode"), "direct")
+        self.assertEqual(handoff.get("runtime_consumer"), "family_runtime_consumer")
+        self.assertEqual(handoff.get("final_scene"), "projects.list")
+        self.assertTrue(handoff.get("workflow_ready"))
+
+    def test_bridge_marks_payment_handoff_as_advisory_consume(self):
+        payload = {
+            "scene": {"key": "payments.approval"},
+            "delivery_handoff_v1": {
+                "family": "payment_approval",
+                "runtime_entry_type": "governed_user_flow",
+                "runtime_consumer": "family_runtime_consumer",
+                "runtime_mode": "direct",
+                "user_entry": "menu:smart_construction_core.menu_sc_tier_review_my_payment_request",
+                "final_scene": "payments.approval",
+                "primary_action": {"action_xmlid": "smart_construction_core.action_sc_tier_review_my_payment_request"},
+                "required_provider": "construction.approval_workbench_provider.v1",
+                "fallback_policy": {"type": "native_action_compat"},
+                "acceptance": {"runtime_ready": True, "workflow_ready": True, "advisory_only": True},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+        handoff = bridged.get("runtime_handoff_surface") or {}
+
+        self.assertEqual(handoff.get("family"), "payment_approval")
+        self.assertEqual(handoff.get("consume_mode"), "advisory")
+        self.assertTrue(handoff.get("runtime_ready"))
+        self.assertTrue(handoff.get("advisory_only"))
+
+    def test_bridge_builds_product_delivery_surface_for_direct_family(self):
+        payload = {
+            "scene": {"key": "projects.list"},
+            "delivery_handoff_v1": {
+                "family": "projects",
+                "runtime_entry_type": "governed_user_flow",
+                "runtime_consumer": "family_runtime_consumer",
+                "runtime_mode": "direct",
+                "user_entry": "menu:smart_construction_core.menu_sc_root",
+                "final_scene": "projects.list",
+                "primary_action": {"action_xmlid": "smart_construction_core.action_sc_project_list"},
+                "required_provider": "construction.projects_ledger_provider.v1|construction.projects_detail_provider.v1",
+                "fallback_policy": {"type": "native_action_compat"},
+                "acceptance": {"runtime_ready": True, "workflow_ready": True, "advisory_only": True},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+        delivery = bridged.get("product_delivery_surface") or {}
+
+        self.assertEqual(delivery.get("family"), "projects")
+        self.assertEqual(delivery.get("delivery_mode"), "direct_delivery")
+        self.assertEqual(delivery.get("entry_kind"), "primary_action")
+        self.assertEqual(delivery.get("final_scene"), "projects.list")
+        self.assertFalse(((delivery.get("advisory") or {}).get("enabled")))
+
+    def test_bridge_builds_product_delivery_surface_for_advisory_family(self):
+        payload = {
+            "scene": {"key": "payments.approval"},
+            "delivery_handoff_v1": {
+                "family": "payment_approval",
+                "runtime_entry_type": "governed_user_flow",
+                "runtime_consumer": "family_runtime_consumer",
+                "runtime_mode": "direct",
+                "user_entry": "menu:smart_construction_core.menu_sc_tier_review_my_payment_request",
+                "final_scene": "payments.approval",
+                "primary_action": {"action_xmlid": "smart_construction_core.action_sc_tier_review_my_payment_request"},
+                "required_provider": "construction.approval_workbench_provider.v1",
+                "fallback_policy": {"type": "native_action_compat"},
+                "acceptance": {"runtime_ready": True, "workflow_ready": True, "advisory_only": True},
+            },
+        }
+
+        bridged = bridge_module.apply_scene_ready_semantic_orchestration_bridge(payload)
+        delivery = bridged.get("product_delivery_surface") or {}
+
+        self.assertEqual(delivery.get("family"), "payment_approval")
+        self.assertEqual(delivery.get("delivery_mode"), "advisory_only")
+        self.assertTrue(((delivery.get("advisory") or {}).get("enabled")))
+        self.assertEqual(((delivery.get("acceptance") or {}).get("advisory_only")), True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_core/tests/test_scene_runtime_contract_chain.py
+++ b/addons/smart_core/tests/test_scene_runtime_contract_chain.py
@@ -76,18 +76,40 @@ class TestSceneRuntimeContractChain(TransactionCase):
                     "name": "项目列表",
                     "layout": {"kind": "list"},
                     "target": {"route": "/s/projects.list", "model": "project.project"},
+                    "related_scenes": ["projects.ledger"],
+                    "ui_base_contract": _sample_ui_base_contract(),
+                },
+                {
+                    "code": "projects.ledger",
+                    "name": "项目台账",
+                    "layout": {"kind": "ledger"},
+                    "target": {"route": "/s/projects.ledger", "model": "project.project"},
                     "ui_base_contract": _sample_ui_base_contract(),
                 }
             ],
             role_surface={"landing_scene_key": "projects.list"},
         )
         entries = contract.get("scenes") or []
-        self.assertEqual(len(entries), 1)
-        row = entries[0]
+        self.assertEqual(len(entries), 2)
+        row = next(
+            (
+                item
+                for item in entries
+                if ((item.get("scene") or {}).get("key")) == "projects.list"
+            ),
+            {},
+        )
+        switch_surface = row.get("switch_surface") or {}
+        switch_items = switch_surface.get("items") or []
         self.assertTrue((row.get("search_surface") or {}).get("filters"))
         self.assertTrue((row.get("permission_surface") or {}).get("allowed"))
         self.assertTrue((row.get("action_surface") or {}).get("counts"))
         self.assertTrue(((row.get("meta") or {}).get("ui_base_orchestrator_input") or {}).get("view_fact"))
+        self.assertEqual(((row.get("view_modes") or [])[0] or {}).get("key"), "tree")
+        self.assertEqual(((row.get("action_surface") or {}).get("selection_mode")), "multi")
+        self.assertEqual(((switch_items[0] or {}).get("label")), "项目列表")
+        self.assertEqual(((switch_items[1] or {}).get("key")), "projects.ledger")
+        self.assertEqual(((switch_items[1] or {}).get("route")), "/s/projects.ledger")
 
     def test_scene_ready_form_runtime_chain(self):
         contract = build_scene_ready_contract_v1(
@@ -109,6 +131,8 @@ class TestSceneRuntimeContractChain(TransactionCase):
         workflow_surface = row.get("workflow_surface") or {}
         self.assertIn("name", validation_surface.get("required_fields") or [])
         self.assertEqual(workflow_surface.get("state_field"), "state")
+        self.assertEqual(((row.get("view_modes") or [])[0] or {}).get("key"), "form")
+        self.assertEqual(((row.get("action_surface") or {}).get("selection_mode")), "single")
         self.assertEqual(row.get("next_scene"), "project.management")
         self.assertEqual(row.get("next_scene_route"), "/s/project.management")
 

--- a/addons/smart_core/utils/contract_governance.py
+++ b/addons/smart_core/utils/contract_governance.py
@@ -119,6 +119,16 @@ _PROJECT_FORM_PRIMARY_FIELDS = [
     "budget_total",
     "location",
 ]
+_PROJECT_FORM_PAGE_PRESERVE_FIELDS = {
+    "access_instruction_message",
+    "alias_id",
+    "alias_email",
+    "alias_name",
+    "alias_domain_id",
+    "alias_contact",
+    "task_ids",
+    "collaborator_ids",
+}
 _PROJECT_FORM_CREATE_HIDDEN_FIELDS = {
     "project_code",
     "code",
@@ -141,6 +151,62 @@ _PROJECT_FORM_ACTION_DEMOTE_KEYWORDS = {
     "ir_cron",
     "演示",
     "showcase",
+}
+_ENTERPRISE_COMPANY_FORM_FIELDS = [
+    "name",
+    "sc_short_name",
+    "sc_credit_code",
+    "sc_contact_phone",
+    "sc_address",
+    "sc_is_active",
+]
+_ENTERPRISE_COMPANY_FIELD_LABELS = {
+    "name": "公司名称",
+    "sc_short_name": "公司简称",
+    "sc_credit_code": "统一社会信用代码",
+    "sc_contact_phone": "联系电话",
+    "sc_address": "地址",
+    "sc_is_active": "启用",
+}
+_ENTERPRISE_DEPARTMENT_FORM_FIELDS = [
+    "name",
+    "parent_id",
+    "sc_manager_user_id",
+    "company_id",
+    "sc_is_active",
+]
+_ENTERPRISE_DEPARTMENT_FIELD_LABELS = {
+    "name": "部门名称",
+    "parent_id": "上级部门",
+    "sc_manager_user_id": "部门负责人",
+    "company_id": "所属公司",
+    "sc_is_active": "启用",
+}
+_ENTERPRISE_USER_FORM_FIELDS = [
+    "name",
+    "login",
+    "password",
+    "phone",
+    "active",
+    "company_id",
+    "sc_department_id",
+    "sc_manager_user_id",
+    "sc_role_profile",
+    "sc_role_effective",
+    "sc_role_landing_label",
+]
+_ENTERPRISE_USER_FIELD_LABELS = {
+    "name": "姓名",
+    "login": "登录账号",
+    "password": "初始密码",
+    "phone": "手机号",
+    "active": "启用",
+    "company_id": "所属公司",
+    "sc_department_id": "所属部门",
+    "sc_manager_user_id": "直属上级",
+    "sc_role_profile": "产品角色",
+    "sc_role_effective": "当前生效角色",
+    "sc_role_landing_label": "默认首页",
 }
 _PROJECT_FORM_ACTION_PRIORITIES = (
     "提交",
@@ -171,6 +237,62 @@ _PROJECT_KANBAN_STATUS_FIELDS = [
     "lifecycle_state",
     "stage_id",
 ]
+_PROJECT_TASK_FORM_FIELDS = [
+    "name",
+    "project_id",
+    "stage_id",
+    "sc_state",
+    "user_ids",
+    "date_deadline",
+    "priority",
+    "description",
+]
+_PROJECT_TASK_FIELD_LABELS = {
+    "name": "任务名称",
+    "project_id": "所属项目",
+    "stage_id": "当前阶段",
+    "sc_state": "执行状态",
+    "user_ids": "执行人",
+    "date_deadline": "截止日期",
+    "priority": "优先级",
+    "description": "执行说明",
+}
+_PROJECT_LIST_COLUMNS = [
+    "name",
+    "user_id",
+    "partner_id",
+    "stage_id",
+    "lifecycle_state",
+    "date_start",
+    "date",
+]
+_PROJECT_LIST_COLUMN_LABELS = {
+    "name": "项目名称",
+    "user_id": "项目经理",
+    "partner_id": "业主单位",
+    "stage_id": "当前阶段",
+    "lifecycle_state": "项目执行阶段",
+    "date_start": "开始日期",
+    "date": "结束日期",
+}
+_PROJECT_TASK_LIST_COLUMNS = [
+    "name",
+    "project_id",
+    "user_ids",
+    "stage_id",
+    "sc_state",
+    "date_deadline",
+    "priority",
+]
+_PROJECT_TASK_LIST_COLUMN_LABELS = {
+    "name": "任务名称",
+    "project_id": "所属项目",
+    "user_ids": "执行人",
+    "stage_id": "当前阶段",
+    "sc_state": "执行状态",
+    "date_deadline": "截止日期",
+    "priority": "优先级",
+}
 _USER_SURFACE_ACTION_GROUP_LABELS = {
     "basic": "基础操作",
     "workflow": "流程推进",
@@ -216,6 +338,28 @@ _FORM_ACTION_READONLY_KEYWORDS = (
     "open",
     "view",
 )
+
+
+def _inject_enterprise_form_governance(data: dict, *, next_action_key: str = "", next_action_label: str = "") -> None:
+    governance = _as_dict(data.get("form_governance"))
+    governance.update(
+        {
+            "surface": "enterprise_enablement",
+            "hide_workflow": True,
+            "hide_search_filters": True,
+            "hide_body_actions": True,
+            "suppress_contract_header_actions": True,
+        }
+    )
+    if _safe_text(next_action_key) and _safe_text(next_action_label):
+        governance["next_action"] = {
+            "step_key": _safe_text(next_action_key),
+            "label": _safe_text(next_action_label),
+        }
+    else:
+        governance.pop("next_action", None)
+    data["form_governance"] = governance
+
 _FORM_PRIMARY_DISABLED_REASON = "请先完成必填字段后再执行主操作"
 _FORM_DISABLED_REASON_CAPABILITY = "缺少执行该操作所需能力"
 
@@ -719,9 +863,32 @@ def _apply_user_surface_policies(data: dict) -> None:
     model = _safe_text(head.get("model") or data.get("model"))
     filters_primary_max = _USER_SURFACE_PRIMARY_FILTER_MAX
     actions_primary_max = _USER_SURFACE_PRIMARY_ACTION_MAX
+    record_open_policy = {
+        "carry_query_mode": "preserve",
+    }
+    batch_policy = {
+        "enabled": False,
+        "delete_allowed": False,
+        "delete_only_mode": False,
+        "available_actions": [],
+    }
     if view_type in {"form"}:
         filters_primary_max = 0
         actions_primary_max = 3
+    if view_type in {"tree", "list"}:
+        delete_allowed = model not in {"project.project"}
+        delete_only_mode = model in {"project.task", "res.company", "hr.department", "res.users"}
+        available_actions = ["delete"] if delete_only_mode else ["archive", "activate", "delete"]
+        if model in {"project.project"}:
+            record_open_policy = {
+                "carry_query_mode": "clear_scene_context",
+            }
+        batch_policy = {
+            "enabled": True,
+            "delete_allowed": delete_allowed,
+            "delete_only_mode": delete_only_mode,
+            "available_actions": available_actions if delete_allowed else ["archive", "activate"],
+        }
     primary_model = _governance_primary_model(data)
     if model and primary_model and model == primary_model:
         filters_primary_max = min(filters_primary_max, 4)
@@ -731,6 +898,9 @@ def _apply_user_surface_policies(data: dict) -> None:
         "actions_primary_max": actions_primary_max,
         "filters_max": _USER_SURFACE_FILTER_MAX,
         "actions_max": _USER_SURFACE_ACTION_MAX,
+        "delete_mode": "unlink" if bool(batch_policy.get("delete_allowed")) else "none",
+        "batch_policy": batch_policy,
+        "record_open_policy": record_open_policy,
     }
 
 
@@ -817,11 +987,49 @@ def _is_project_form_contract(data: dict) -> bool:
     if not view_type and has_form_view:
         view_type = "form"
     primary_model = _governance_primary_model(data)
+    if primary_model != "project.project":
+        return False
     if not primary_model or model != primary_model:
         return False
     if has_form_view:
         return "form" in view_type if view_type else True
     return view_type == "form"
+
+
+def _is_enterprise_company_form_contract(data: dict) -> bool:
+    head = _as_dict(data.get("head"))
+    views = _as_dict(data.get("views"))
+    form_view = _as_dict(views.get("form"))
+    permissions = _as_dict(data.get("permissions"))
+    model = _safe_text(
+        head.get("model")
+        or data.get("model")
+        or form_view.get("model")
+        or permissions.get("model")
+    )
+    view_type = _safe_text(head.get("view_type") or data.get("view_type")).lower()
+    if not view_type and isinstance(views.get("form"), dict):
+        view_type = "form"
+    primary_model = _governance_primary_model(data)
+    return bool(primary_model == "res.company" and model == "res.company" and "form" in view_type)
+
+
+def _is_enterprise_user_form_contract(data: dict) -> bool:
+    head = _as_dict(data.get("head"))
+    views = _as_dict(data.get("views"))
+    form_view = _as_dict(views.get("form"))
+    permissions = _as_dict(data.get("permissions"))
+    model = _safe_text(
+        head.get("model")
+        or data.get("model")
+        or form_view.get("model")
+        or permissions.get("model")
+    )
+    view_type = _safe_text(head.get("view_type") or data.get("view_type")).lower()
+    if not view_type and isinstance(views.get("form"), dict):
+        view_type = "form"
+    primary_model = _governance_primary_model(data)
+    return bool(primary_model == "res.users" and model == "res.users" and "form" in view_type)
 
 
 def _is_project_kanban_contract(data: dict) -> bool:
@@ -835,11 +1043,55 @@ def _is_project_kanban_contract(data: dict) -> bool:
         or kanban_view.get("model")
         or permissions.get("model")
     )
-    view_type = _safe_text(head.get("view_type") or data.get("view_type")).lower()
+    current_view_type = _safe_text(data.get("view_type")).lower()
+    if current_view_type and current_view_type != "kanban":
+        return False
+    render_profile = _safe_text(data.get("render_profile")).lower()
+    if render_profile in {_RENDER_PROFILE_CREATE, _RENDER_PROFILE_EDIT, _RENDER_PROFILE_READONLY}:
+        return False
+    if _safe_text(data.get("record_id") or data.get("res_id")) and isinstance(views.get("form"), dict):
+        return False
+    view_type = _safe_text(current_view_type or head.get("view_type")).lower()
     if not view_type and isinstance(views.get("kanban"), dict):
         view_type = "kanban"
     primary_model = _governance_primary_model(data)
     return bool(primary_model and model == primary_model and "kanban" in view_type)
+
+
+def _is_project_task_form_contract(data: dict) -> bool:
+    head = _as_dict(data.get("head"))
+    views = _as_dict(data.get("views"))
+    form_view = _as_dict(views.get("form"))
+    permissions = _as_dict(data.get("permissions"))
+    model = _safe_text(
+        head.get("model")
+        or data.get("model")
+        or form_view.get("model")
+        or permissions.get("model")
+    )
+    view_type = _safe_text(head.get("view_type") or data.get("view_type")).lower()
+    if not view_type and isinstance(views.get("form"), dict):
+        view_type = "form"
+    primary_model = _governance_primary_model(data)
+    return bool(primary_model == "project.task" and model == "project.task" and "form" in view_type)
+
+
+def _is_model_tree_contract(data: dict, model_name: str) -> bool:
+    head = _as_dict(data.get("head"))
+    views = _as_dict(data.get("views"))
+    tree_view = _as_dict(views.get("tree") or views.get("list"))
+    permissions = _as_dict(data.get("permissions"))
+    model = _safe_text(
+        head.get("model")
+        or data.get("model")
+        or tree_view.get("model")
+        or permissions.get("model")
+    )
+    view_type = _safe_text(head.get("view_type") or data.get("view_type")).lower()
+    if not view_type and isinstance(views.get("tree"), dict):
+        view_type = "tree"
+    primary_model = _governance_primary_model(data)
+    return bool(primary_model == model_name and model == model_name and "tree" in view_type)
 
 
 def _is_form_contract(data: dict) -> bool:
@@ -855,6 +1107,8 @@ def _is_technical_field(name: str, descriptor: dict) -> bool:
     low = _safe_lower(name)
     if not low:
         return True
+    if low in _PROJECT_FORM_PAGE_PRESERVE_FIELDS:
+        return False
     if low in {"id", "__last_update", "display_name"}:
         return True
     if low.startswith(("create_", "write_", "message_", "activity_", "access_", "alias_", "website_")):
@@ -881,10 +1135,41 @@ def _pick_project_form_fields(data: dict) -> list[str]:
         return []
     ordered_fields = _iter_field_order(data)
 
+    def _collect_page_fields(nodes: list, current_page: str = "", out: list[str] | None = None) -> list[str]:
+        collected = out or []
+        for node in nodes:
+            if not isinstance(node, dict):
+                continue
+            node_type = _safe_lower(node.get("type") or node.get("kind"))
+            page_name = current_page
+            if node_type == "page":
+                page_name = _safe_text(node.get("name") or node.get("label") or node.get("string"))
+            if node_type == "field" and page_name:
+                name = _safe_text(node.get("name"))
+                descriptor = _as_dict(fields_map.get(name))
+                if name and descriptor and not _is_technical_field(name, descriptor) and name not in collected:
+                    collected.append(name)
+            for key in ("children", "tabs", "pages", "nodes", "items"):
+                candidate = node.get(key)
+                if isinstance(candidate, list):
+                    _collect_page_fields(candidate, page_name, collected)
+        return collected
+
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    layout = form.get("layout")
+    page_fields = _collect_page_fields(layout if isinstance(layout, list) else [])
+
     selected: list[str] = []
     for name in _PROJECT_FORM_PRIMARY_FIELDS:
         descriptor = _as_dict(fields_map.get(name))
         if descriptor and not _is_technical_field(name, descriptor) and name not in selected:
+            selected.append(name)
+
+    for name in page_fields:
+        if len(selected) >= _PROJECT_FORM_FIELD_MAX:
+            break
+        if name not in selected:
             selected.append(name)
 
     for name in ordered_fields:
@@ -989,58 +1274,10 @@ def _restructure_project_form_layout(data: dict) -> None:
     layout = form.get("layout")
     if not isinstance(layout, list):
         return
-
-    fields_map = _as_dict(data.get("fields"))
-    field_names = [name for name in fields_map.keys() if _safe_text(name)]
-    visible_fields = data.get("visible_fields") if isinstance(data.get("visible_fields"), list) else []
-    ordered = [str(name).strip() for name in visible_fields if str(name).strip() in fields_map]
-    if not ordered:
-        ordered = field_names
-
-    profile = _as_dict(data.get("form_profile"))
-    core_raw = profile.get("core_fields") if isinstance(profile.get("core_fields"), list) else []
-    advanced_raw = profile.get("advanced_fields") if isinstance(profile.get("advanced_fields"), list) else []
-    core_fields = [str(name).strip() for name in core_raw if str(name).strip() in ordered]
-    advanced_fields = [str(name).strip() for name in advanced_raw if str(name).strip() in ordered]
-    if not core_fields:
-        core_fields = ordered[: min(8, len(ordered))]
-    if not advanced_fields:
-        advanced_fields = [name for name in ordered if name not in set(core_fields)]
-
-    header_nodes = [
-        node
-        for node in layout
-        if isinstance(node, dict) and _safe_lower(node.get("type")) == "header"
-    ]
-    groups = []
-    if core_fields:
-        groups.append(
-            {
-                "type": "group",
-                "name": "core_group",
-                "string": "核心信息",
-                "children": [{"type": "field", "name": name} for name in core_fields],
-            }
-        )
-    if advanced_fields:
-        groups.append(
-            {
-                "type": "group",
-                "name": "advanced_group",
-                "string": "高级信息",
-                "children": [{"type": "field", "name": name} for name in advanced_fields],
-            }
-        )
-    if not groups:
-        return
-
-    form["layout"] = header_nodes + [
-        {
-            "type": "sheet",
-            "name": "project_form_sheet",
-            "children": groups,
-        }
-    ]
+    # Keep parser-native container hierarchy intact. Downstream user governance will
+    # prune fields from this tree, but it should not replace notebook/page/group with
+    # synthetic buckets because frontend detail rendering depends on the native shape.
+    form["layout"] = layout
     views["form"] = form
     data["views"] = views
 
@@ -1084,14 +1321,19 @@ def _filter_project_form_layout(data: dict, selected_fields: list[str]) -> None:
                     cleaned.append(node)
                 continue
             copied = dict(node)
-            keep_node = True
+            structured_children_present = False
             for key in ("children", "tabs", "pages", "nodes", "items"):
                 raw_children = node.get(key)
                 if not isinstance(raw_children, list):
                     continue
                 pruned_children = _prune_layout(raw_children, allowed)
                 copied[key] = pruned_children
-                if node_type in {"group", "page", "notebook", "sheet", "header"} and not pruned_children and key in {"children", "tabs", "pages"}:
+                if key in {"children", "tabs", "pages"} and pruned_children:
+                    structured_children_present = True
+            keep_node = True
+            if node_type in {"group", "page", "notebook", "sheet", "header"}:
+                has_structured_key = any(isinstance(node.get(key), list) for key in ("children", "tabs", "pages"))
+                if has_structured_key and not structured_children_present:
                     keep_node = False
             if keep_node:
                 cleaned.append(copied)
@@ -1115,59 +1357,7 @@ def _filter_project_form_layout(data: dict, selected_fields: list[str]) -> None:
     missing_selected = [name for name in selected_order if name and name not in existing_set]
     for name in missing_selected:
         filtered_layout.append({"type": "field", "name": name})
-    form_profile = _as_dict(data.get("form_profile"))
-    core_raw = form_profile.get("core_fields")
-    advanced_raw = form_profile.get("advanced_fields")
-    core_fields = [
-        _safe_text(name)
-        for name in (core_raw if isinstance(core_raw, list) else [])
-        if _safe_text(name) in selected_set
-    ]
-    advanced_fields = [
-        _safe_text(name)
-        for name in (advanced_raw if isinstance(advanced_raw, list) else [])
-        if _safe_text(name) in selected_set
-    ]
-    field_order = [name for name in selected_order if name in selected_set]
-    if not core_fields and field_order:
-        core_fields = field_order[: min(8, len(field_order))]
-    if not advanced_fields:
-        advanced_fields = [name for name in field_order if name not in set(core_fields)]
-
-    header_nodes: list[dict] = []
-    for node in filtered_layout:
-        if isinstance(node, dict) and _safe_lower(node.get("type")) == "header":
-            header_nodes.append(node)
-
-    grouped_children: list[dict] = []
-    if core_fields:
-        grouped_children.append(
-            {
-                "type": "group",
-                "name": "core_group",
-                "string": "核心信息",
-                "children": [{"type": "field", "name": name} for name in core_fields],
-            }
-        )
-    if advanced_fields:
-        grouped_children.append(
-            {
-                "type": "group",
-                "name": "advanced_group",
-                "string": "高级信息",
-                "children": [{"type": "field", "name": name} for name in advanced_fields],
-            }
-        )
-
-    if grouped_children:
-        sheet_node = {
-            "type": "sheet",
-            "name": "project_form_sheet",
-            "children": grouped_children,
-        }
-        form["layout"] = header_nodes + [sheet_node]
-    else:
-        form["layout"] = filtered_layout
+    form["layout"] = filtered_layout
     views["form"] = form
     data["views"] = views
 
@@ -1257,6 +1447,18 @@ def _build_project_action_groups(rows: list[dict]) -> list[dict]:
     return result
 
 
+def _emit_scene_action_semantics(data: dict, *, header_rows: list[dict], record_rows: list[dict]) -> None:
+    semantic_page = _as_dict(data.get("semantic_page"))
+    actions = _as_dict(semantic_page.get("actions"))
+    actions["header_actions"] = [dict(row) for row in header_rows if isinstance(row, dict)]
+    actions["record_actions"] = [dict(row) for row in record_rows if isinstance(row, dict)]
+    actions.setdefault("toolbar_actions", [])
+    actions["owner_layer"] = "scene_orchestration"
+    actions["source"] = "contract_governance.curated_action_facts"
+    semantic_page["actions"] = actions
+    data["semantic_page"] = semantic_page
+
+
 def _govern_project_form_actions(data: dict) -> None:
     toolbar = _as_dict(data.get("toolbar"))
     if isinstance(toolbar.get("header"), list):
@@ -1283,6 +1485,11 @@ def _govern_project_form_actions(data: dict) -> None:
     smart_rows = sorted(smart_rows, key=lambda item: (_action_priority(item), _safe_text(item.get("label"))))
     curated = header_rows[:_PROJECT_FORM_HEADER_ACTION_MAX] + smart_rows[:_PROJECT_FORM_SMART_ACTION_MAX]
     data["buttons"] = curated
+    _emit_scene_action_semantics(
+        data,
+        header_rows=header_rows[:_PROJECT_FORM_HEADER_ACTION_MAX],
+        record_rows=smart_rows[:_PROJECT_FORM_SMART_ACTION_MAX],
+    )
     data["action_groups"] = _build_project_action_groups(curated)
 
 
@@ -1326,20 +1533,31 @@ def _build_project_lifecycle_summary(data: dict) -> None:
         "blockers": [],
         "progress_percent": 0 if state_keys else None,
     }
+    data["workflow_surface"] = {
+        "owner_layer": "business_fact",
+        "source": "contract_governance.workflow_facts",
+        "state_field": _safe_text(workflow.get("state_field"), "stage_id"),
+        "states": state_keys,
+        "transitions": transitions[:8],
+        "highlight_states": workflow.get("highlight_states") if isinstance(workflow.get("highlight_states"), list) else [],
+    }
 
 
 def _govern_project_form_contract_for_user(data: dict) -> None:
     selected = _pick_project_form_fields(data)
-    selected_set = set(selected)
     fields_map = _as_dict(data.get("fields"))
-    data["fields"] = {name: fields_map.get(name) for name in selected if name in fields_map}
+    # Keep full field map for native form-structure fidelity. Restricting fields to
+    # selected subset can prune page containers indirectly in user surface.
+    data["fields"] = fields_map
     data["visible_fields"] = selected
+    _backfill_form_layout_from_visible_fields(data)
     data["form_profile"] = {
         "core_fields": selected[:8],
         "advanced_fields": selected[8:],
         "max_fields": _PROJECT_FORM_FIELD_MAX,
     }
-    _filter_project_form_layout(data, selected)
+    # Keep parser-native notebook/page tree intact for project form alignment.
+    # Do not prune form layout by selected fields in user mode.
     views = _as_dict(data.get("views"))
     form = _as_dict(views.get("form"))
     form["form_profile"] = _as_dict(data.get("form_profile"))
@@ -1349,13 +1567,125 @@ def _govern_project_form_contract_for_user(data: dict) -> None:
     permissions = _as_dict(data.get("permissions"))
     field_groups = _as_dict(permissions.get("field_groups"))
     if field_groups:
-        permissions["field_groups"] = {name: val for name, val in field_groups.items() if name in selected_set}
+        permissions["field_groups"] = field_groups
     data["permissions"] = permissions
 
     _govern_project_form_actions(data)
     _govern_project_form_search(data)
     _build_project_lifecycle_summary(data)
     _realign_access_policy_with_visible_fields(data)
+
+
+def _govern_project_task_form_for_user(data: dict) -> None:
+    if not _is_project_task_form_contract(data):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    selected = [name for name in _PROJECT_TASK_FORM_FIELDS if name in fields_map]
+    if not selected:
+        return
+
+    data["visible_fields"] = selected
+    data["field_groups"] = [
+        {
+            "name": "core",
+            "label": "任务基础信息",
+            "priority": 1,
+            "collapsible": False,
+            "fields": [name for name in selected if name != "description"],
+        },
+        {
+            "name": "advanced",
+            "label": "任务说明",
+            "priority": 2,
+            "collapsible": True,
+            "fields": [name for name in selected if name == "description"],
+        },
+    ]
+
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    form["layout"] = [
+        {
+            "type": "sheet",
+            "name": "project_task_form_sheet",
+            "children": [
+                {
+                    "type": "group",
+                    "name": "project_task_core_group",
+                    "string": "任务基础信息",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _PROJECT_TASK_FIELD_LABELS)
+                        for name in selected
+                        if name != "description"
+                    ],
+                },
+                {
+                    "type": "group",
+                    "name": "project_task_description_group",
+                    "string": "任务说明",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _PROJECT_TASK_FIELD_LABELS)
+                        for name in selected
+                        if name == "description"
+                    ],
+                },
+            ],
+        }
+    ]
+    views["form"] = form
+    data["views"] = views
+
+
+def _govern_standard_list_for_user(
+    data: dict,
+    *,
+    model_name: str,
+    columns_order: list[str],
+    column_labels: dict[str, str],
+    row_primary: str,
+    row_secondary: str,
+    status_field: str,
+) -> None:
+    if not _is_model_tree_contract(data, model_name):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    selected = [name for name in columns_order if name in fields_map]
+    if not selected:
+        return
+
+    views = _as_dict(data.get("views"))
+    tree = _as_dict(views.get("tree") or views.get("list"))
+    tree["columns"] = selected
+    views["tree"] = tree
+    data["views"] = views
+
+    list_profile = _as_dict(data.get("list_profile"))
+    list_profile.update(
+        {
+            "columns": selected,
+            "hidden_columns": [],
+            "column_labels": {name: column_labels.get(name, name) for name in selected},
+            "row_primary": row_primary,
+            "row_secondary": row_secondary,
+            "primary_field": row_primary,
+            "status_field": status_field,
+        }
+    )
+    data["list_profile"] = list_profile
+
+    semantic_page = _as_dict(data.get("semantic_page"))
+    list_semantics = _as_dict(semantic_page.get("list_semantics"))
+    list_semantics["owner_layer"] = "scene_orchestration"
+    list_semantics["source"] = "contract_governance.curated_list_facts"
+    list_semantics["columns"] = [
+        {"name": name, "label": column_labels.get(name, name)}
+        for name in selected
+    ]
+    list_semantics["row_primary"] = row_primary
+    list_semantics["row_secondary"] = row_secondary
+    list_semantics["status_field"] = status_field
+    semantic_page["list_semantics"] = list_semantics
+    data["semantic_page"] = semantic_page
 
 
 def _realign_access_policy_with_visible_fields(data: dict) -> None:
@@ -1430,6 +1760,306 @@ def _realign_access_policy_with_visible_fields(data: dict) -> None:
         data["warnings"] = warnings
     else:
         data.pop("warnings", None)
+
+
+def _normalize_native_view_contract_surface(data: dict) -> None:
+    parser_contract = _as_dict(data.get("parser_contract"))
+    if parser_contract:
+        parser_contract.setdefault("layout", _as_dict(parser_contract.get("layout")))
+        contract_version = _safe_text(data.get("contract_version")) or "native_view.v1"
+        parser_contract.setdefault("contract_version", contract_version)
+        data["parser_contract"] = parser_contract
+
+    view_semantics = _as_dict(data.get("view_semantics"))
+    if view_semantics:
+        view_semantics.setdefault("kind", "view_semantics")
+        view_semantics["capability_flags"] = _as_dict(view_semantics.get("capability_flags"))
+        view_semantics["semantic_meta"] = _as_dict(view_semantics.get("semantic_meta"))
+        data["view_semantics"] = view_semantics
+
+    native_view = _as_dict(data.get("native_view"))
+    if native_view:
+        native_view["views"] = _as_dict(native_view.get("views"))
+        native_view["search"] = _as_dict(native_view.get("search"))
+        native_view["toolbar"] = _as_dict(native_view.get("toolbar"))
+        data["native_view"] = native_view
+
+
+def _normalize_scene_semantic_surface(data: dict) -> None:
+    def _normalize_page_surface(page_payload: dict) -> dict:
+        page = _as_dict(page_payload)
+        surface = _as_dict(page.get("surface"))
+        if surface:
+            surface["semantic_view"] = _as_dict(surface.get("semantic_view"))
+            surface["semantic_page"] = _as_dict(surface.get("semantic_page"))
+            page["surface"] = surface
+        return page
+
+    def _normalize_parser_semantic_surface(surface_payload: dict) -> dict:
+        surface = _as_dict(surface_payload)
+        if not surface:
+            return {}
+        parser_contract = _as_dict(surface.get("parser_contract"))
+        if parser_contract:
+            parser_contract.setdefault("layout", _as_dict(parser_contract.get("layout")))
+            parser_contract.setdefault(
+                "contract_version",
+                _safe_text(data.get("contract_version")) or "native_view.v1",
+            )
+            surface["parser_contract"] = parser_contract
+        view_semantics = _as_dict(surface.get("view_semantics"))
+        if view_semantics:
+            view_semantics.setdefault("kind", "view_semantics")
+            view_semantics["capability_flags"] = _as_dict(view_semantics.get("capability_flags"))
+            view_semantics["semantic_meta"] = _as_dict(view_semantics.get("semantic_meta"))
+            surface["view_semantics"] = view_semantics
+        native_view = _as_dict(surface.get("native_view"))
+        if native_view:
+            native_view["views"] = _as_dict(native_view.get("views"))
+            native_view["search"] = _as_dict(native_view.get("search"))
+            native_view["toolbar"] = _as_dict(native_view.get("toolbar"))
+            surface["native_view"] = native_view
+        semantic_page = _as_dict(surface.get("semantic_page"))
+        if semantic_page:
+            surface["semantic_page"] = semantic_page
+        return surface
+
+    scene_contract_standard = _as_dict(data.get("scene_contract_standard_v1"))
+    if scene_contract_standard:
+        scene_contract_standard["page"] = _normalize_page_surface(scene_contract_standard.get("page"))
+        governance = _as_dict(scene_contract_standard.get("governance"))
+        parser_surface = _normalize_parser_semantic_surface(governance.get("parser_semantic_surface"))
+        if parser_surface:
+            governance["parser_semantic_surface"] = parser_surface
+        scene_contract_standard["governance"] = governance
+        data["scene_contract_standard_v1"] = scene_contract_standard
+
+    scene_contract_v1 = _as_dict(data.get("scene_contract_v1"))
+    if scene_contract_v1:
+        scene_contract_v1["page"] = _normalize_page_surface(scene_contract_v1.get("page"))
+        diagnostics = _as_dict(scene_contract_v1.get("diagnostics"))
+        parser_surface = _normalize_parser_semantic_surface(diagnostics.get("parser_semantic_surface"))
+        if parser_surface:
+            diagnostics["parser_semantic_surface"] = parser_surface
+        scene_contract_v1["diagnostics"] = diagnostics
+        data["scene_contract_v1"] = scene_contract_v1
+
+    semantic_runtime = _as_dict(data.get("semantic_runtime"))
+    if semantic_runtime:
+        semantic_runtime["semantic_view"] = _as_dict(semantic_runtime.get("semantic_view"))
+        semantic_runtime["semantic_page"] = _as_dict(semantic_runtime.get("semantic_page"))
+        parser_surface = _normalize_parser_semantic_surface(semantic_runtime.get("parser_semantic_surface"))
+        if parser_surface:
+            semantic_runtime["parser_semantic_surface"] = parser_surface
+        data["semantic_runtime"] = semantic_runtime
+
+    released_scene_surface = _as_dict(data.get("released_scene_semantic_surface"))
+    if released_scene_surface:
+        released_scene_surface["page_surface"] = _normalize_page_surface({"surface": released_scene_surface.get("page_surface")}).get("surface") or {}
+        parser_surface = _normalize_parser_semantic_surface(released_scene_surface.get("parser_semantic_surface"))
+        if parser_surface:
+            released_scene_surface["parser_semantic_surface"] = parser_surface
+        data["released_scene_semantic_surface"] = released_scene_surface
+
+
+def _search_surface_from_contract(data: dict) -> dict:
+    search = _as_dict(data.get("search"))
+    if not search:
+        return {}
+    surface: dict[str, Any] = {
+        "owner_layer": "scene_orchestration",
+        "source": "contract_governance.search_surface",
+    }
+    for source_key, target_key in (
+        ("filters", "filters"),
+        ("fields", "fields"),
+        ("group_by", "group_by"),
+        ("groupBy", "group_by"),
+        ("searchpanel", "searchpanel"),
+        ("search_panel", "searchpanel"),
+        ("searchPanel", "searchpanel"),
+        ("native_search_menu", "native_search_menu"),
+        ("nativeSearchMenu", "native_search_menu"),
+        ("default_state", "default_state"),
+    ):
+        value = search.get(source_key)
+        if isinstance(value, (list, dict)) and value:
+            surface[target_key] = _deep_clone_json_like(value)
+    interaction_model = _safe_text(search.get("interaction_model") or search.get("interactionModel"))
+    if interaction_model:
+        surface["interaction_model"] = interaction_model
+    default_sort = _safe_text(search.get("default_sort") or search.get("defaultSort") or data.get("default_sort"))
+    if default_sort:
+        surface["default_sort"] = default_sort
+    mode = _safe_text(search.get("mode"))
+    if mode:
+        surface["mode"] = mode
+    elif any(surface.get(key) for key in ("filters", "group_by", "searchpanel")):
+        surface["mode"] = "faceted"
+    return surface if len(surface) > 2 else {}
+
+
+def _scene_actions_from_contract(data: dict) -> dict:
+    semantic_page = _as_dict(data.get("semantic_page"))
+    semantic_actions = _as_dict(semantic_page.get("actions"))
+    out: dict[str, Any] = {}
+
+    header_actions = semantic_actions.get("header_actions")
+    record_actions = semantic_actions.get("record_actions")
+    toolbar_actions = semantic_actions.get("toolbar_actions")
+    if isinstance(header_actions, list) and header_actions:
+        out["primary_actions"] = _deep_clone_json_like(header_actions)
+    if isinstance(record_actions, list) and record_actions:
+        out["contextual_actions"] = _deep_clone_json_like(record_actions)
+    if isinstance(toolbar_actions, list) and toolbar_actions:
+        out["secondary_actions"] = _deep_clone_json_like(toolbar_actions)
+
+    if not out:
+        grouped_rows = data.get("action_groups")
+        if isinstance(grouped_rows, list):
+            for group in grouped_rows:
+                if not isinstance(group, dict):
+                    continue
+                key = _safe_lower(group.get("key"))
+                rows = group.get("actions")
+                if not isinstance(rows, list) or not rows:
+                    continue
+                if key in {"basic", "primary", "workflow"} and "primary_actions" not in out:
+                    out["primary_actions"] = _deep_clone_json_like(rows)
+                elif key in {"drilldown", "record", "contextual"} and "contextual_actions" not in out:
+                    out["contextual_actions"] = _deep_clone_json_like(rows)
+                elif "secondary_actions" not in out:
+                    out["secondary_actions"] = _deep_clone_json_like(rows)
+
+    if not out:
+        rows = data.get("buttons")
+        if isinstance(rows, list) and rows:
+            out["primary_actions"] = _deep_clone_json_like(rows[:_USER_SURFACE_ACTION_MAX])
+
+    if out:
+        out["owner_layer"] = "scene_orchestration"
+        out["source"] = "contract_governance.action_surface"
+    return out
+
+
+def _ensure_scene_contract_v1_envelope(data: dict) -> None:
+    semantic_page = _as_dict(data.get("semantic_page"))
+    list_profile = _as_dict(data.get("list_profile"))
+    if list_profile and not _as_dict(semantic_page.get("list_semantics")):
+        list_semantics = {
+            "owner_layer": "scene_orchestration",
+            "source": "contract_governance.list_profile_bridge",
+            "columns": [
+                {"name": _safe_text(name), "label": _safe_text((_as_dict(list_profile.get("column_labels"))).get(_safe_text(name)), _safe_text(name))}
+                for name in (list_profile.get("columns") if isinstance(list_profile.get("columns"), list) else [])
+                if _safe_text(name)
+            ],
+            "hidden_columns": [
+                _safe_text(name)
+                for name in (list_profile.get("hidden_columns") if isinstance(list_profile.get("hidden_columns"), list) else [])
+                if _safe_text(name)
+            ],
+            "row_primary": _safe_text(list_profile.get("row_primary")),
+            "row_secondary": _safe_text(list_profile.get("row_secondary")),
+            "status_field": _safe_text(list_profile.get("status_field")),
+        }
+        semantic_page["list_semantics"] = list_semantics
+
+    search_surface = _search_surface_from_contract(data)
+    actions = _scene_actions_from_contract(data)
+    if not semantic_page and not search_surface and not actions:
+        return
+
+    scene_contract = _as_dict(data.get("scene_contract_v1"))
+    scene_contract["contract_version"] = "v1"
+    scene_contract.setdefault("owner_layer", "scene_orchestration")
+    scene_contract.setdefault("source", "ui.contract.delivery_surface")
+    if semantic_page:
+        current_semantic_page = _as_dict(scene_contract.get("semantic_page"))
+        current_semantic_page.update(_deep_clone_json_like(semantic_page))
+        scene_contract["semantic_page"] = current_semantic_page
+    if search_surface and not _as_dict(scene_contract.get("search_surface")):
+        scene_contract["search_surface"] = search_surface
+    if actions:
+        current_actions = _as_dict(scene_contract.get("actions"))
+        for key, value in actions.items():
+            current_actions.setdefault(key, value)
+        scene_contract["actions"] = current_actions
+    diagnostics = _as_dict(scene_contract.get("diagnostics"))
+    diagnostics.setdefault("scene_contract_supply", "ui_contract_governance_bridge")
+    diagnostics.setdefault("scene_contract_supply_owner_layer", "scene_orchestration")
+    scene_contract["diagnostics"] = diagnostics
+    data["scene_contract_v1"] = scene_contract
+
+
+def _native_node_label(node: dict) -> str:
+    attributes = node.get("attributes") if isinstance(node.get("attributes"), dict) else {}
+    label = _safe_text(attributes.get("string") or node.get("string"))
+    translations = {
+        "description": "描述",
+        "settings": "设置",
+    }
+    return translations.get(label.strip().lower(), label)
+
+
+def _preserve_native_layout_labels(data: dict) -> None:
+    views = data.get("views") if isinstance(data.get("views"), dict) else {}
+    form = views.get("form") if isinstance(views.get("form"), dict) else {}
+    layout = form.get("layout")
+    if not isinstance(layout, list):
+        return
+
+    def visit(nodes):
+        for node in nodes or []:
+            if not isinstance(node, dict):
+                continue
+            if _safe_text(node.get("type")).lower() == "page":
+                label = _native_node_label(node)
+                if label:
+                    node["title"] = label
+                    node["label"] = label
+            for key in ("children", "tabs", "pages", "nodes", "items"):
+                nested = node.get(key)
+                if isinstance(nested, list):
+                    visit(nested)
+
+    visit(layout)
+    form["layout"] = layout
+    views["form"] = form
+    data["views"] = views
+
+
+def _emit_relation_entry_semantics(data: dict) -> None:
+    fields_map = data.get("fields") if isinstance(data.get("fields"), dict) else {}
+    entries: list[dict[str, Any]] = []
+    for field_name, descriptor_raw in fields_map.items():
+        descriptor = _as_dict(descriptor_raw)
+        relation_entry = _as_dict(descriptor.get("relation_entry"))
+        if not relation_entry:
+            continue
+        field = _safe_text(field_name)
+        if not field:
+            continue
+        entries.append(
+            {
+                "field": field,
+                "model": _safe_text(relation_entry.get("model") or descriptor.get("relation")),
+                "create_mode": _safe_text(relation_entry.get("create_mode"), "disabled"),
+                "can_read": bool(relation_entry.get("can_read", True)),
+                "can_create": bool(relation_entry.get("can_create", False)),
+                "reason_code": _safe_text(relation_entry.get("reason_code")),
+                "default_vals": _as_dict(relation_entry.get("default_vals")),
+                "action_id": relation_entry.get("action_id"),
+                "menu_id": relation_entry.get("menu_id"),
+                "source": _safe_text(relation_entry.get("source"), "field.relation_entry"),
+            }
+        )
+    if not entries:
+        return
+    semantic_page = _as_dict(data.get("semantic_page"))
+    semantic_page["relation_entries"] = entries
+    semantic_page["relation_entries_owner_layer"] = "scene_orchestration"
+    data["semantic_page"] = semantic_page
 
 
 def _to_bool(value: Any, fallback: bool = False) -> bool:
@@ -1568,6 +2198,12 @@ def _derive_form_core_fields(data: dict) -> list[str]:
 def _apply_form_field_groups(data: dict) -> None:
     if not _is_form_contract(data):
         return
+    existing_groups = data.get("field_groups") if isinstance(data.get("field_groups"), list) else []
+    if existing_groups and (
+        _is_enterprise_company_form_contract(data)
+        or _is_enterprise_user_form_contract(data)
+    ):
+        return
     fields_map = _as_dict(data.get("fields"))
     if not fields_map:
         return
@@ -1595,6 +2231,144 @@ def _apply_form_field_groups(data: dict) -> None:
             "fields": advanced_fields,
         },
     ]
+
+
+def _collect_layout_field_names(nodes: Any) -> list[str]:
+    ordered: list[str] = []
+
+    def _iter_children(node: dict) -> list[list]:
+        rows: list[list] = []
+        for key in ("children", "tabs", "pages", "nodes", "items"):
+            candidate = node.get(key)
+            if isinstance(candidate, list):
+                rows.append(candidate)
+        return rows
+
+    def _collect(items: list) -> None:
+        for node in items:
+            if not isinstance(node, dict):
+                continue
+            if _safe_lower(node.get("type")) == "field":
+                name = _safe_text(node.get("name"))
+                if name and name not in ordered:
+                    ordered.append(name)
+            for children in _iter_children(node):
+                _collect(children)
+
+    if isinstance(nodes, list):
+        _collect(nodes)
+    elif isinstance(nodes, dict):
+        _collect([nodes])
+    return ordered
+
+
+def _find_layout_sheet_node(nodes: Any) -> dict | None:
+    if isinstance(nodes, dict):
+        nodes = [nodes]
+    if not isinstance(nodes, list):
+        return None
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        if _safe_lower(node.get("type")) == "sheet":
+            return node
+        for key in ("children", "tabs", "pages", "nodes", "items"):
+            candidate = node.get(key)
+            if isinstance(candidate, list):
+                found = _find_layout_sheet_node(candidate)
+                if found:
+                    return found
+    return None
+
+
+def _backfill_form_layout_from_visible_fields(data: dict) -> None:
+    if not _is_form_contract(data):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    if not fields_map:
+        return
+    visible_fields = [
+        _safe_text(name)
+        for name in (data.get("visible_fields") or [])
+        if _safe_text(name) in fields_map
+    ]
+    if not visible_fields:
+        return
+
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    layout = form.get("layout")
+    if not isinstance(layout, list) or not layout:
+        return
+
+    existing = set(_collect_layout_field_names(layout))
+    missing = [
+        name
+        for name in visible_fields
+        if name not in existing and not _is_technical_field(name, _as_dict(fields_map.get(name)))
+    ]
+    if not missing:
+        return
+
+    backfill_group = {
+        "type": "group",
+        "name": "visible_fields_backfill_group",
+        "string": "补充业务信息",
+        "children": [
+            _make_labeled_field_node(name, fields_map)
+            for name in missing
+        ],
+    }
+
+    target = _find_layout_sheet_node(layout)
+    if target:
+        children = target.get("children")
+        if not isinstance(children, list):
+            children = []
+        children.append(backfill_group)
+        target["children"] = children
+    else:
+        layout.append(backfill_group)
+    form["layout"] = layout
+    views["form"] = form
+    data["views"] = views
+
+
+def _make_labeled_field_node(
+    name: str,
+    fields_map: dict[str, Any],
+    preferred_labels: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    descriptor = _as_dict(fields_map.get(name))
+    label = _safe_text((preferred_labels or {}).get(name), "")
+    if not label:
+        label = _safe_text(_ENTERPRISE_USER_FIELD_LABELS.get(name) or _ENTERPRISE_COMPANY_FIELD_LABELS.get(name), "")
+    if not label:
+        label = _safe_text(descriptor.get("string") if descriptor else "", name)
+    ttype = _safe_lower(descriptor.get("type") or descriptor.get("ttype"))
+    widget = _safe_text(descriptor.get("widget"))
+    if not widget:
+        widget = {
+            "many2one": "many2one",
+            "one2many": "one2many_list",
+            "many2many": "many2many_tags",
+            "boolean": "boolean",
+            "date": "date",
+            "datetime": "datetime",
+            "text": "textarea",
+            "html": "html",
+            "binary": "image",
+        }.get(ttype, "")
+    node = {"type": "field", "name": name}
+    if label:
+        node["string"] = label
+    node["fieldInfo"] = {
+        "name": name,
+        "label": label or name,
+    }
+    if widget:
+        node["fieldInfo"]["widget"] = widget
+    return node
 
 
 def _infer_action_semantic(action: dict) -> str:
@@ -1963,6 +2737,214 @@ def _build_form_action_policies(data: dict) -> dict[str, dict[str, Any]]:
     return policies
 
 
+def _govern_enterprise_company_form_for_user(data: dict) -> None:
+    if not _is_enterprise_company_form_contract(data):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    selected = [name for name in _ENTERPRISE_COMPANY_FORM_FIELDS if name in fields_map]
+    if not selected:
+        return
+    data["visible_fields"] = selected
+    data["field_groups"] = [
+        {
+            "name": "core",
+            "label": "企业基础信息",
+            "priority": 1,
+            "collapsible": False,
+            "fields": selected,
+        },
+    ]
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    form["layout"] = [
+        {
+            "type": "sheet",
+            "name": "enterprise_company_form_sheet",
+            "children": [
+                {
+                    "type": "group",
+                    "name": "enterprise_company_core_group",
+                    "string": "企业基础信息",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _ENTERPRISE_COMPANY_FIELD_LABELS)
+                        for name in selected
+                    ],
+                }
+            ],
+        }
+    ]
+    views["form"] = form
+    data["views"] = views
+
+    if _resolve_render_profile(data) == _RENDER_PROFILE_CREATE:
+        toolbar = _as_dict(data.get("toolbar"))
+        if isinstance(toolbar.get("header"), list):
+            toolbar["header"] = []
+        data["toolbar"] = toolbar
+        data["buttons"] = []
+        data["action_groups"] = []
+    _inject_enterprise_form_governance(
+        data,
+        next_action_key="department",
+        next_action_label="进入组织架构",
+    )
+
+
+def _govern_enterprise_department_form_for_user(data: dict) -> None:
+    if _governance_primary_model(data) != "hr.department":
+        return
+    if not _is_form_contract(data):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    selected = [name for name in _ENTERPRISE_DEPARTMENT_FORM_FIELDS if name in fields_map]
+    if not selected:
+        return
+    data["visible_fields"] = selected
+    data["field_groups"] = [
+        {
+            "name": "core",
+            "label": "组织基础信息",
+            "priority": 1,
+            "collapsible": False,
+            "fields": selected,
+        },
+    ]
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    form["layout"] = [
+        {
+            "type": "sheet",
+            "name": "enterprise_department_form_sheet",
+            "children": [
+                {
+                    "type": "group",
+                    "name": "enterprise_department_core_group",
+                    "string": "组织基础信息",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _ENTERPRISE_DEPARTMENT_FIELD_LABELS)
+                        for name in selected
+                    ],
+                }
+            ],
+        }
+    ]
+    views["form"] = form
+    data["views"] = views
+
+    if _resolve_render_profile(data) == _RENDER_PROFILE_CREATE:
+        toolbar = _as_dict(data.get("toolbar"))
+        if isinstance(toolbar.get("header"), list):
+            toolbar["header"] = []
+        data["toolbar"] = toolbar
+        data["buttons"] = []
+        data["action_groups"] = []
+    _inject_enterprise_form_governance(
+        data,
+        next_action_key="user",
+        next_action_label="进入用户设置",
+    )
+
+
+def _govern_enterprise_user_form_for_user(data: dict) -> None:
+    if not _is_enterprise_user_form_contract(data):
+        return
+    fields_map = _as_dict(data.get("fields"))
+    selected = [name for name in _ENTERPRISE_USER_FORM_FIELDS if name in fields_map]
+    if not selected:
+        return
+    data["visible_fields"] = selected
+    data["field_groups"] = [
+        {
+            "name": "basic",
+            "label": "用户基础信息",
+            "priority": 1,
+            "collapsible": False,
+            "fields": [name for name in selected if name in {"name", "login", "password", "phone", "active"}],
+        },
+        {
+            "name": "assignment",
+            "label": "组织与角色",
+            "priority": 2,
+            "collapsible": False,
+            "fields": [
+                name
+                for name in selected
+                if name in {"company_id", "sc_department_id", "sc_manager_user_id", "sc_role_profile", "sc_role_effective", "sc_role_landing_label"}
+            ],
+        },
+    ]
+    views = _as_dict(data.get("views"))
+    form = _as_dict(views.get("form"))
+    form["layout"] = [
+        {
+            "type": "sheet",
+            "name": "enterprise_user_form_sheet",
+            "children": [
+                {
+                    "type": "group",
+                    "name": "enterprise_user_basic_group",
+                    "string": "用户基础信息",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _ENTERPRISE_USER_FIELD_LABELS)
+                        for name in selected
+                        if name in {"name", "login", "password", "phone", "active"}
+                    ],
+                },
+                {
+                    "type": "group",
+                    "name": "enterprise_user_assignment_group",
+                    "string": "组织与角色",
+                    "children": [
+                        _make_labeled_field_node(name, fields_map, _ENTERPRISE_USER_FIELD_LABELS)
+                        for name in selected
+                        if name in {"company_id", "sc_department_id", "sc_manager_user_id", "sc_role_profile", "sc_role_effective", "sc_role_landing_label"}
+                    ],
+                },
+            ],
+        }
+    ]
+    views["form"] = form
+    data["views"] = views
+
+    field_policies = _as_dict(data.get("field_policies"))
+    basic_fields = {"name", "login", "password", "phone", "active"}
+    readonly_fields = {"sc_role_effective", "sc_role_landing_label"}
+    contract_required_fields = set(_resolve_contract_required_fields(data, fields_map))
+    for name in selected:
+        descriptor = _as_dict(fields_map.get(name))
+        readonly = name in readonly_fields or _to_bool(descriptor.get("readonly"), fallback=False)
+        field_policies[name] = {
+            "visible_profiles": [
+                _RENDER_PROFILE_CREATE,
+                _RENDER_PROFILE_EDIT,
+                _RENDER_PROFILE_READONLY,
+            ],
+            "required_profiles": (
+                [_RENDER_PROFILE_CREATE, _RENDER_PROFILE_EDIT]
+                if name in contract_required_fields and not readonly
+                else []
+            ),
+            "readonly_profiles": (
+                [_RENDER_PROFILE_CREATE, _RENDER_PROFILE_EDIT, _RENDER_PROFILE_READONLY]
+                if readonly
+                else [_RENDER_PROFILE_READONLY]
+            ),
+            "source_required": name in contract_required_fields and not readonly,
+            "source_readonly": readonly,
+            "group": "core" if name in basic_fields else "secondary",
+        }
+    data["field_policies"] = field_policies
+
+    if _resolve_render_profile(data) == _RENDER_PROFILE_CREATE:
+        toolbar = _as_dict(data.get("toolbar"))
+        if isinstance(toolbar.get("header"), list):
+            toolbar["header"] = []
+        data["toolbar"] = toolbar
+        data["buttons"] = []
+        data["action_groups"] = []
+    _inject_enterprise_form_governance(data)
+
+
 def _build_form_validation_rules(data: dict, contract_mode: str) -> list[dict[str, Any]]:
     rules: list[dict[str, Any]] = []
     fields_map = _as_dict(data.get("fields"))
@@ -2174,6 +3156,33 @@ def apply_project_form_domain_override(data: dict, contract_mode: str) -> None:
         _restructure_project_form_layout(data)
     if contract_mode == "user" and _is_project_form_contract(data):
         _govern_project_form_contract_for_user(data)
+    if contract_mode == "user" and _is_project_task_form_contract(data):
+        _govern_project_task_form_for_user(data)
+    if contract_mode == "user":
+        _govern_standard_list_for_user(
+            data,
+            model_name="project.project",
+            columns_order=_PROJECT_LIST_COLUMNS,
+            column_labels=_PROJECT_LIST_COLUMN_LABELS,
+            row_primary="name",
+            row_secondary="stage_id",
+            status_field="lifecycle_state",
+        )
+        _govern_standard_list_for_user(
+            data,
+            model_name="project.task",
+            columns_order=_PROJECT_TASK_LIST_COLUMNS,
+            column_labels=_PROJECT_TASK_LIST_COLUMN_LABELS,
+            row_primary="name",
+            row_secondary="project_id",
+            status_field="sc_state",
+        )
+    if contract_mode == "user" and _is_enterprise_company_form_contract(data):
+        _govern_enterprise_company_form_for_user(data)
+    if contract_mode == "user":
+        _govern_enterprise_department_form_for_user(data)
+    if contract_mode == "user" and _is_enterprise_user_form_contract(data):
+        _govern_enterprise_user_form_for_user(data)
     if contract_mode == "user" and _is_project_kanban_contract(data):
         _govern_project_kanban_contract_for_user(data)
 
@@ -2380,6 +3389,9 @@ def apply_contract_governance(
             inject_contract_mode=False,
         )
 
+    _normalize_native_view_contract_surface(data)
+    _normalize_scene_semantic_surface(data)
+
     effective_mode = contract_mode
     if normalized_surface == "native":
         # Native surface keeps parser-origin structure and skips user/hud policy transforms.
@@ -2389,6 +3401,9 @@ def apply_contract_governance(
         _apply_sanitize_governance(data, effective_mode)
         _apply_semantic_governance(data, effective_mode)
         override_failures = _apply_domain_overrides(data, effective_mode)
+        _preserve_native_layout_labels(data)
+        _emit_relation_entry_semantics(data)
+        _ensure_scene_contract_v1_envelope(data)
     else:
         override_failures = []
     _annotate_field_semantics(data)

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SCENE-READY-ORCHESTRATION-PA87.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SCENE-READY-ORCHESTRATION-PA87.yaml
@@ -1,0 +1,58 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-SCENE-READY-ORCHESTRATION-PA87
+title: Split residual smart_core scene-ready orchestration slice from 56b7eba
+objective: >
+  Isolate the platform-layer smart_core scene-ready orchestration residual slice
+  from commit 56b7eba into a bounded child batch for mainline review.
+context:
+  layer_target: Platform Layer
+  module: smart_core
+  module_ownership: Platform kernel
+  kernel_or_scenario: kernel
+  architecture_reason: >
+    This batch recovers scene-ready orchestration and contract governance
+    semantics that belong to smart_core platform runtime assembly. It must stay
+    separate from construction scene providers and domain semantic carriers.
+scope:
+  allowed_paths:
+    - addons/smart_core/core/page_contracts_builder.py
+    - addons/smart_core/core/scene_contract_builder.py
+    - addons/smart_core/core/scene_merge_resolver.py
+    - addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py
+    - addons/smart_core/handlers/system_init.py
+    - addons/smart_core/handlers/ui_contract.py
+    - addons/smart_core/utils/contract_governance.py
+    - addons/smart_core/tests/test_backend_semantic_copy_supply.py
+    - addons/smart_core/tests/test_contract_governance_project_form.py
+    - addons/smart_core/tests/test_release_operator_surface_copy_backend.py
+    - addons/smart_core/tests/test_scene_contract_builder_semantics.py
+    - addons/smart_core/tests/test_scene_ready_semantic_orchestration_bridge.py
+    - addons/smart_core/tests/test_scene_runtime_contract_chain.py
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SCENE-READY-ORCHESTRATION-PA87.yaml
+  forbidden_paths:
+    - addons/smart_construction_scene/**
+    - addons/smart_construction_core/**
+    - addons/smart_core/controllers/platform_menu_api.py
+    - addons/smart_core/delivery/menu_target_interpreter_service.py
+    - addons/smart_core/governance/scene_normalizer.py
+    - addons/smart_core/identity/identity_resolver.py
+    - addons/smart_core/orchestration/**
+    - addons/smart_core/delivery/**
+    - addons/smart_core/**/payment*
+    - addons/smart_core/**/settlement*
+    - addons/smart_core/**/account*
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_core/core/page_contracts_builder.py addons/smart_core/core/scene_contract_builder.py addons/smart_core/core/scene_merge_resolver.py addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py addons/smart_core/handlers/system_init.py addons/smart_core/handlers/ui_contract.py addons/smart_core/utils/contract_governance.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Split the second platform-layer residual slice from `56b7eba` out of residual umbrella PR #577.

This PR isolates smart_core scene-ready orchestration, contract governance assembly, and related tests without carrying construction scene providers, construction semantic carriers, or payment residual files.

## Scope

- `addons/smart_core/core/page_contracts_builder.py`
- `addons/smart_core/core/scene_contract_builder.py`
- `addons/smart_core/core/scene_merge_resolver.py`
- `addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py`
- `addons/smart_core/handlers/system_init.py`
- `addons/smart_core/handlers/ui_contract.py`
- `addons/smart_core/utils/contract_governance.py`
- `addons/smart_core/tests/test_backend_semantic_copy_supply.py`
- `addons/smart_core/tests/test_contract_governance_project_form.py`
- `addons/smart_core/tests/test_release_operator_surface_copy_backend.py`
- `addons/smart_core/tests/test_scene_contract_builder_semantics.py`
- `addons/smart_core/tests/test_scene_ready_semantic_orchestration_bridge.py`
- `addons/smart_core/tests/test_scene_runtime_contract_chain.py`

## Architecture Impact

- Layer Target: Platform Layer
- Affected Modules: `smart_core`
- Reason: recover scene-ready orchestration and contract-governance runtime assembly into a bounded mainline-reviewable child slice

## Verify

- `python3 -m py_compile addons/smart_core/core/page_contracts_builder.py addons/smart_core/core/scene_contract_builder.py addons/smart_core/core/scene_merge_resolver.py addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py addons/smart_core/handlers/system_init.py addons/smart_core/handlers/ui_contract.py addons/smart_core/utils/contract_governance.py`

## Relation

- parent residual umbrella: #577
- predecessor merged splits: #578 #579 #580 #581 #582 #583 #584 #585 #586
- predecessor residual slice: #587
