### PR TITLE
[split] construction scene provider supply residual slice

### DIFF
--- a/addons/smart_construction_scene/bootstrap/register_scene_providers.py
+++ b/addons/smart_construction_scene/bootstrap/register_scene_providers.py
@@ -29,6 +29,14 @@ def register_scene_content_providers(registry, addons_root: Path) -> None:
         source="industry_registration",
     )
     registry.register_spec(
+        scene_key="project.management",
+        provider_key="construction.project_management_dashboard.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "profiles" / "project_dashboard_scene_content.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
         scene_key="scene.registry",
         provider_key="construction.scene_registry.v1",
         module_name=scene_module,
@@ -49,6 +57,126 @@ def register_scene_content_providers(registry, addons_root: Path) -> None:
         provider_key="construction.project_intake_provider.v1",
         module_name=scene_module,
         provider_path=addons_root / scene_module / "providers" / "project_intake_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="projects.ledger",
+        provider_key="construction.projects_ledger_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "projects_ledger_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="projects.detail",
+        provider_key="construction.projects_detail_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "projects_detail_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="cost.project_budget",
+        provider_key="construction.cost_project_budget_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "cost_project_budget_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="task.center",
+        provider_key="construction.task_center_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "task_center_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="task.board",
+        provider_key="construction.task_board_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "task_board_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="finance.center",
+        provider_key="construction.finance_center_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "finance_center_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="finance.workspace",
+        provider_key="construction.finance_workspace_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "finance_workspace_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="finance.payment_requests",
+        provider_key="construction.payment_entry_workbench_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "payment_entry_workbench_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="payments.approval",
+        provider_key="construction.approval_workbench_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "approval_workbench_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="contract.center",
+        provider_key="construction.contract_center_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "contract_center_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="contracts.workspace",
+        provider_key="construction.contracts_workspace_provider.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "contracts_workspace_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="enterprise.company",
+        provider_key="construction.enterprise_bootstrap_provider.company.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "enterprise_bootstrap_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="enterprise.department",
+        provider_key="construction.enterprise_bootstrap_provider.department.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "enterprise_bootstrap_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="enterprise.user",
+        provider_key="construction.enterprise_bootstrap_provider.user.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "enterprise_bootstrap_provider.py",
+        priority=300,
+        source="industry_registration",
+    )
+    registry.register_spec(
+        scene_key="enterprise.post",
+        provider_key="construction.enterprise_bootstrap_provider.post.v1",
+        module_name=scene_module,
+        provider_path=addons_root / scene_module / "providers" / "enterprise_bootstrap_provider.py",
         priority=300,
         source="industry_registration",
     )

--- a/addons/smart_construction_scene/core_extension.py
+++ b/addons/smart_construction_scene/core_extension.py
@@ -1,0 +1,341 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any
+
+from odoo.addons.smart_construction_scene import scene_registry
+
+ROLE_SURFACE_OVERRIDES = {
+    "owner": {
+        "label": "普通员工",
+        "landing_scene_candidates": ["projects.list", "project.initiation", "projects.intake"],
+        "menu_xmlids": [
+            "smart_construction_core.menu_sc_project_center",
+            "smart_construction_core.menu_sc_contract_center",
+        ],
+    },
+    "pm": {
+        "label": "项目经理",
+        "landing_scene_candidates": [
+            "project.management",
+            "project.dashboard",
+            "projects.intake",
+            "projects.list",
+            "projects.ledger",
+            "my_work.workspace",
+        ],
+        "menu_xmlids": [
+            "smart_construction_core.menu_sc_project_center",
+            "smart_construction_core.menu_sc_project_management_scene",
+            "smart_construction_core.menu_sc_project_dashboard",
+            "smart_construction_core.menu_sc_contract_center",
+            "smart_construction_core.menu_sc_cost_center",
+        ],
+        "menu_blocklist_xmlids": [],
+    },
+    "finance": {
+        "label": "财务人员",
+        "landing_scene_candidates": ["finance.payment_requests", "projects.ledger", "projects.list"],
+        "menu_xmlids": [
+            "smart_construction_core.menu_sc_finance_center",
+            "smart_construction_core.menu_sc_settlement_center",
+            "smart_construction_core.menu_payment_request",
+        ],
+    },
+    "executive": {
+        "label": "管理层",
+        "landing_scene_candidates": [
+            "portal.dashboard",
+            "project.management",
+            "projects.list",
+            "projects.ledger",
+            "project.initiation",
+            "projects.intake",
+        ],
+        "menu_xmlids": [
+            "smart_construction_core.menu_sc_root",
+            "smart_construction_core.menu_sc_projection_root",
+            "smart_construction_core.menu_sc_project_center",
+        ],
+    },
+}
+
+ROLE_GROUPS_EXPLICIT = {
+    "executive": {
+        "smart_construction_custom.group_sc_role_executive",
+    },
+    "pm": {
+        "smart_construction_custom.group_sc_role_pm",
+        "smart_construction_custom.group_sc_role_project_manager",
+        "smart_construction_core.group_sc_role_project_manager",
+    },
+    "finance": {
+        "smart_construction_custom.group_sc_role_finance",
+        "smart_construction_custom.group_sc_role_payment_manager",
+        "smart_construction_custom.group_sc_role_payment_user",
+        "smart_construction_core.group_sc_role_finance_manager",
+        "smart_construction_core.group_sc_role_finance_user",
+    },
+}
+
+ROLE_GROUPS_CAPABILITY_FALLBACK = {
+    "pm": {
+        "smart_construction_core.group_sc_cap_project_manager",
+    },
+    "finance": {
+        "smart_construction_core.group_sc_cap_finance_user",
+        "smart_construction_core.group_sc_cap_finance_manager",
+    },
+}
+
+ROLE_PRECEDENCE = ("executive", "pm", "finance")
+
+NAV_MENU_SCENE_MAP = {
+    "smart_construction_demo.menu_sc_project_list_showcase": "projects.list",
+    "smart_construction_core.menu_sc_project_initiation": "projects.intake",
+    "smart_construction_core.menu_sc_project_manage": "project.management",
+    "smart_construction_core.menu_sc_project_project": "projects.ledger",
+    "smart_construction_core.menu_sc_project_management_scene": "project.management",
+    "smart_construction_core.menu_sc_project_quick_create": "projects.intake",
+    "smart_construction_core.menu_sc_project_cost_code": "config.project_cost_code",
+    "smart_construction_core.menu_sc_root": "projects.list",
+    "smart_construction_core.menu_sc_project_dashboard": "project.dashboard",
+    "smart_construction_demo.menu_sc_project_dashboard_showcase": "projects.dashboard_showcase",
+    "smart_construction_core.menu_sc_dictionary": "data.dictionary",
+    "smart_construction_core.menu_payment_request": "finance.payment_requests",
+    "smart_construction_core.menu_sc_tier_review_my_payment_request": "payments.approval",
+    "smart_construction_portal.menu_sc_portal_lifecycle": "portal.lifecycle",
+    "smart_construction_portal.menu_sc_portal_capability_matrix": "portal.capability_matrix",
+    "smart_construction_portal.menu_sc_portal_dashboard": "portal.dashboard",
+}
+
+NAV_ACTION_SCENE_MAP = {
+    "smart_construction_demo.action_sc_project_list_showcase": "projects.list",
+    "smart_construction_core.action_project_initiation": "projects.intake",
+    "smart_construction_core.action_project_initiation_quick": "projects.intake",
+    "smart_construction_core.action_sc_project_kanban_lifecycle": "projects.ledger",
+    "smart_construction_core.action_sc_project_list": "projects.list",
+    "smart_construction_core.action_sc_project_manage": "project.management",
+    "smart_construction_core.action_sc_project_my_list": "projects.list",
+    "smart_construction_core.action_sc_project_overview": "projects.list",
+    "smart_construction_core.action_project_dashboard": "project.dashboard",
+    "smart_construction_demo.action_project_dashboard_showcase": "projects.dashboard_showcase",
+    "smart_construction_core.action_project_dictionary": "data.dictionary",
+    "smart_construction_core.action_project_cost_code": "config.project_cost_code",
+    "smart_construction_core.action_payment_request": "finance.payment_requests",
+    "smart_construction_core.action_payment_request_my": "finance.payment_requests",
+    "smart_construction_portal.action_sc_portal_lifecycle": "portal.lifecycle",
+    "smart_construction_portal.action_sc_portal_capability_matrix": "portal.capability_matrix",
+    "smart_construction_portal.action_sc_portal_dashboard": "portal.dashboard",
+}
+
+NAV_MODEL_VIEW_SCENE_MAP = {
+    ("project.project", "list"): "projects.list",
+    ("project.project", "form"): "projects.intake",
+    ("payment.request", "list"): "finance.payment_requests",
+    ("payment.request", "form"): "finance.payment_requests",
+}
+
+SURFACE_NAV_ALLOWLIST = {
+    "construction_pm_v1": [
+        "project.management",
+        "project.dashboard",
+        "projects.dashboard",
+        "projects.ledger",
+        "project.initiation",
+        "projects.intake",
+        "my_work.workspace",
+    ]
+}
+
+SURFACE_DEEP_LINK_ALLOWLIST = {
+    "construction_pm_v1": [
+        "contract.center",
+        "cost.budget_alloc",
+        "cost.cost_compare",
+        "cost.profit_compare",
+        "cost.project_boq",
+        "cost.project_budget",
+        "cost.project_cost_ledger",
+        "cost.project_progress",
+        "data.dictionary",
+        "finance.center",
+        "finance.operating_metrics",
+        "finance.payment_ledger",
+        "finance.payment_requests",
+        "finance.settlement_orders",
+        "finance.treasury_ledger",
+        "config.project_cost_code",
+        "risk.monitor",
+        "task.center",
+    ]
+}
+
+SURFACE_POLICY_DEFAULT_NAME = "construction_pm_v1"
+SURFACE_POLICY_DEFAULT_FILE = "docs/product/delivery/v1/construction_pm_v1_scene_surface_policy.json"
+
+CRITICAL_SCENE_TARGET_OVERRIDES = {
+    "contract.center",
+    "projects.list",
+    "projects.detail",
+    "projects.intake",
+    "projects.ledger",
+    "projects.execution",
+    "projects.dashboard",
+    "project.management",
+    "my_work.workspace",
+    "portal.dashboard",
+    "finance.payment_requests",
+}
+
+CRITICAL_SCENE_TARGET_ROUTE_OVERRIDES = {
+    "my_work.workspace": "/my-work",
+}
+
+_DERIVED_NAV_SCENE_MAP_CACHE: dict[str, dict[str, dict[Any, str]]] = {}
+
+
+def _scene_cache_key(env) -> str:
+    try:
+        dbname = str(getattr(getattr(env, "cr", None), "dbname", "") or "").strip()
+    except Exception:
+        dbname = ""
+    return dbname or "__default__"
+
+
+def _normalize_view_mode(raw: Any) -> str:
+    value = str(raw or "").strip().lower()
+    if value in {"tree", "list", "kanban"}:
+        return "list"
+    if value in {"form"}:
+        return "form"
+    return value
+
+
+def _derive_nav_scene_maps_from_registry(env) -> dict[str, dict[Any, str]]:
+    cache_key = _scene_cache_key(env)
+    cached = _DERIVED_NAV_SCENE_MAP_CACHE.get(cache_key)
+    if isinstance(cached, dict):
+        return cached
+
+    menu_scene_map: dict[str, str] = {}
+    action_xmlid_scene_map: dict[str, str] = {}
+    model_view_scene_map: dict[tuple[str, str], str] = {}
+
+    try:
+        scenes = scene_registry.load_scene_configs(env)
+    except Exception:
+        scenes = []
+
+    for scene in scenes or []:
+        if not isinstance(scene, dict):
+            continue
+        scene_key = str(scene.get("code") or scene.get("key") or "").strip()
+        if not scene_key:
+            continue
+        target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+        menu_xmlid = str(target.get("menu_xmlid") or "").strip()
+        action_xmlid = str(target.get("action_xmlid") or "").strip()
+        model = str(target.get("model") or "").strip()
+        view_mode = _normalize_view_mode(target.get("view_mode") or target.get("view_type"))
+
+        if menu_xmlid and menu_xmlid not in menu_scene_map:
+            menu_scene_map[menu_xmlid] = scene_key
+        if action_xmlid and action_xmlid not in action_xmlid_scene_map:
+            action_xmlid_scene_map[action_xmlid] = scene_key
+        if model and view_mode and (model, view_mode) not in model_view_scene_map:
+            model_view_scene_map[(model, view_mode)] = scene_key
+
+    derived = {
+        "menu_scene_map": menu_scene_map,
+        "action_xmlid_scene_map": action_xmlid_scene_map,
+        "model_view_scene_map": model_view_scene_map,
+    }
+    _DERIVED_NAV_SCENE_MAP_CACHE[cache_key] = derived
+    return derived
+
+
+def get_intent_handler_contributions():
+    return []
+
+
+def smart_core_identity_profile(env):
+    del env
+    return {
+        "role_surface_map": ROLE_SURFACE_OVERRIDES,
+        "role_groups_explicit": ROLE_GROUPS_EXPLICIT,
+        "role_groups_capability_fallback": ROLE_GROUPS_CAPABILITY_FALLBACK,
+        "role_precedence": ROLE_PRECEDENCE,
+    }
+
+
+def smart_core_nav_scene_maps(env):
+    derived = _derive_nav_scene_maps_from_registry(env)
+    menu_scene_map = dict(derived.get("menu_scene_map") or {})
+    action_xmlid_scene_map = dict(derived.get("action_xmlid_scene_map") or {})
+    model_view_scene_map = dict(derived.get("model_view_scene_map") or {})
+    menu_scene_map.update(NAV_MENU_SCENE_MAP)
+    action_xmlid_scene_map.update(NAV_ACTION_SCENE_MAP)
+    model_view_scene_map.update(NAV_MODEL_VIEW_SCENE_MAP)
+    return {
+        "menu_scene_map": menu_scene_map,
+        "action_xmlid_scene_map": action_xmlid_scene_map,
+        "model_view_scene_map": model_view_scene_map,
+    }
+
+
+def smart_core_surface_nav_allowlist(env):
+    del env
+    return {str(surface): list(codes) for surface, codes in SURFACE_NAV_ALLOWLIST.items()}
+
+
+def smart_core_surface_deep_link_allowlist(env):
+    del env
+    return {str(surface): list(codes) for surface, codes in SURFACE_DEEP_LINK_ALLOWLIST.items()}
+
+
+def smart_core_surface_policy_default_name(env):
+    del env
+    return SURFACE_POLICY_DEFAULT_NAME
+
+
+def smart_core_surface_policy_file_default(env):
+    del env
+    return SURFACE_POLICY_DEFAULT_FILE
+
+
+def smart_core_critical_scene_target_overrides(env):
+    del env
+    return list(CRITICAL_SCENE_TARGET_OVERRIDES)
+
+
+def smart_core_critical_scene_target_route_overrides(env):
+    del env
+    return dict(CRITICAL_SCENE_TARGET_ROUTE_OVERRIDES)
+
+
+def smart_core_extend_system_init(data, env, user):
+    del user
+    try:
+        ext_facts = data.get("ext_facts")
+        if not isinstance(ext_facts, dict):
+            ext_facts = {}
+        module_facts = ext_facts.get("smart_construction_scene")
+        if not isinstance(module_facts, dict):
+            module_facts = {}
+
+        module_facts["role_surface_override_provider"] = {
+            "key": "smart_construction_scene",
+            "enabled": True,
+            "priority": 100,
+            "domain_key": "construction",
+            "root_xmlids": ["smart_construction_core.menu_sc_root"],
+            "scene_codes": ["projects.intake", "projects.list", "projects.ledger", "my_work.workspace", "project.management"],
+            "role_surface_overrides": ROLE_SURFACE_OVERRIDES,
+        }
+
+        ext_facts["smart_construction_scene"] = module_facts
+        data["ext_facts"] = ext_facts
+    except Exception:
+        return None
+    return None

--- a/addons/smart_construction_scene/profiles/project_dashboard_scene_content.py
+++ b/addons/smart_construction_scene/profiles/project_dashboard_scene_content.py
@@ -65,7 +65,21 @@ def build_project_dashboard_scene_content() -> Dict[str, Any]:
             "key": "project.management.dashboard",
             "title": "项目驾驶舱",
             "route": "/s/project.management",
+            "page_type": "dashboard",
+            "layout_mode": "dashboard",
         },
         "zone_blocks": zone_blocks,
     }
 
+
+def build(*, scene_key: str = "", runtime: Dict[str, Any] | None = None, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Scene-ready provider entry expected by the startup contract loader."""
+    _scene_key = str(scene_key or "").strip()
+    payload = build_project_dashboard_scene_content()
+    if _scene_key and _scene_key not in {"project.management", "project.dashboard"}:
+      return {}
+    return payload
+
+
+def get_scene_content(*, scene_key: str = "", runtime: Dict[str, Any] | None = None, context: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return build(scene_key=scene_key, runtime=runtime, context=context)

--- a/addons/smart_construction_scene/profiles/scene_registry_content.py
+++ b/addons/smart_construction_scene/profiles/scene_registry_content.py
@@ -37,6 +37,15 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             },
         },
         {
+            "code": "project.dashboard",
+            "name": "项目驾驶舱（产品场景）",
+            "target": {
+                "route": "/s/project.dashboard",
+                "menu_xmlid": "smart_construction_core.menu_sc_project_dashboard",
+                "action_xmlid": "smart_construction_core.action_project_dashboard",
+            },
+        },
+        {
             "code": "projects.dashboard_showcase",
             "name": "项目驾驶舱（演示）",
             "is_test": True,
@@ -51,6 +60,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "name": "项目驾驶舱",
             "target": {
                 "menu_xmlid": "smart_construction_core.menu_sc_project_management_scene",
+                "action_xmlid": "smart_construction_core.action_project_dashboard",
                 "route": "/s/project.management",
             },
         },
@@ -58,22 +68,76 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "projects.intake",
             "name": "项目立项",
             "target": {
+                "route": "/s/projects.intake",
                 "menu_xmlid": "smart_construction_core.menu_sc_project_initiation",
                 "action_xmlid": "smart_construction_core.action_project_initiation",
+            },
+        },
+        {
+            "code": "project.initiation",
+            "name": "项目立项（产品场景）",
+            "target": {
+                "route": "/s/project.initiation",
+            },
+        },
+        {
+            "code": "enterprise.company",
+            "name": "企业信息",
+            "target": {
+                "route": "/s/enterprise.company",
+                "menu_xmlid": "smart_enterprise_base.menu_enterprise_company",
+                "action_xmlid": "smart_enterprise_base.action_enterprise_company",
+                "model": "res.company",
+                "view_type": "form",
+            },
+        },
+        {
+            "code": "enterprise.department",
+            "name": "组织架构",
+            "target": {
+                "route": "/s/enterprise.department",
+                "menu_xmlid": "smart_enterprise_base.menu_enterprise_department",
+                "action_xmlid": "smart_enterprise_base.action_enterprise_department",
+                "model": "hr.department",
+                "view_type": "tree",
+            },
+        },
+        {
+            "code": "enterprise.user",
+            "name": "用户设置",
+            "target": {
+                "route": "/s/enterprise.user",
+                "menu_xmlid": "smart_enterprise_base.menu_enterprise_user",
+                "action_xmlid": "smart_enterprise_base.action_enterprise_user",
+                "model": "res.users",
+                "view_type": "tree",
+            },
+        },
+        {
+            "code": "enterprise.post",
+            "name": "岗位管理",
+            "target": {
+                "route": "/s/enterprise.post",
+                "menu_xmlid": "smart_enterprise_base.menu_enterprise_post",
+                "action_xmlid": "smart_enterprise_base.action_enterprise_post",
+                "model": "sc.enterprise.post",
+                "view_type": "tree",
             },
         },
         {
             "code": "projects.list",
             "name": "项目列表",
             "target": {
+                "route": "/s/projects.list",
                 "menu_xmlid": "smart_construction_core.menu_sc_root",
                 "action_xmlid": "smart_construction_core.action_sc_project_list",
             },
         },
         {
             "code": "projects.ledger",
-            "name": "项目台账（试点）",
+            "name": "项目台账",
             "target": {
+                "route": "/s/projects.ledger",
                 "menu_xmlid": "smart_construction_core.menu_sc_project_project",
                 "action_xmlid": "smart_construction_core.action_sc_project_kanban_lifecycle",
             },
@@ -82,15 +146,23 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "task.center",
             "name": "任务中心",
             "target": {
+                "route": "/s/task.center",
                 "action_xmlid": "project.action_view_all_task",
+            },
+        },
+        {
+            "code": "task.board",
+            "name": "任务看板",
+            "target": {
+                "route": "/s/task.board",
             },
         },
         {
             "code": "contract.center",
             "name": "合同中心",
             "target": {
+                "route": "/s/contract.center",
                 "menu_xmlid": "smart_construction_core.menu_sc_contract_center",
-                "action_xmlid": "smart_construction_core.action_construction_contract_my",
             },
         },
         {
@@ -129,8 +201,9 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "finance.center",
             "name": "财务中心",
             "target": {
+                "route": "/s/finance.center",
                 "menu_xmlid": "smart_construction_core.menu_sc_finance_center",
-                "action_xmlid": "smart_construction_core.action_sc_tier_review_my_payment_request",
+                "action_xmlid": "smart_construction_core.action_sc_finance_dashboard",
             },
         },
         {
@@ -139,7 +212,6 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "target": {
                 "route": "/s/finance.workspace",
                 "menu_xmlid": "smart_construction_core.menu_sc_finance_center",
-                "action_xmlid": "smart_construction_core.action_sc_tier_review_my_payment_request",
             },
         },
         {
@@ -154,14 +226,16 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "finance.payment_requests",
             "name": "付款收款申请",
             "target": {
+                "route": "/s/finance.payment_requests",
                 "menu_xmlid": "smart_construction_core.menu_payment_request",
-                "action_xmlid": "smart_construction_core.action_payment_request",
+                "action_xmlid": "smart_construction_core.action_payment_request_my",
             },
         },
         {
             "code": "finance.settlement_orders",
             "name": "结算单",
             "target": {
+                "route": "/s/finance.settlement_orders",
                 "menu_xmlid": "smart_construction_core.menu_sc_settlement_order",
                 "action_xmlid": "smart_construction_core.action_sc_settlement_order",
             },
@@ -170,6 +244,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "finance.treasury_ledger",
             "name": "资金台账",
             "target": {
+                "route": "/s/finance.treasury_ledger",
                 "menu_xmlid": "smart_construction_core.menu_sc_treasury_ledger",
                 "action_xmlid": "smart_construction_core.action_sc_treasury_ledger",
             },
@@ -178,6 +253,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "finance.payment_ledger",
             "name": "收付款台账",
             "target": {
+                "route": "/s/finance.payment_ledger",
                 "menu_xmlid": "smart_construction_core.menu_payment_ledger",
                 "action_xmlid": "smart_construction_core.action_payment_ledger",
             },
@@ -186,6 +262,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "cost.cost_compare",
             "name": "成本中心",
             "target": {
+                "route": "/s/cost.cost_compare",
                 "menu_xmlid": "smart_construction_core.menu_sc_cost_center",
                 "action_xmlid": "smart_construction_core.action_project_cost_compare",
             },
@@ -194,8 +271,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "cost.project_budget",
             "name": "预算管理",
             "target": {
-                "menu_xmlid": "smart_construction_core.menu_sc_project_budget",
-                "action_xmlid": "smart_construction_core.action_project_budget",
+                "route": "/s/cost.project_budget",
             },
         },
         {
@@ -236,6 +312,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "cost.project_progress",
             "name": "进度填报",
             "target": {
+                "route": "/s/cost.project_progress",
                 "menu_xmlid": "smart_construction_core.menu_sc_project_progress",
                 "action_xmlid": "smart_construction_core.action_project_progress_entry",
             },
@@ -252,6 +329,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "code": "cost.profit_compare",
             "name": "盈亏对比",
             "target": {
+                "route": "/s/cost.profit_compare",
                 "menu_xmlid": "smart_construction_core.menu_sc_profit_reports",
                 "action_xmlid": "smart_construction_core.action_project_profit_compare",
             },
@@ -264,7 +342,7 @@ def list_scene_entries() -> List[Dict[str, Any]]:
         {
             "code": "portal.capability_matrix",
             "name": "能力矩阵",
-            "target": {"route": "/s/project.management"},
+            "target": {"route": "/s/portal.capability_matrix"},
         },
         {
             "code": "portal.dashboard",
@@ -276,7 +354,8 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "name": "收付款审批中心",
             "target": {
                 "route": "/s/payments.approval",
-                "menu_xmlid": "smart_construction_core.menu_payment_request",
+                "menu_xmlid": "smart_construction_core.menu_sc_tier_review_my_payment_request",
+                "action_xmlid": "smart_construction_core.action_sc_tier_review_my_payment_request",
             },
         },
         {
@@ -290,7 +369,6 @@ def list_scene_entries() -> List[Dict[str, Any]]:
             "target": {
                 "route": "/s/projects.detail",
                 "menu_xmlid": "smart_construction_core.menu_sc_project_project",
-                "action_xmlid": "smart_construction_core.action_sc_project_kanban_lifecycle",
             },
         },
         {

--- a/addons/smart_construction_scene/providers/approval_workbench_provider.py
+++ b/addons/smart_construction_scene/providers/approval_workbench_provider.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
+
+def build(scene_key: str = "payments.approval", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    action_xmlid = "smart_construction_core.action_sc_tier_review_my_payment_request"
+    primary_action = {
+        "label": "进入付款审批",
+        "action_xmlid": action_xmlid,
+        "semantic": "payment_approval_workbench_entry",
+    }
+    fallback_strategy = {
+        "type": "native_action_compat",
+        "action_xmlid": action_xmlid,
+        "reason": "keep the native approval action available while payments.approval remains the canonical approval-specific workbench entry",
+    }
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "付款审批工作台",
+            "message": "从审批工作台进入个人待审付款请求，保持 approval-first 的动作语义，不回退到通用付款列表。",
+        },
+        "primary_action": primary_action,
+        "next_action": {
+            "label": "处理待审付款请求",
+            "action_xmlid": action_xmlid,
+            "semantic": "payment_approval_queue",
+        },
+        "fallback_strategy": fallback_strategy,
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="payment_approval",
+            user_entry="menu:smart_construction_core.menu_sc_tier_review_my_payment_request",
+            final_scene="payments.approval",
+            primary_action=primary_action,
+            required_provider="construction.approval_workbench_provider.v1",
+            fallback_policy=fallback_strategy,
+            rollout_wave="wave_2_held",
+        ),
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/contract_center_provider.py
+++ b/addons/smart_construction_scene/providers/contract_center_provider.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
+
+def build(scene_key: str = "contract.center", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    primary_action = {
+        "label": "进入合同中心",
+        "route": "/s/contract.center",
+        "semantic": "contract_root_scene_entry",
+    }
+    fallback_strategy = {
+        "type": "native_menu_compat",
+        "menu_xmlid": "smart_construction_core.menu_sc_contract_center",
+        "action_xmlid": "smart_construction_core.action_construction_contract_my",
+        "reason": "keep native contract root menu/action available while contract.center remains canonical root owner",
+    }
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "合同中心",
+            "message": "先进入合同中心场景总览，再按工作台或监控分支继续处理合同任务。",
+        },
+        "primary_action": primary_action,
+        "fallback_strategy": fallback_strategy,
+        "shared_root_compatibility": {
+            "used": True,
+            "closure_status": "root_owner_retained",
+            "owner_scene": "contract.center",
+        },
+        "next_scene": "contracts.workspace",
+        "next_scene_route": "/s/contracts.workspace",
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="contracts",
+            user_entry="menu:smart_construction_core.menu_sc_contract_center",
+            final_scene="contract.center",
+            primary_action=primary_action,
+            required_provider="construction.contract_center_provider.v1|construction.contracts_workspace_provider.v1",
+            fallback_policy=fallback_strategy,
+            rollout_wave="wave_2",
+        ),
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/contracts_workspace_provider.py
+++ b/addons/smart_construction_scene/providers/contracts_workspace_provider.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
+
+def build(scene_key: str = "contracts.workspace", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    primary_action = {
+        "label": "进入合同工作台",
+        "route": "/s/contracts.workspace",
+        "semantic": "contract_workspace_entry",
+    }
+    fallback_strategy = {
+        "type": "native_action_compat",
+        "menu_xmlid": "smart_construction_core.menu_sc_contract_center",
+        "action_xmlid": "smart_construction_core.action_construction_contract_my",
+        "reason": "contracts.workspace keeps contract root menu/action context without claiming a new family root authority",
+    }
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "合同工作台",
+            "message": "从 route-first 合同工作台入口继续处理合同跟进任务，并保持与合同中心根入口一致的上下文。",
+        },
+        "primary_action": primary_action,
+        "fallback_strategy": fallback_strategy,
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="contracts",
+            user_entry="route:/s/contracts.workspace",
+            final_scene="contracts.workspace",
+            primary_action=primary_action,
+            required_provider="construction.contract_center_provider.v1|construction.contracts_workspace_provider.v1",
+            fallback_policy=fallback_strategy,
+            rollout_wave="wave_2",
+        ),
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/cost_project_budget_provider.py
+++ b/addons/smart_construction_scene/providers/cost_project_budget_provider.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def build(scene_key: str = "cost.project_budget", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "预算管理",
+            "message": "围绕项目预算、分配与成本控制组织预算管理入口。",
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/enterprise_bootstrap_provider.py
+++ b/addons/smart_construction_scene/providers/enterprise_bootstrap_provider.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+_GUIDANCE_BY_SCENE = {
+    "enterprise.company": {
+        "title": "企业信息",
+        "message": "先补齐企业基础信息，保存后继续进入组织架构。",
+        "next_scene": "enterprise.department",
+    },
+    "enterprise.department": {
+        "title": "组织架构",
+        "message": "先创建一级部门，再补齐二级和三级部门，最后进入用户设置。",
+        "next_scene": "enterprise.post",
+    },
+    "enterprise.post": {
+        "title": "岗位管理",
+        "message": "补齐岗位主数据后，再进入用户设置给人员挂主岗位。",
+        "next_scene": "enterprise.user",
+    },
+    "enterprise.user": {
+        "title": "用户设置",
+        "message": "给用户挂公司、部门、产品角色和初始密码，再用该账号登录验证首页入口。",
+        "next_scene": "",
+    },
+}
+
+
+def build(scene_key: str = "", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    normalized_scene_key = str(scene_key or "").strip()
+    guidance = _GUIDANCE_BY_SCENE.get(normalized_scene_key)
+    if not guidance:
+        return {}
+
+    next_scene = str(guidance.get("next_scene") or "").strip()
+    payload = {
+        "scene_key": normalized_scene_key,
+        "guidance": {
+            "title": str(guidance.get("title") or normalized_scene_key).strip(),
+            "message": str(guidance.get("message") or "").strip(),
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }
+    if next_scene:
+        payload["next_scene"] = next_scene
+        payload["next_scene_route"] = f"/s/{next_scene}"
+    return payload

--- a/addons/smart_construction_scene/providers/finance_center_provider.py
+++ b/addons/smart_construction_scene/providers/finance_center_provider.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
+
+def build(scene_key: str = "finance.center", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    primary_action = {
+        "label": "进入财务中心",
+        "route": "/s/finance.center",
+        "semantic": "finance_root_entry",
+    }
+    fallback_strategy = {
+        "type": "native_menu_compat",
+        "menu_xmlid": "smart_construction_core.menu_sc_finance_center",
+        "action_xmlid": "smart_construction_core.action_sc_finance_dashboard",
+        "reason": "keep native finance root menu/action available while finance.center remains canonical root owner",
+    }
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "财务中心",
+            "message": "先从财务中心总览进入资金主入口，再按工作台分流到收付与跟进动作。",
+        },
+        "primary_action": primary_action,
+        "fallback_strategy": fallback_strategy,
+        "shared_root_compatibility": {
+            "used": True,
+            "closure_status": "root_owner_retained",
+            "owner_scene": "finance.center",
+        },
+        "next_scene": "finance.workspace",
+        "next_scene_route": "/s/finance.workspace",
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="finance_center",
+            user_entry="menu:smart_construction_core.menu_sc_finance_center",
+            final_scene="finance.center",
+            primary_action=primary_action,
+            required_provider="construction.finance_center_provider.v1|construction.finance_workspace_provider.v1",
+            fallback_policy=fallback_strategy,
+        ),
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/finance_workspace_provider.py
+++ b/addons/smart_construction_scene/providers/finance_workspace_provider.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def build(scene_key: str = "finance.workspace", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "资金管理工作台",
+            "message": "从 route-first 工作台入口继续处理财务跟进任务，并保持与财务中心根菜单一致的上下文。",
+        },
+        "primary_action": {
+            "label": "进入资金工作台",
+            "route": "/s/finance.workspace",
+            "semantic": "finance_workspace_entry",
+        },
+        "fallback_strategy": {
+            "type": "native_menu_compat",
+            "menu_xmlid": "smart_construction_core.menu_sc_finance_center",
+            "reason": "finance.workspace keeps finance root menu context but no longer claims native root action ownership",
+        },
+        "shared_root_compatibility": {
+            "used": True,
+            "closure_status": "route_plus_menu_compat",
+            "owner_scene": "finance.center",
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/projects_detail_provider.py
+++ b/addons/smart_construction_scene/providers/projects_detail_provider.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def build(scene_key: str = "projects.detail", runtime: dict | None = None, context: dict | None = None) -> dict:
+    context_payload = context or {}
+    runtime_payload = runtime or {}
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "项目详情",
+            "message": "从项目详情入口继续处理台账后的明细工作与下一步动作。",
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+            "record_id": context_payload.get("record_id") or runtime_payload.get("record_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/projects_ledger_provider.py
+++ b/addons/smart_construction_scene/providers/projects_ledger_provider.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def build(scene_key: str = "projects.ledger", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "项目台账",
+            "message": "围绕项目台账、风险和关键跟进项组织项目工作入口。",
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/projects_list_provider.py
+++ b/addons/smart_construction_scene/providers/projects_list_provider.py
@@ -1,19 +1,43 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
 
 def build(scene_key: str = "projects.list", runtime: dict | None = None, context: dict | None = None) -> dict:
     _ = context or {}
     runtime_payload = runtime or {}
+    primary_action = {
+        "label": "进入项目列表",
+        "action_xmlid": "smart_construction_core.action_sc_project_list",
+        "semantic": "projects_list_entry",
+    }
+    fallback_strategy = {
+        "type": "native_menu_action_compat",
+        "menu_xmlid": "smart_construction_core.menu_sc_root",
+        "action_xmlid": "smart_construction_core.action_sc_project_list",
+        "reason": "keep the native project root menu/action available while projects.list remains the canonical wave-1 handoff entry",
+    }
     return {
         "scene_key": scene_key,
         "guidance": {
             "title": "项目列表",
             "message": "从编排后的列表入口查看项目状态、排序和批量动作。",
         },
+        "primary_action": primary_action,
+        "fallback_strategy": fallback_strategy,
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="projects",
+            user_entry="menu:smart_construction_core.menu_sc_root",
+            final_scene="projects.list",
+            primary_action=primary_action,
+            required_provider="construction.projects_ledger_provider.v1|construction.projects_detail_provider.v1",
+            fallback_policy=fallback_strategy,
+        ),
         "runtime": {
             "role_code": runtime_payload.get("role_code"),
             "company_id": runtime_payload.get("company_id"),
         },
     }
-

--- a/addons/smart_construction_scene/providers/task_board_provider.py
+++ b/addons/smart_construction_scene/providers/task_board_provider.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def build(scene_key: str = "task.board", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "任务看板",
+            "message": "从 route-first 的任务看板入口继续处理板式任务流，同时保持与 task.center 分离的工作语义。",
+        },
+        "primary_action": {
+            "label": "进入任务看板",
+            "route": "/s/task.board",
+            "semantic": "task_board_entry",
+        },
+        "fallback_strategy": {
+            "type": "route_compat",
+            "route": "/s/task.board",
+            "reason": "task.board stays as a route-first compat carrier without claiming native task action ownership",
+        },
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/providers/task_center_provider.py
+++ b/addons/smart_construction_scene/providers/task_center_provider.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_scene.services.workflow_rollout_handoff import (
+    build_direct_runtime_handoff,
+)
+
+
+def build(scene_key: str = "task.center", runtime: dict | None = None, context: dict | None = None) -> dict:
+    _ = context or {}
+    runtime_payload = runtime or {}
+    primary_action = {
+        "label": "进入任务工作台",
+        "action_xmlid": "project.action_view_all_task",
+        "semantic": "task_work_center_entry",
+    }
+    fallback_strategy = {
+        "type": "native_action_compat",
+        "action_xmlid": "project.action_view_all_task",
+        "reason": "keep the generic task native action available while task.center remains the canonical action-first work-center entry",
+    }
+    return {
+        "scene_key": scene_key,
+        "guidance": {
+            "title": "任务工作台",
+            "message": "从任务工作台进入任务列表、筛选和主动作处理，保持 action-first 的任务入口语义。",
+        },
+        "primary_action": primary_action,
+        "fallback_strategy": fallback_strategy,
+        "delivery_handoff_v1": build_direct_runtime_handoff(
+            family="tasks",
+            user_entry="action:project.action_view_all_task",
+            final_scene="task.center",
+            primary_action=primary_action,
+            required_provider="construction.task_center_provider.v1|construction.task_board_provider.v1",
+            fallback_policy=fallback_strategy,
+        ),
+        "runtime": {
+            "role_code": runtime_payload.get("role_code"),
+            "company_id": runtime_payload.get("company_id"),
+        },
+    }

--- a/addons/smart_construction_scene/scene_registry.py
+++ b/addons/smart_construction_scene/scene_registry.py
@@ -1,8 +1,11 @@
 # -*- coding: utf-8 -*-
 import json
 import os
+import time
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
+
+import yaml
 
 SCENE_VERSION = "v2"
 SCHEMA_VERSION = "v2"
@@ -46,31 +49,68 @@ def _load_scene_registry_content_module():
 
 
 def _load_scene_registry_content_entries():
+    rows, _timings = _load_scene_registry_content_entries_with_timings()
+    return rows
+
+
+def _load_scene_registry_content_entries_with_timings():
+    timings_ms = {}
+
+    def _mark(stage, started_at):
+        timings_ms[stage] = int((time.perf_counter() - started_at) * 1000)
+        return time.perf_counter()
+
     def _load_entries_directly():
         content_path = Path(__file__).resolve().parent / "profiles" / "scene_registry_content.py"
         if not content_path.exists():
-            return []
+            return [], {"direct_missing_content_path": 0}
+        direct_timings = {}
         try:
+            stage_ts = time.perf_counter()
             spec = spec_from_file_location("smart_construction_scene_registry_content", content_path)
             if spec is None or spec.loader is None:
-                return []
+                direct_timings["direct_module_spec"] = int((time.perf_counter() - stage_ts) * 1000)
+                return [], direct_timings
+            stage_ts = _mark_direct(direct_timings, "direct_module_spec", stage_ts)
             module = module_from_spec(spec)
             spec.loader.exec_module(module)
+            stage_ts = _mark_direct(direct_timings, "direct_module_exec", stage_ts)
             rows = module.list_scene_entries() if hasattr(module, "list_scene_entries") else []
-            return rows if isinstance(rows, list) else []
+            _mark_direct(direct_timings, "direct_list_scene_entries", stage_ts)
+            return (rows if isinstance(rows, list) else []), direct_timings
         except Exception:
-            return []
+            return [], direct_timings
 
+    def _mark_direct(bucket, stage, started_at):
+        bucket[stage] = int((time.perf_counter() - started_at) * 1000)
+        return time.perf_counter()
+
+    stage_ts = time.perf_counter()
     engine = _load_scene_registry_engine_module()
+    stage_ts = _mark("load_scene_registry_engine_module", stage_ts)
     loader = getattr(engine, "load_scene_registry_content_entries", None) if engine else None
+    timed_loader = getattr(engine, "load_scene_registry_content_entries_with_timings", None) if engine else None
     if callable(loader):
         try:
-            rows = loader(Path(__file__))
+            engine_ts = time.perf_counter()
+            if callable(timed_loader):
+                rows, engine_timings = timed_loader(Path(__file__))
+            else:
+                rows = loader(Path(__file__))
+                engine_timings = {}
+            _mark("engine_loader_call", engine_ts)
+            if isinstance(engine_timings, dict):
+                for key, value in engine_timings.items():
+                    timings_ms[f"engine.{key}"] = int(value)
             if isinstance(rows, list) and rows:
-                return rows
+                return rows, timings_ms
         except Exception:
             pass
-    return _load_entries_directly()
+    rows, direct_timings = _load_entries_directly()
+    if isinstance(direct_timings, dict):
+        for key, value in direct_timings.items():
+            timings_ms[key] = int(value)
+    return rows, timings_ms
 
 
 def _append_drift(drift, *, scene_key, kind, fields, severity="info", source="db->registry"):
@@ -163,6 +203,74 @@ def _normalize_scene(scene, drift=None, source="registry"):
             scene["tags"].append("smoke")
     scene = _apply_scene_defaults(scene, drift=drift, source=source)
     return scene
+
+
+def _scene_asset_root() -> Path:
+    return Path(__file__).resolve().parent / "scenes"
+
+
+def _normalize_scene_asset_payload(payload):
+    if not isinstance(payload, dict):
+        return {}
+    scene_key = str(payload.get("scene_key") or payload.get("code") or payload.get("key") or "").strip()
+    if not scene_key:
+        return {}
+    out = {
+        "code": scene_key,
+    }
+    scene_type = str(payload.get("scene_type") or "").strip()
+    if scene_type:
+        out["scene_type"] = scene_type
+
+    page = dict(payload.get("page") or {}) if isinstance(payload.get("page"), dict) else {}
+    if page:
+        out["page"] = page
+    zones = payload.get("zones")
+    if not isinstance(zones, list):
+        zones = page.get("zones") if isinstance(page.get("zones"), list) else []
+    if isinstance(zones, list) and zones:
+        out["zones"] = list(zones)
+
+    target = dict(payload.get("target") or {}) if isinstance(payload.get("target"), dict) else {}
+    route = str(page.get("route") or target.get("route") or "").strip()
+    if route:
+        target["route"] = route
+    if target:
+        out["target"] = target
+
+    for key in ("blocks", "search_surface", "permission_surface", "actions"):
+        value = payload.get(key)
+        if isinstance(value, list) and value:
+            out[key] = list(value)
+        elif isinstance(value, dict) and value:
+            out[key] = dict(value)
+    return out
+
+
+def _load_scene_asset_entries_with_timings():
+    timings_ms = {}
+    root = _scene_asset_root()
+    started = time.perf_counter()
+    if not root.exists():
+        timings_ms["asset_root_missing"] = int((time.perf_counter() - started) * 1000)
+        return [], timings_ms
+
+    stage = time.perf_counter()
+    paths = sorted(root.rglob("*.scene.yaml"))
+    timings_ms["discover_scene_asset_files"] = int((time.perf_counter() - stage) * 1000)
+
+    rows = []
+    stage = time.perf_counter()
+    for path in paths:
+        try:
+            payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except Exception:
+            continue
+        normalized = _normalize_scene_asset_payload(payload)
+        if normalized:
+            rows.append(normalized)
+    timings_ms["load_scene_asset_files"] = int((time.perf_counter() - stage) * 1000)
+    return rows, timings_ms
 
 
 def _apply_scene_defaults(scene, drift=None, source="registry"):
@@ -282,10 +390,25 @@ def _load_imported_scenes(env, drift=None):
 
 
 def load_scene_configs(env, drift=None):
+    scenes, _timings = load_scene_configs_with_timings(env, drift=drift)
+    return scenes
+
+
+def load_scene_configs_with_timings(env, drift=None):
+    timings_ms = {}
+
+    def _mark(stage, started_at):
+        timings_ms[stage] = int((time.perf_counter() - started_at) * 1000)
+        return time.perf_counter()
+
     # Prefer DB scenes if present; fallback to code-defined scenes.
+    stage_ts = time.perf_counter()
     db_scenes = _load_from_db(env, drift=drift)
+    stage_ts = _mark("load_from_db", stage_ts)
     imported_scenes = _load_imported_scenes(env, drift=drift)
+    stage_ts = _mark("load_imported_scenes", stage_ts)
     include_tests = _include_test_scenes(env)
+    stage_ts = _mark("include_test_scenes", stage_ts)
     # Note: keep configs data-only; target IDs are resolved by system_init.
     # Complete migration: platform fallback keeps only minimal internal defaults.
     fallback = [
@@ -304,25 +427,6 @@ def load_scene_configs(env, drift=None):
             "target": {"route": "/workbench?scene=scene_smoke_default"},
         },
     ]
-    for scene in _load_scene_registry_content_entries():
-        code = str(scene.get("code") or "").strip()
-        if not code:
-            continue
-        fallback = [item for item in fallback if str(item.get("code") or "").strip() != code]
-        fallback.append(scene)
-    if not db_scenes:
-        if not imported_scenes:
-            return _filter_test_scenes(fallback, include_tests)
-        imported_codes = {scene.get("code") for scene in imported_scenes if scene.get("code")}
-        merged = list(imported_scenes)
-        for scene in fallback:
-            if scene.get("code") not in imported_codes:
-                merged.append(scene)
-        return _filter_test_scenes(merged, include_tests)
-
-    fallback_map = {scene.get("code"): scene for scene in fallback}
-    imported_map = {scene.get("code"): scene for scene in imported_scenes if scene.get("code")}
-    seen = {scene.get("code") for scene in db_scenes if scene.get("code")}
 
     def _merge_missing(scene, defaults):
         for key, value in defaults.items():
@@ -340,6 +444,61 @@ def load_scene_configs(env, drift=None):
                 continue
             if isinstance(value, list) and not isinstance(current, list):
                 scene[key] = value
+
+    stage_ts = time.perf_counter()
+    content_entries, content_timings_ms = _load_scene_registry_content_entries_with_timings()
+    if isinstance(content_timings_ms, dict):
+        for key, value in content_timings_ms.items():
+            timings_ms[f"content_entries.{key}"] = int(value)
+    for scene in content_entries:
+        code = str(scene.get("code") or "").strip()
+        if not code:
+            continue
+        fallback = [item for item in fallback if str(item.get("code") or "").strip() != code]
+        fallback.append(scene)
+    stage_ts = _mark("load_scene_registry_content_entries", stage_ts)
+    stage_ts = time.perf_counter()
+    asset_entries, asset_timings_ms = _load_scene_asset_entries_with_timings()
+    if isinstance(asset_timings_ms, dict):
+        for key, value in asset_timings_ms.items():
+            timings_ms[f"scene_asset_entries.{key}"] = int(value)
+    fallback_map_for_assets = {
+        str(scene.get("code") or "").strip(): scene
+        for scene in fallback
+        if str(scene.get("code") or "").strip()
+    }
+    for asset in asset_entries:
+        code = str(asset.get("code") or "").strip()
+        if not code:
+            continue
+        existing = fallback_map_for_assets.get(code)
+        if existing:
+            _merge_missing(existing, asset)
+        else:
+            fallback.append(asset)
+            fallback_map_for_assets[code] = asset
+    stage_ts = _mark("load_scene_asset_entries", stage_ts)
+    if not db_scenes:
+        if not imported_scenes:
+            stage_ts = time.perf_counter()
+            filtered = _filter_test_scenes(fallback, include_tests)
+            _mark("filter_test_scenes", stage_ts)
+            return filtered, timings_ms
+        imported_codes = {scene.get("code") for scene in imported_scenes if scene.get("code")}
+        merged = list(imported_scenes)
+        for scene in fallback:
+            if scene.get("code") not in imported_codes:
+                merged.append(scene)
+        stage_ts = time.perf_counter()
+        filtered = _filter_test_scenes(merged, include_tests)
+        _mark("filter_test_scenes", stage_ts)
+        return filtered, timings_ms
+
+    stage_ts = time.perf_counter()
+    fallback_map = {scene.get("code"): scene for scene in fallback}
+    imported_map = {scene.get("code"): scene for scene in imported_scenes if scene.get("code")}
+    seen = {scene.get("code") for scene in db_scenes if scene.get("code")}
+    stage_ts = _mark("build_maps", stage_ts)
 
     def _upgrade_fallback_target(scene, defaults):
         current = scene.get("target")
@@ -364,6 +523,7 @@ def load_scene_configs(env, drift=None):
         if has_resolvable_default:
             scene["target"] = dict(default_target)
 
+    merge_ts = time.perf_counter()
     for scene in db_scenes:
         code = scene.get("code")
         if not code:
@@ -375,7 +535,9 @@ def load_scene_configs(env, drift=None):
         imported = imported_map.get(code)
         if imported:
             _merge_missing(scene, imported)
+    merge_ts = _mark("merge_db_with_fallback_and_imported", merge_ts)
 
+    append_ts = time.perf_counter()
     for code, scene in imported_map.items():
         if code not in seen:
             db_scenes.append(scene)
@@ -384,4 +546,8 @@ def load_scene_configs(env, drift=None):
     for code, scene in fallback_map.items():
         if code not in seen:
             db_scenes.append(scene)
-    return _filter_test_scenes(db_scenes, include_tests)
+    _mark("append_missing_imported_and_fallback", append_ts)
+    stage_ts = time.perf_counter()
+    filtered = _filter_test_scenes(db_scenes, include_tests)
+    _mark("filter_test_scenes", stage_ts)
+    return filtered, timings_ms

--- a/addons/smart_construction_scene/scenes/cost/cost.project_budget.scene.yaml
+++ b/addons/smart_construction_scene/scenes/cost/cost.project_budget.scene.yaml
@@ -1,0 +1,22 @@
+scene_key: cost.project_budget
+scene_type: list
+page:
+  route: /s/cost.project_budget
+  zones:
+    - name: header
+      blocks: [scene.header]
+    - name: search
+      blocks: [scene.search]
+    - name: main
+      blocks: [scene.list]
+blocks:
+  - type: list_block
+    zone: main
+    source: ui_base_contract.views.tree
+  - type: insight_block
+    zone: header
+    provider: construction.cost_project_budget_provider
+search_surface:
+  source: ui_base_contract.search
+permission_surface:
+  source: ui_base_contract.permissions

--- a/addons/smart_construction_scene/scenes/projects/projects.ledger.scene.yaml
+++ b/addons/smart_construction_scene/scenes/projects/projects.ledger.scene.yaml
@@ -1,0 +1,22 @@
+scene_key: projects.ledger
+scene_type: list
+page:
+  route: /s/projects.ledger
+  zones:
+    - name: header
+      blocks: [scene.header]
+    - name: search
+      blocks: [scene.search]
+    - name: main
+      blocks: [scene.list]
+blocks:
+  - type: list_block
+    zone: main
+    source: ui_base_contract.views.tree
+  - type: insight_block
+    zone: header
+    provider: construction.projects_ledger_provider
+search_surface:
+  source: ui_base_contract.search
+permission_surface:
+  source: ui_base_contract.permissions

--- a/addons/smart_construction_scene/services/__init__.py
+++ b/addons/smart_construction_scene/services/__init__.py
@@ -1,3 +1,12 @@
 # -*- coding: utf-8 -*-
-from . import scene_governance_service  # noqa: F401
-from . import scene_package_service  # noqa: F401
+from . import capability_scene_targets  # noqa: F401
+from . import my_work_scene_targets  # noqa: F401
+from . import project_management_entry_target  # noqa: F401
+
+try:
+    from . import scene_governance_service  # noqa: F401
+    from . import scene_package_service  # noqa: F401
+except (ImportError, ModuleNotFoundError) as exc:
+    message = str(exc)
+    if "odoo" not in message and getattr(exc, "name", "") != "odoo":
+        raise

--- a/addons/smart_construction_scene/services/capability_scene_targets.py
+++ b/addons/smart_construction_scene/services/capability_scene_targets.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Tuple
+
+from odoo.addons.smart_construction_scene import scene_registry
+
+
+_SCENE_CONFIGS_CACHE: dict[str, list[dict[str, Any]]] = {}
+_SCENE_MAP_CACHE: dict[str, dict[str, dict[str, Any]]] = {}
+_TARGET_SCENE_LOOKUP_CACHE: dict[str, dict[tuple[str, str], str]] = {}
+
+
+CAPABILITY_ENTRY_SCENE_MAP: dict[str, str] = {
+    "project.initiation.enter": "projects.intake",
+    "project.list.open": "projects.list",
+    "project.board.open": "projects.ledger",
+    "project.dashboard.enter": "project.management",
+    "project.dashboard.open": "project.management",
+    "project.plan_bootstrap.enter": "project.plan_bootstrap",
+    "project.execution.enter": "project.execution",
+    "project.execution.advance": "project.execution",
+    "project.lifecycle.open": "portal.lifecycle",
+    "project.task.list": "task.center",
+    "project.task.board": "task.board",
+    "project.document.open": "projects.ledger",
+    "project.structure.manage": "cost.project_boq",
+    "project.risk.list": "projects.ledger",
+    "project.weekly_report.open": "projects.ledger",
+    "project.lifecycle.transition": "portal.lifecycle",
+    "finance.payment_request.list": "finance.payment_requests",
+    "finance.payment_request.form": "finance.payment_requests",
+    "finance.approval.center": "finance.center",
+    "finance.ledger.payment": "finance.payment_ledger",
+    "finance.ledger.treasury": "finance.treasury_ledger",
+    "finance.settlement.order": "finance.settlement_orders",
+    "finance.invoice.list": "finance.center",
+    "finance.plan.funding": "finance.center",
+    "finance.metrics.operating": "finance.operating_metrics",
+    "finance.exception.monitor": "finance.operating_metrics",
+    "cost.ledger.open": "cost.project_cost_ledger",
+    "cost.budget.manage": "cost.project_budget",
+    "cost.boq.manage": "cost.project_boq",
+    "cost.progress.report": "cost.project_progress",
+    "cost.profit.compare": "cost.profit_compare",
+    "contract.center.open": "contract.center",
+    "contract.income.track": "projects.ledger",
+    "contract.expense.track": "projects.ledger",
+    "contract.settlement.audit": "finance.settlement_orders",
+    "analytics.dashboard.executive": "projects.dashboard",
+    "analytics.lifecycle.monitor": "portal.lifecycle",
+    "analytics.exception.list": "finance.operating_metrics",
+    "analytics.project.focus": "projects.list",
+    "governance.capability.matrix": "portal.capability_matrix",
+    "governance.scene.openability": "portal.capability_matrix",
+    "governance.runtime.audit": "portal.dashboard",
+    "material.catalog.open": "projects.ledger",
+    "material.procurement.list": "projects.ledger",
+    "workspace.today.focus": "portal.dashboard",
+    "workspace.project.watch": "projects.list",
+}
+
+EXECUTION_SOURCE_SCENE_MAP: dict[str, str] = {
+    "construction.contract": "contracts.list",
+    "payment.request": "finance.payment_requests",
+    "sc.settlement.order": "settlement",
+}
+
+
+def _resolve_ref_id(env, xmlid: str) -> int | None:
+    value = str(xmlid or "").strip()
+    if not value:
+        return None
+    rec = env.ref(value, raise_if_not_found=False)
+    if not rec:
+        return None
+    return int(rec.id)
+
+
+def _resolve_scene_map(env) -> dict[str, dict[str, Any]]:
+    scenes = scene_registry.load_scene_configs(env)
+    out: dict[str, dict[str, Any]] = {}
+    for scene in scenes or []:
+        if not isinstance(scene, dict):
+            continue
+        key = str(scene.get("code") or scene.get("key") or "").strip()
+        if not key:
+            continue
+        out[key] = dict(scene)
+    return out
+
+
+def _scene_cache_key(env) -> str:
+    try:
+        dbname = str(getattr(getattr(env, "cr", None), "dbname", "") or "").strip()
+    except Exception:
+        dbname = ""
+    return dbname or "__default__"
+
+
+def _load_scene_map_with_timings(env) -> Tuple[dict[str, dict[str, Any]], dict[str, int]]:
+    cache_key = _scene_cache_key(env)
+    cached_map = _SCENE_MAP_CACHE.get(cache_key)
+    if isinstance(cached_map, dict):
+        return cached_map, {
+            "load_scene_configs_cache_hit": 0,
+            "build_scene_map_cache_hit": 0,
+        }
+
+    timings_ms: dict[str, int] = {}
+    scenes, scene_config_timings_ms = scene_registry.load_scene_configs_with_timings(env)
+    if isinstance(scene_config_timings_ms, dict):
+        for key, value in scene_config_timings_ms.items():
+            timings_ms[key] = int(value)
+    if isinstance(scenes, list):
+        _SCENE_CONFIGS_CACHE[cache_key] = list(scenes)
+    map_ts = time.perf_counter()
+    scene_map = {
+        str(scene.get("code") or scene.get("key") or "").strip(): dict(scene)
+        for scene in (scenes or [])
+        if isinstance(scene, dict) and str(scene.get("code") or scene.get("key") or "").strip()
+    }
+    timings_ms["build_scene_map"] = int((time.perf_counter() - map_ts) * 1000)
+    _SCENE_MAP_CACHE[cache_key] = scene_map
+    return scene_map, timings_ms
+
+
+def _build_target_scene_lookup(env) -> dict[tuple[str, str], str]:
+    cache_key = _scene_cache_key(env)
+    cached = _TARGET_SCENE_LOOKUP_CACHE.get(cache_key)
+    if isinstance(cached, dict):
+        return cached
+
+    scene_map, _timings = _load_scene_map_with_timings(env)
+    lookup: dict[tuple[str, str], str] = {}
+    for scene_key, scene in (scene_map or {}).items():
+        if not isinstance(scene, dict):
+            continue
+        target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+        action_xmlid = str(target.get("action_xmlid") or "").strip()
+        menu_xmlid = str(target.get("menu_xmlid") or "").strip()
+        model = str(target.get("model") or "").strip()
+        view_mode = str(target.get("view_mode") or target.get("view_type") or "").strip().lower()
+        if action_xmlid:
+            lookup.setdefault(("action_xmlid", action_xmlid), scene_key)
+        if menu_xmlid:
+            lookup.setdefault(("menu_xmlid", menu_xmlid), scene_key)
+        if model and view_mode:
+            lookup.setdefault(("model_view", f"{model}:{view_mode}"), scene_key)
+    _TARGET_SCENE_LOOKUP_CACHE[cache_key] = lookup
+    return lookup
+
+
+def _derive_scene_key_from_explicit_target(env, explicit_target: dict[str, Any] | None = None) -> str:
+    if not env or not isinstance(explicit_target, dict):
+        return ""
+    lookup = _build_target_scene_lookup(env)
+    action_xmlid = str(explicit_target.get("action_xmlid") or "").strip()
+    if action_xmlid:
+        scene_key = str(lookup.get(("action_xmlid", action_xmlid), "") or "").strip()
+        if scene_key:
+            return scene_key
+    menu_xmlid = str(explicit_target.get("menu_xmlid") or "").strip()
+    if menu_xmlid:
+        scene_key = str(lookup.get(("menu_xmlid", menu_xmlid), "") or "").strip()
+        if scene_key:
+            return scene_key
+    model = str(explicit_target.get("model") or "").strip()
+    view_mode = str(explicit_target.get("view_mode") or explicit_target.get("view_type") or "").strip().lower()
+    if model and view_mode:
+        return str(lookup.get(("model_view", f"{model}:{view_mode}"), "") or "").strip()
+    return ""
+
+
+def resolve_capability_entry_scene_key(
+    capability_key: str,
+    *,
+    env=None,
+    explicit_target: dict[str, Any] | None = None,
+) -> str:
+    resolved = str(CAPABILITY_ENTRY_SCENE_MAP.get(str(capability_key or "").strip(), "") or "").strip()
+    if resolved:
+        return resolved
+    return _derive_scene_key_from_explicit_target(env, explicit_target=explicit_target)
+
+
+def build_capability_entry_target(
+    capability_key: str,
+    explicit_target: dict[str, Any] | None = None,
+    *,
+    env=None,
+) -> dict[str, Any]:
+    target = dict(explicit_target or {})
+    scene_key = resolve_capability_entry_scene_key(
+        capability_key,
+        env=env,
+        explicit_target=explicit_target,
+    )
+    if scene_key and not str(target.get("scene_key") or "").strip():
+        target["scene_key"] = scene_key
+    return target
+
+
+def resolve_capability_entry_target_payload(env, capability_key: str, explicit_target: dict[str, Any] | None = None) -> dict[str, Any]:
+    payload, _timings = resolve_capability_entry_target_payload_with_timings(
+        env,
+        capability_key,
+        explicit_target=explicit_target,
+    )
+    return payload
+
+
+def resolve_capability_entry_target_payload_with_timings(
+    env,
+    capability_key: str,
+    explicit_target: dict[str, Any] | None = None,
+) -> Tuple[dict[str, Any], dict[str, int]]:
+    timings_ms: dict[str, int] = {}
+
+    def _mark(stage: str, started_at: float) -> float:
+        timings_ms[stage] = int((time.perf_counter() - started_at) * 1000)
+        return time.perf_counter()
+
+    stage_ts = time.perf_counter()
+    target = build_capability_entry_target(capability_key, explicit_target=explicit_target, env=env)
+    stage_ts = _mark("build_capability_entry_target", stage_ts)
+    scene_key = str(target.get("scene_key") or "").strip()
+    payload: dict[str, Any] = {}
+    if scene_key:
+        payload["scene_key"] = scene_key
+        scene_ts = time.perf_counter()
+        scene_map, scene_map_timings_ms = _load_scene_map_with_timings(env)
+        scene_ts = _mark("resolve_scene_map", scene_ts)
+        if isinstance(scene_map_timings_ms, dict):
+            for key, value in scene_map_timings_ms.items():
+                timings_ms[f"scene_registry.{key}"] = int(value)
+        scene = scene_map.get(scene_key) or {}
+        scene_target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+        payload["route"] = str(scene_target.get("route") or f"/workbench?scene={scene_key}")
+        for key in ("model", "view_type", "view_mode", "record_id"):
+            if scene_target.get(key) not in (None, ""):
+                payload[key] = scene_target.get(key)
+        action_xmlid = str(scene_target.get("action_xmlid") or "").strip()
+        menu_xmlid = str(scene_target.get("menu_xmlid") or "").strip()
+        action_id = scene_target.get("action_id")
+        menu_id = scene_target.get("menu_id")
+        xmlid_ts = time.perf_counter()
+        if action_xmlid and not action_id:
+            action_id = _resolve_ref_id(env, action_xmlid)
+        if menu_xmlid and not menu_id:
+            menu_id = _resolve_ref_id(env, menu_xmlid)
+        _mark("resolve_xmlids", xmlid_ts)
+        if action_id:
+            payload["action_id"] = int(action_id)
+        if menu_id:
+            payload["menu_id"] = int(menu_id)
+        stage_ts = _mark("scene_target_payload", stage_ts)
+    for key in ("route", "model", "view_type", "view_mode", "record_id", "action_id", "menu_id"):
+        if target.get(key) not in (None, ""):
+            payload[key] = target.get(key)
+    _mark("overlay_explicit_target", stage_ts)
+    return payload, timings_ms
+
+
+def resolve_execution_projection_scene_key(source_model: str, explicit_scene_key: str = "") -> str:
+    explicit = str(explicit_scene_key or "").strip()
+    if explicit:
+        return explicit
+    return str(EXECUTION_SOURCE_SCENE_MAP.get(str(source_model or "").strip(), "projects.list") or "projects.list")

--- a/addons/smart_construction_scene/services/my_work_scene_targets.py
+++ b/addons/smart_construction_scene/services/my_work_scene_targets.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List
+
+
+DEFAULT_MY_WORK_SCENE_KEY = "projects.list"
+
+
+def resolve_my_work_scene_key(
+    *,
+    explicit_scene_key: str = "",
+    model_name: str = "",
+    source_key: str = "",
+    section_key: str = "",
+) -> str:
+    explicit = str(explicit_scene_key or "").strip()
+    if explicit:
+        return explicit
+
+    normalized_model = str(model_name or "").strip()
+    normalized_source = str(source_key or "").strip()
+    normalized_section = str(section_key or "").strip().lower()
+
+    model_map = {
+        "project.project": "projects.detail",
+        "project.task": "task.center",
+        "payment.request": "finance.payment_requests",
+        "construction.contract": "contracts.list",
+        "sc.settlement.order": "settlement",
+        "sc.workflow.instance": "projects.list",
+        "sale.order": "contracts.list",
+        "account.move": "finance.vouchers.list",
+    }
+    if normalized_model in model_map:
+        return model_map[normalized_model]
+
+    source_map = {
+        "project.task": "task.center",
+        "project.project": "projects.detail",
+        "project.risk": "projects.list",
+        "mail.activity": "projects.list",
+        "mail.message": "projects.list",
+        "mail.followers": "projects.list",
+        "tier.review": "projects.list",
+        "sc.workflow.workitem": "projects.list",
+    }
+    if normalized_source in source_map:
+        return source_map[normalized_source]
+
+    if normalized_section in {"todo", "owned", "mentions", "following"}:
+        return DEFAULT_MY_WORK_SCENE_KEY
+    return DEFAULT_MY_WORK_SCENE_KEY
+
+
+def build_my_work_target(
+    *,
+    model_name: str = "",
+    record_id: int = 0,
+    action_id: int = 0,
+    menu_id: int = 0,
+    explicit_scene_key: str = "",
+    source_key: str = "",
+    section_key: str = "",
+) -> Dict[str, Any]:
+    model = str(model_name or "").strip()
+    rid = int(record_id or 0)
+    scene_key = resolve_my_work_scene_key(
+        explicit_scene_key=explicit_scene_key,
+        model_name=model,
+        source_key=source_key,
+        section_key=section_key,
+    )
+    target = {
+        "kind": "record" if model and rid else "scene",
+        "scene_key": scene_key,
+    }
+    if model:
+        target["model"] = model
+    if rid:
+        target["record_id"] = rid
+    if int(action_id or 0) > 0:
+        target["action_id"] = int(action_id)
+    if int(menu_id or 0) > 0:
+        target["menu_id"] = int(menu_id)
+    return target
+
+
+def build_my_work_section_rows(section_labels: Dict[str, str]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for key in ("todo", "owned", "mentions", "following"):
+        rows.append(
+            {
+                "key": key,
+                "label": str((section_labels or {}).get(key) or key),
+                "scene_key": resolve_my_work_scene_key(section_key=key),
+            }
+        )
+    return rows
+
+
+def build_my_work_summary_rows(summary_items: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for item in list(summary_items or []):
+        if not isinstance(item, dict):
+            continue
+        row = dict(item)
+        row["scene_key"] = resolve_my_work_scene_key(
+            explicit_scene_key=str(row.get("scene_key") or ""),
+            source_key=str(row.get("source") or ""),
+            section_key=str(row.get("key") or ""),
+        )
+        rows.append(row)
+    return rows

--- a/addons/smart_construction_scene/services/workflow_rollout_handoff.py
+++ b/addons/smart_construction_scene/services/workflow_rollout_handoff.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+def _text(value) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value) -> dict:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def build_direct_runtime_handoff(
+    *,
+    family: str,
+    user_entry: str,
+    final_scene: str,
+    primary_action: dict,
+    required_provider: str,
+    fallback_policy: dict,
+    rollout_wave: str = "wave_1",
+) -> dict:
+    return {
+        "owner_layer": "scene_orchestration",
+        "rollout_wave": rollout_wave,
+        "family": family,
+        "runtime_entry_type": "governed_user_flow",
+        "runtime_consumer": "family_runtime_consumer",
+        "runtime_mode": "direct",
+        "user_entry": user_entry,
+        "final_scene": final_scene,
+        "primary_action": dict(primary_action),
+        "required_provider": required_provider,
+        "fallback_policy": dict(fallback_policy),
+        "acceptance": {
+            "runtime_ready": True,
+            "workflow_ready": True,
+            "advisory_only": True,
+        },
+    }
+
+
+def build_wave1_rollout_handoff(runtime_handoff_surface: dict | None) -> dict:
+    runtime_handoff = _as_dict(runtime_handoff_surface)
+    if not runtime_handoff:
+        return {}
+
+    consume_mode = _text(runtime_handoff.get("consume_mode")) or "direct"
+    advisory_only = consume_mode == "advisory"
+    rollout_mode = "advisory_only" if advisory_only else "direct_runtime_handoff"
+
+    return {
+        "owner_layer": "scene_orchestration",
+        "rollout_wave": "wave_1",
+        "family": _text(runtime_handoff.get("family")),
+        "rollout_mode": rollout_mode,
+        "consume_mode": consume_mode,
+        "runtime_entry_type": _text(runtime_handoff.get("runtime_entry_type")) or "governed_user_flow",
+        "runtime_consumer": _text(runtime_handoff.get("runtime_consumer")) or "family_runtime_consumer",
+        "runtime_mode": _text(runtime_handoff.get("runtime_mode")) or "direct",
+        "user_entry": _text(runtime_handoff.get("user_entry")),
+        "final_scene": _text(runtime_handoff.get("final_scene")),
+        "primary_action": _as_dict(runtime_handoff.get("primary_action")),
+        "required_provider": _text(runtime_handoff.get("required_provider")),
+        "fallback_policy": _as_dict(runtime_handoff.get("fallback_policy")),
+        "acceptance": {
+            "runtime_ready": bool(runtime_handoff.get("runtime_ready")),
+            "workflow_ready": bool(runtime_handoff.get("workflow_ready")),
+            "advisory_only": advisory_only,
+        },
+    }

--- a/addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py
+++ b/addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py
@@ -1,0 +1,785 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+SCENE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+
+scene_pkg = sys.modules.setdefault("odoo.addons.smart_construction_scene", types.ModuleType("odoo.addons.smart_construction_scene"))
+scene_pkg.__path__ = [str(SCENE_DIR)]
+
+scene_registry_mod = types.ModuleType("odoo.addons.smart_construction_scene.scene_registry")
+scene_registry_mod.load_scene_configs = lambda env: []
+scene_registry_mod.load_scene_configs_with_timings = lambda env: ([], {})
+sys.modules["odoo.addons.smart_construction_scene.scene_registry"] = scene_registry_mod
+scene_pkg.scene_registry = scene_registry_mod
+
+enterprise_base_pkg = sys.modules.setdefault("odoo.addons.smart_enterprise_base", types.ModuleType("odoo.addons.smart_enterprise_base"))
+enterprise_base_pkg.__path__ = [str(SCENE_DIR.parent / "smart_enterprise_base")]
+
+target_core_extension = _load_module(
+    "odoo.addons.smart_construction_scene.core_extension",
+    SCENE_DIR / "core_extension.py",
+)
+scene_merge_resolver = _load_module(
+    "odoo.addons.smart_core.core.scene_merge_resolver",
+    SCENE_DIR.parent / "smart_core" / "core" / "scene_merge_resolver.py",
+)
+project_dashboard_scene_content = _load_module(
+    "odoo.addons.smart_construction_scene.profiles.project_dashboard_scene_content",
+    SCENE_DIR / "profiles" / "project_dashboard_scene_content.py",
+)
+enterprise_bootstrap_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.enterprise_bootstrap_provider",
+    SCENE_DIR / "providers" / "enterprise_bootstrap_provider.py",
+)
+contract_center_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.contract_center_provider",
+    SCENE_DIR / "providers" / "contract_center_provider.py",
+)
+contracts_workspace_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.contracts_workspace_provider",
+    SCENE_DIR / "providers" / "contracts_workspace_provider.py",
+)
+workflow_rollout_handoff = _load_module(
+    "odoo.addons.smart_construction_scene.services.workflow_rollout_handoff",
+    SCENE_DIR / "services" / "workflow_rollout_handoff.py",
+)
+approval_workbench_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.approval_workbench_provider",
+    SCENE_DIR / "providers" / "approval_workbench_provider.py",
+)
+projects_list_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.projects_list_provider",
+    SCENE_DIR / "providers" / "projects_list_provider.py",
+)
+finance_center_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.finance_center_provider",
+    SCENE_DIR / "providers" / "finance_center_provider.py",
+)
+cost_project_budget_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.cost_project_budget_provider",
+    SCENE_DIR / "providers" / "cost_project_budget_provider.py",
+)
+task_center_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.task_center_provider",
+    SCENE_DIR / "providers" / "task_center_provider.py",
+)
+payment_entry_workbench_provider = _load_module(
+    "odoo.addons.smart_construction_scene.providers.payment_entry_workbench_provider",
+    SCENE_DIR / "providers" / "payment_entry_workbench_provider.py",
+)
+register_scene_providers = _load_module(
+    "odoo.addons.smart_construction_scene.bootstrap.register_scene_providers",
+    SCENE_DIR / "bootstrap" / "register_scene_providers.py",
+)
+enterprise_base_core_extension = _load_module(
+    "odoo.addons.smart_enterprise_base.core_extension",
+    SCENE_DIR.parent / "smart_enterprise_base" / "core_extension.py",
+)
+scene_registry_content = _load_module(
+    "odoo.addons.smart_construction_scene.profiles.scene_registry_content",
+    SCENE_DIR / "profiles" / "scene_registry_content.py",
+)
+target_capability = _load_module(
+    "odoo.addons.smart_construction_scene.services.capability_scene_targets",
+    SCENE_DIR / "services" / "capability_scene_targets.py",
+)
+scene_ready_bridge = _load_module(
+    "odoo.addons.smart_core.core.scene_ready_semantic_orchestration_bridge",
+    SCENE_DIR.parent / "smart_core" / "core" / "scene_ready_semantic_orchestration_bridge.py",
+)
+
+
+class _DummyRef:
+    def __init__(self, record_id: int):
+        self.id = record_id
+
+
+class _DummyCursor:
+    dbname = "test_sc_scene_semantic_supply"
+
+
+class _DummyEnv:
+    def __init__(self, refs=None):
+        self.cr = _DummyCursor()
+        self._refs = dict(refs or {})
+
+    def ref(self, xmlid, raise_if_not_found=False):
+        record_id = self._refs.get(str(xmlid or "").strip())
+        if not record_id:
+            return None
+        return _DummyRef(int(record_id))
+
+    @property
+    def company(self):
+        return None
+
+    def __getitem__(self, model_name):
+        return _DummyModel(model_name)
+
+
+class _DummyModel:
+    def __init__(self, model_name: str):
+        self._model_name = model_name
+
+    def sudo(self):
+        return self
+
+    def search_count(self, domain):
+        _ = domain
+        return 0
+
+
+class _DummyUser:
+    def __init__(self):
+        self.id = 7
+        self.company_id = None
+
+
+class _DummyRegistry:
+    def __init__(self):
+        self.specs = []
+
+    def register_spec(self, **kwargs):
+        self.specs.append(dict(kwargs))
+
+
+def _reset_caches():
+    target_core_extension._DERIVED_NAV_SCENE_MAP_CACHE.clear()
+    target_capability._SCENE_CONFIGS_CACHE.clear()
+    target_capability._SCENE_MAP_CACHE.clear()
+    target_capability._TARGET_SCENE_LOOKUP_CACHE.clear()
+
+
+class TestActionOnlySceneSemanticSupply(unittest.TestCase):
+    def test_project_dashboard_entry_capability_converges_to_project_management_scene(self):
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["project.dashboard.enter"],
+            "project.management",
+        )
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["project.dashboard.open"],
+            "project.management",
+        )
+
+    def test_project_management_scene_declares_explicit_dashboard_action_target(self):
+        rows = scene_registry_content.list_scene_entries()
+        project_management = next((row for row in rows if row.get("code") == "project.management"), {})
+        target = project_management.get("target") if isinstance(project_management.get("target"), dict) else {}
+
+        self.assertEqual(target.get("menu_xmlid"), "smart_construction_core.menu_sc_project_management_scene")
+        self.assertEqual(target.get("action_xmlid"), "smart_construction_core.action_project_dashboard")
+        self.assertEqual(target.get("route"), "/s/project.management")
+
+    def test_project_intake_scene_is_canonical_registry_owner_for_project_initiation_menu(self):
+        rows = scene_registry_content.list_scene_entries()
+        project_intake = next((row for row in rows if row.get("code") == "projects.intake"), {})
+        project_initiation = next((row for row in rows if row.get("code") == "project.initiation"), {})
+
+        self.assertEqual(((project_intake.get("target") or {}).get("route")), "/s/projects.intake")
+        self.assertEqual(
+            ((project_intake.get("target") or {}).get("menu_xmlid")),
+            "smart_construction_core.menu_sc_project_initiation",
+        )
+        self.assertEqual(
+            ((project_intake.get("target") or {}).get("action_xmlid")),
+            "smart_construction_core.action_project_initiation",
+        )
+        self.assertEqual(((project_initiation.get("target") or {}).get("route")), "/s/project.initiation")
+        self.assertFalse(bool(((project_initiation.get("target") or {}).get("menu_xmlid"))))
+        self.assertFalse(bool(((project_initiation.get("target") or {}).get("action_xmlid"))))
+
+    def test_project_initiation_entry_capability_converges_to_projects_intake_scene(self):
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["project.initiation.enter"],
+            "projects.intake",
+        )
+
+    def test_projects_list_scene_supplies_canonical_route_with_native_menu_action_parity(self):
+        rows = scene_registry_content.list_scene_entries()
+        projects_list = next((row for row in rows if row.get("code") == "projects.list"), {})
+
+        self.assertEqual(((projects_list.get("target") or {}).get("route")), "/s/projects.list")
+        self.assertEqual(
+            ((projects_list.get("target") or {}).get("menu_xmlid")),
+            "smart_construction_core.menu_sc_root",
+        )
+        self.assertEqual(
+            ((projects_list.get("target") or {}).get("action_xmlid")),
+            "smart_construction_core.action_sc_project_list",
+        )
+
+    def test_task_center_scene_supplies_canonical_route_without_menu_authority(self):
+        rows = scene_registry_content.list_scene_entries()
+        task_center = next((row for row in rows if row.get("code") == "task.center"), {})
+        task_board = next((row for row in rows if row.get("code") == "task.board"), {})
+
+        self.assertEqual(((task_center.get("target") or {}).get("route")), "/s/task.center")
+        self.assertEqual(((task_center.get("target") or {}).get("action_xmlid")), "project.action_view_all_task")
+        self.assertFalse(bool(((task_center.get("target") or {}).get("menu_xmlid"))))
+        self.assertEqual(((task_board.get("target") or {}).get("route")), "/s/task.board")
+        self.assertFalse(bool(((task_board.get("target") or {}).get("menu_xmlid"))))
+        self.assertFalse(bool(((task_board.get("target") or {}).get("action_xmlid"))))
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["project.task.list"],
+            "task.center",
+        )
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["project.task.board"],
+            "task.board",
+        )
+
+    def test_projects_ledger_scene_supplies_canonical_route_with_shared_native_parity(self):
+        rows = scene_registry_content.list_scene_entries()
+        projects_ledger = next((row for row in rows if row.get("code") == "projects.ledger"), {})
+
+        self.assertEqual(((projects_ledger.get("target") or {}).get("route")), "/s/projects.ledger")
+        self.assertEqual(
+            ((projects_ledger.get("target") or {}).get("menu_xmlid")),
+            "smart_construction_core.menu_sc_project_project",
+        )
+        self.assertEqual(
+            ((projects_ledger.get("target") or {}).get("action_xmlid")),
+            "smart_construction_core.action_sc_project_kanban_lifecycle",
+        )
+
+    def test_projects_detail_scene_keeps_route_and_menu_without_sharing_ledger_action_authority(self):
+        rows = scene_registry_content.list_scene_entries()
+        projects_detail = next((row for row in rows if row.get("code") == "projects.detail"), {})
+
+        self.assertEqual(((projects_detail.get("target") or {}).get("route")), "/s/projects.detail")
+        self.assertEqual(
+            ((projects_detail.get("target") or {}).get("menu_xmlid")),
+            "smart_construction_core.menu_sc_project_project",
+        )
+        self.assertIsNone(((projects_detail.get("target") or {}).get("action_xmlid")))
+
+    def test_finance_center_scene_targets_align_with_root_menu_action(self):
+        rows = scene_registry_content.list_scene_entries()
+        finance_center = next((row for row in rows if row.get("code") == "finance.center"), {})
+        finance_workspace = next((row for row in rows if row.get("code") == "finance.workspace"), {})
+
+        self.assertEqual(((finance_center.get("target") or {}).get("route")), "/s/finance.center")
+        self.assertEqual(((finance_center.get("target") or {}).get("menu_xmlid")), "smart_construction_core.menu_sc_finance_center")
+        self.assertEqual(((finance_center.get("target") or {}).get("action_xmlid")), "smart_construction_core.action_sc_finance_dashboard")
+        self.assertEqual(((finance_workspace.get("target") or {}).get("route")), "/s/finance.workspace")
+        self.assertEqual(((finance_workspace.get("target") or {}).get("menu_xmlid")), "smart_construction_core.menu_sc_finance_center")
+        self.assertIsNone(((finance_workspace.get("target") or {}).get("action_xmlid")))
+
+    def test_payments_approval_scene_supplies_formal_approval_action_target(self):
+        rows = scene_registry_content.list_scene_entries()
+        approval = next((row for row in rows if row.get("code") == "payments.approval"), {})
+
+        self.assertEqual(((approval.get("target") or {}).get("route")), "/s/payments.approval")
+        self.assertEqual(
+            ((approval.get("target") or {}).get("menu_xmlid")),
+            "smart_construction_core.menu_sc_tier_review_my_payment_request",
+        )
+        self.assertEqual(
+            ((approval.get("target") or {}).get("action_xmlid")),
+            "smart_construction_core.action_sc_tier_review_my_payment_request",
+        )
+
+    def test_finance_payment_requests_scene_aligns_with_personal_entry_action(self):
+        rows = scene_registry_content.list_scene_entries()
+        payment_requests = next((row for row in rows if row.get("code") == "finance.payment_requests"), {})
+
+        self.assertEqual(((payment_requests.get("target") or {}).get("route")), "/s/finance.payment_requests")
+        self.assertEqual(((payment_requests.get("target") or {}).get("menu_xmlid")), "smart_construction_core.menu_payment_request")
+        self.assertEqual(
+            ((payment_requests.get("target") or {}).get("action_xmlid")),
+            "smart_construction_core.action_payment_request_my",
+        )
+
+    def test_cost_project_budget_scene_prefers_direct_scene_route_over_native_action_target(self):
+        rows = scene_registry_content.list_scene_entries()
+        budget = next((row for row in rows if row.get("code") == "cost.project_budget"), {})
+
+        self.assertEqual(((budget.get("target") or {}).get("route")), "/s/cost.project_budget")
+        self.assertFalse(bool(((budget.get("target") or {}).get("menu_xmlid"))))
+        self.assertFalse(bool(((budget.get("target") or {}).get("action_xmlid"))))
+
+    def test_cost_project_budget_provider_supplies_guidance_payload(self):
+        payload = cost_project_budget_provider.build(scene_key="cost.project_budget", runtime={"company_id": 9})
+
+        self.assertEqual(payload.get("scene_key"), "cost.project_budget")
+        self.assertEqual(((payload.get("guidance") or {}).get("title")), "预算管理")
+        self.assertEqual(((payload.get("runtime") or {}).get("company_id")), 9)
+
+    def test_finance_menu_scene_maps_keep_payment_list_and_approval_split(self):
+        _reset_caches()
+        target_core_extension.scene_registry.load_scene_configs = lambda env: list(scene_registry_content.list_scene_entries())
+        maps = target_core_extension.smart_core_nav_scene_maps(_DummyEnv())
+
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_payment_request"],
+            "finance.payment_requests",
+        )
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_sc_tier_review_my_payment_request"],
+            "payments.approval",
+        )
+
+    def test_contract_center_capability_converges_to_contract_family_root_authority(self):
+        self.assertEqual(
+            target_capability.CAPABILITY_ENTRY_SCENE_MAP["contract.center.open"],
+            "contract.center",
+        )
+
+    def test_contract_center_provider_supplies_delivery_handoff_v1(self):
+        payload = contract_center_provider.build(scene_key="contract.center", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(((payload.get("primary_action") or {}).get("route")), "/s/contract.center")
+        self.assertEqual(handoff.get("family"), "contracts")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "menu:smart_construction_core.menu_sc_contract_center")
+        self.assertEqual(handoff.get("final_scene"), "contract.center")
+
+    def test_contract_center_registry_target_is_scene_first(self):
+        rows = scene_registry_content.list_scene_entries()
+        contract_center = next((row for row in rows if row.get("code") == "contract.center"), {})
+        target = contract_center.get("target") or {}
+
+        self.assertEqual(target.get("route"), "/s/contract.center")
+        self.assertEqual(target.get("menu_xmlid"), "smart_construction_core.menu_sc_contract_center")
+        self.assertNotIn("action_xmlid", target)
+
+    def test_contract_center_capability_default_payload_is_scene_first(self):
+        xml_path = SCENE_DIR / "data" / "sc_scene_orchestration.xml"
+        tree = ET.parse(str(xml_path))
+        capability = next(
+            record
+            for record in tree.findall(".//record")
+            if record.get("id") == "smart_construction_core.sc_cap_contract_work"
+        )
+        default_payload = next(
+            field
+            for field in capability.findall("field")
+            if field.get("name") == "default_payload"
+        )
+        payload_expr = str(default_payload.get("eval") or "")
+
+        self.assertIn("'scene_key': 'contract.center'", payload_expr)
+        self.assertIn("'route': '/s/contract.center'", payload_expr)
+        self.assertIn("'menu_xmlid': 'smart_construction_core.menu_sc_contract_center'", payload_expr)
+        self.assertNotIn("action_xmlid", payload_expr)
+
+    def test_contract_center_is_in_critical_runtime_target_overrides(self):
+        overrides = set(target_core_extension.smart_core_critical_scene_target_overrides(None))
+        self.assertIn("contract.center", overrides)
+
+    def test_contracts_workspace_provider_supplies_delivery_handoff_v1(self):
+        payload = contracts_workspace_provider.build(scene_key="contracts.workspace", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(handoff.get("family"), "contracts")
+        self.assertEqual(handoff.get("runtime_entry_type"), "governed_user_flow")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "route:/s/contracts.workspace")
+        self.assertEqual(handoff.get("final_scene"), "contracts.workspace")
+
+    def test_enterprise_bootstrap_scenes_supply_explicit_registry_targets(self):
+        rows = scene_registry_content.list_scene_entries()
+        company = next((row for row in rows if row.get("code") == "enterprise.company"), {})
+        department = next((row for row in rows if row.get("code") == "enterprise.department"), {})
+        user = next((row for row in rows if row.get("code") == "enterprise.user"), {})
+        post = next((row for row in rows if row.get("code") == "enterprise.post"), {})
+
+        self.assertEqual(((company.get("target") or {}).get("route")), "/s/enterprise.company")
+        self.assertEqual(((company.get("target") or {}).get("menu_xmlid")), "smart_enterprise_base.menu_enterprise_company")
+        self.assertEqual(((department.get("target") or {}).get("route")), "/s/enterprise.department")
+        self.assertEqual(((department.get("target") or {}).get("action_xmlid")), "smart_enterprise_base.action_enterprise_department")
+        self.assertEqual(((user.get("target") or {}).get("route")), "/s/enterprise.user")
+        self.assertEqual(((user.get("target") or {}).get("action_xmlid")), "smart_enterprise_base.action_enterprise_user")
+        self.assertEqual(((post.get("target") or {}).get("route")), "/s/enterprise.post")
+        self.assertEqual(((post.get("target") or {}).get("action_xmlid")), "smart_enterprise_base.action_enterprise_post")
+
+    def test_enterprise_bootstrap_provider_supplies_guidance_and_next_scene(self):
+        company = enterprise_bootstrap_provider.build(scene_key="enterprise.company", runtime={"company_id": 9})
+        department = enterprise_bootstrap_provider.build(scene_key="enterprise.department", runtime={"company_id": 9})
+        post = enterprise_bootstrap_provider.build(scene_key="enterprise.post", runtime={"company_id": 9})
+        user = enterprise_bootstrap_provider.build(scene_key="enterprise.user", runtime={"company_id": 9})
+
+        self.assertEqual(company.get("next_scene"), "enterprise.department")
+        self.assertEqual(company.get("next_scene_route"), "/s/enterprise.department")
+        self.assertEqual(((department.get("guidance") or {}).get("title")), "组织架构")
+        self.assertEqual(department.get("next_scene"), "enterprise.post")
+        self.assertEqual(((post.get("guidance") or {}).get("title")), "岗位管理")
+        self.assertEqual(post.get("next_scene"), "enterprise.user")
+        self.assertFalse(bool(user.get("next_scene")))
+        self.assertEqual(((user.get("guidance") or {}).get("title")), "用户设置")
+
+    def test_approval_workbench_provider_supplies_approval_first_semantics(self):
+        payload = approval_workbench_provider.build(scene_key="payments.approval", runtime={"company_id": 9})
+
+        self.assertEqual(((payload.get("guidance") or {}).get("title")), "付款审批工作台")
+        self.assertEqual(((payload.get("primary_action") or {}).get("action_xmlid")), "smart_construction_core.action_sc_tier_review_my_payment_request")
+        self.assertEqual(((payload.get("primary_action") or {}).get("semantic")), "payment_approval_workbench_entry")
+        self.assertEqual(((payload.get("next_action") or {}).get("semantic")), "payment_approval_queue")
+        self.assertEqual(((payload.get("fallback_strategy") or {}).get("type")), "native_action_compat")
+
+    def test_approval_workbench_provider_supplies_delivery_handoff_v1(self):
+        payload = approval_workbench_provider.build(scene_key="payments.approval", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(handoff.get("family"), "payment_approval")
+        self.assertEqual(handoff.get("runtime_entry_type"), "governed_user_flow")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "menu:smart_construction_core.menu_sc_tier_review_my_payment_request")
+        self.assertEqual(handoff.get("final_scene"), "payments.approval")
+
+    def test_payment_entry_workbench_provider_supplies_personal_entry_semantics(self):
+        payload = payment_entry_workbench_provider.build(scene_key="finance.payment_requests", runtime={"company_id": 9})
+
+        self.assertEqual(((payload.get("guidance") or {}).get("title")), "付款申请列表")
+        self.assertEqual(((payload.get("primary_action") or {}).get("action_xmlid")), "smart_construction_core.action_payment_request_my")
+        self.assertEqual(((payload.get("primary_action") or {}).get("semantic")), "payment_request_personal_entry")
+        self.assertEqual(((payload.get("next_action") or {}).get("semantic")), "payment_request_list_queue")
+        self.assertEqual(((payload.get("fallback_strategy") or {}).get("action_xmlid")), "smart_construction_core.action_payment_request")
+
+    def test_payment_entry_workbench_provider_supplies_delivery_handoff_v1(self):
+        payload = payment_entry_workbench_provider.build(scene_key="finance.payment_requests", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(handoff.get("family"), "payment_entry")
+        self.assertEqual(handoff.get("runtime_entry_type"), "governed_user_flow")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "menu:smart_construction_core.menu_payment_request")
+        self.assertEqual(handoff.get("final_scene"), "finance.payment_requests")
+
+    def test_wave1_projects_provider_supplies_delivery_handoff_v1(self):
+        payload = projects_list_provider.build(scene_key="projects.list", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual((payload.get("primary_action") or {}).get("action_xmlid"), "smart_construction_core.action_sc_project_list")
+        self.assertEqual(handoff.get("family"), "projects")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "menu:smart_construction_core.menu_sc_root")
+        self.assertEqual(handoff.get("final_scene"), "projects.list")
+
+    def test_wave1_finance_provider_supplies_delivery_handoff_v1(self):
+        payload = finance_center_provider.build(scene_key="finance.center", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(handoff.get("family"), "finance_center")
+        self.assertEqual(handoff.get("runtime_consumer"), "family_runtime_consumer")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("final_scene"), "finance.center")
+        self.assertEqual(((handoff.get("acceptance") or {}).get("workflow_ready")), True)
+
+    def test_wave1_task_provider_supplies_delivery_handoff_v1(self):
+        payload = task_center_provider.build(scene_key="task.center", runtime={"company_id": 9})
+        handoff = payload.get("delivery_handoff_v1") or {}
+
+        self.assertEqual(handoff.get("family"), "tasks")
+        self.assertEqual(handoff.get("runtime_entry_type"), "governed_user_flow")
+        self.assertEqual(handoff.get("runtime_mode"), "direct")
+        self.assertEqual(handoff.get("user_entry"), "action:project.action_view_all_task")
+        self.assertEqual(handoff.get("final_scene"), "task.center")
+
+    def test_wave1_rollout_handoff_consumes_direct_runtime_surface(self):
+        payload = projects_list_provider.build(scene_key="projects.list", runtime={"company_id": 9})
+        bridged = scene_ready_bridge.apply_scene_ready_semantic_orchestration_bridge(
+            payload,
+            scene_key="projects.list",
+        )
+
+        rollout = workflow_rollout_handoff.build_wave1_rollout_handoff(
+            bridged.get("runtime_handoff_surface")
+        )
+
+        self.assertEqual(rollout.get("family"), "projects")
+        self.assertEqual(rollout.get("rollout_mode"), "direct_runtime_handoff")
+        self.assertEqual(rollout.get("consume_mode"), "direct")
+        self.assertEqual(rollout.get("final_scene"), "projects.list")
+        self.assertEqual(((rollout.get("acceptance") or {}).get("advisory_only")), False)
+        self.assertEqual(((rollout.get("acceptance") or {}).get("workflow_ready")), True)
+
+    def test_wave1_rollout_handoff_consumes_advisory_runtime_surface(self):
+        payload = approval_workbench_provider.build(scene_key="payments.approval", runtime={"company_id": 9})
+        bridged = scene_ready_bridge.apply_scene_ready_semantic_orchestration_bridge(
+            payload,
+            scene_key="payments.approval",
+        )
+
+        rollout = workflow_rollout_handoff.build_wave1_rollout_handoff(
+            bridged.get("runtime_handoff_surface")
+        )
+
+        self.assertEqual(rollout.get("family"), "payment_approval")
+        self.assertEqual(rollout.get("rollout_mode"), "advisory_only")
+        self.assertEqual(rollout.get("consume_mode"), "advisory")
+        self.assertEqual(rollout.get("final_scene"), "payments.approval")
+        self.assertEqual(((rollout.get("acceptance") or {}).get("advisory_only")), True)
+
+    def test_project_management_scene_ready_provider_exposes_dashboard_page_semantics(self):
+        payload = project_dashboard_scene_content.build(scene_key="project.management", runtime={}, context={})
+        page = payload.get("page") if isinstance(payload.get("page"), dict) else {}
+
+        self.assertEqual(page.get("key"), "project.management.dashboard")
+        self.assertEqual(page.get("route"), "/s/project.management")
+        self.assertEqual(page.get("page_type"), "dashboard")
+        self.assertEqual(page.get("layout_mode"), "dashboard")
+
+    def test_provider_merge_projects_dashboard_page_semantics_into_startup_contract(self):
+        compiled = {
+            "scene": {"key": "project.management", "title": "项目驾驶舱", "layout": {}},
+            "page": {"scene_key": "project.management", "route": "/s/project.management", "zones": []},
+            "meta": {},
+        }
+        providers = [{"key": "runtime.scene_provider.project.management", "payload": project_dashboard_scene_content.build(scene_key="project.management")}]
+        merged = scene_merge_resolver.apply_provider_merge(
+            compiled,
+            providers,
+            scene_merge_resolver.MergeContext(scene_key="project.management", runtime={}, provider_registry={}),
+        )
+        page = merged.get("page") if isinstance(merged.get("page"), dict) else {}
+
+        self.assertEqual(page.get("key"), "project.management.dashboard")
+        self.assertEqual(page.get("page_type"), "dashboard")
+        self.assertEqual(page.get("layout_mode"), "dashboard")
+
+    def test_smart_core_nav_scene_maps_derives_missing_action_and_menu_mappings(self):
+        _reset_caches()
+        target_core_extension.scene_registry.load_scene_configs = lambda env: [
+            {
+                "code": "finance.operating_metrics",
+                "target": {
+                    "menu_xmlid": "smart_construction_core.menu_sc_operating_metrics_project",
+                    "action_xmlid": "smart_construction_core.action_sc_operating_metrics_project",
+                    "model": "operating.metrics.project",
+                    "view_type": "tree",
+                },
+            }
+        ]
+        maps = target_core_extension.smart_core_nav_scene_maps(_DummyEnv())
+
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_sc_operating_metrics_project"],
+            "finance.operating_metrics",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_operating_metrics_project"],
+            "finance.operating_metrics",
+        )
+        self.assertEqual(
+            maps["model_view_scene_map"][("operating.metrics.project", "list")],
+            "finance.operating_metrics",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_list"],
+            "projects.list",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_overview"],
+            "projects.list",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_my_list"],
+            "projects.list",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_manage"],
+            "project.management",
+        )
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_sc_project_initiation"],
+            "projects.intake",
+        )
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_sc_project_quick_create"],
+            "projects.intake",
+        )
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_construction_core.menu_sc_project_manage"],
+            "project.management",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_project_initiation"],
+            "projects.intake",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_project_initiation_quick"],
+            "projects.intake",
+        )
+
+    def test_projects_detail_remains_route_plus_record_context_authority_not_shared_action_owner(self):
+        _reset_caches()
+        target_core_extension.scene_registry.load_scene_configs = lambda env: list(scene_registry_content.list_scene_entries())
+        maps = target_core_extension.smart_core_nav_scene_maps(_DummyEnv())
+
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_kanban_lifecycle"],
+            "projects.ledger",
+        )
+        self.assertNotEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_overview"],
+            "projects.detail",
+        )
+        self.assertNotEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_my_list"],
+            "projects.detail",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_construction_core.action_sc_project_manage"],
+            "project.management",
+        )
+
+    def test_smart_core_nav_scene_maps_include_enterprise_bootstrap_registry_targets(self):
+        _reset_caches()
+        target_core_extension.scene_registry.load_scene_configs = lambda env: list(scene_registry_content.list_scene_entries())
+        maps = target_core_extension.smart_core_nav_scene_maps(_DummyEnv())
+
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_enterprise_base.menu_enterprise_company"],
+            "enterprise.company",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_enterprise_base.action_enterprise_department"],
+            "enterprise.department",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_enterprise_base.action_enterprise_user"],
+            "enterprise.user",
+        )
+        self.assertEqual(
+            maps["action_xmlid_scene_map"]["smart_enterprise_base.action_enterprise_post"],
+            "enterprise.post",
+        )
+        self.assertEqual(
+            maps["menu_scene_map"]["smart_enterprise_base.menu_enterprise_post"],
+            "enterprise.post",
+        )
+
+    def test_register_scene_providers_includes_enterprise_bootstrap_scenes(self):
+        registry = _DummyRegistry()
+        register_scene_providers.register_scene_content_providers(registry, SCENE_DIR.parent)
+        specs = {row.get("scene_key"): row for row in registry.specs}
+
+        self.assertEqual(
+            ((specs.get("enterprise.company") or {}).get("provider_path")).name,
+            "enterprise_bootstrap_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("enterprise.department") or {}).get("provider_path")).name,
+            "enterprise_bootstrap_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("enterprise.user") or {}).get("provider_path")).name,
+            "enterprise_bootstrap_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("enterprise.post") or {}).get("provider_path")).name,
+            "enterprise_bootstrap_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("payments.approval") or {}).get("provider_path")).name,
+            "approval_workbench_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("payments.approval") or {}).get("provider_key")),
+            "construction.approval_workbench_provider.v1",
+        )
+        self.assertEqual(
+            ((specs.get("finance.payment_requests") or {}).get("provider_path")).name,
+            "payment_entry_workbench_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("finance.payment_requests") or {}).get("provider_key")),
+            "construction.payment_entry_workbench_provider.v1",
+        )
+        self.assertEqual(
+            ((specs.get("cost.project_budget") or {}).get("provider_path")).name,
+            "cost_project_budget_provider.py",
+        )
+        self.assertEqual(
+            ((specs.get("cost.project_budget") or {}).get("provider_key")),
+            "construction.cost_project_budget_provider.v1",
+        )
+
+    def test_enterprise_enablement_targets_publish_scene_first_routes(self):
+        payload = {}
+        env = _DummyEnv(
+            refs={
+                "smart_enterprise_base.action_enterprise_company": 246,
+                "smart_enterprise_base.menu_enterprise_company": 144,
+                "smart_enterprise_base.action_enterprise_department": 247,
+                "smart_enterprise_base.menu_enterprise_department": 145,
+                "smart_enterprise_base.action_enterprise_user": 248,
+                "smart_enterprise_base.menu_enterprise_user": 146,
+            }
+        )
+
+        enterprise_base_core_extension.smart_core_extend_system_init(payload, env, _DummyUser())
+        mainline = (((payload.get("ext_facts") or {}).get("enterprise_enablement") or {}).get("mainline") or {})
+        steps = mainline.get("steps") or []
+
+        self.assertEqual((((steps[0] or {}).get("target") or {}).get("route")), "/s/enterprise.company")
+        self.assertEqual((((steps[1] or {}).get("target") or {}).get("route")), "/s/enterprise.department")
+        self.assertEqual((((steps[2] or {}).get("target") or {}).get("route")), "/s/enterprise.user")
+        self.assertEqual(((mainline.get("primary_action") or {}).get("route")), "/s/enterprise.company")
+
+    def test_capability_entry_target_derives_scene_key_and_route_from_explicit_action_target(self):
+        _reset_caches()
+        scene_rows = [
+            {
+                "code": "finance.operating_metrics",
+                "target": {
+                    "route": "/s/finance.operating_metrics",
+                    "menu_xmlid": "smart_construction_core.menu_sc_operating_metrics_project",
+                    "action_xmlid": "smart_construction_core.action_sc_operating_metrics_project",
+                    "action_id": 931,
+                    "menu_id": 417,
+                    "model": "operating.metrics.project",
+                    "view_type": "tree",
+                },
+            }
+        ]
+        target_capability.scene_registry.load_scene_configs = lambda env: list(scene_rows)
+        target_capability.scene_registry.load_scene_configs_with_timings = lambda env: (list(scene_rows), {})
+
+        env = _DummyEnv(
+            refs={
+                "smart_construction_core.action_sc_operating_metrics_project": 931,
+                "smart_construction_core.menu_sc_operating_metrics_project": 417,
+            }
+        )
+        entry_target = target_capability.build_capability_entry_target(
+            "",
+            explicit_target={"action_xmlid": "smart_construction_core.action_sc_operating_metrics_project"},
+            env=env,
+        )
+        payload = target_capability.resolve_capability_entry_target_payload(
+            env,
+            "",
+            explicit_target={"action_xmlid": "smart_construction_core.action_sc_operating_metrics_project"},
+        )
+
+        self.assertEqual(entry_target["scene_key"], "finance.operating_metrics")
+        self.assertEqual(payload["scene_key"], "finance.operating_metrics")
+        self.assertEqual(payload["route"], "/s/finance.operating_metrics")
+        self.assertEqual(payload["action_id"], 931)
+        self.assertEqual(payload["menu_id"], 417)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_construction_scene/tests/test_my_work_scene_targets.py
+++ b/addons/smart_construction_scene/tests/test_my_work_scene_targets.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCENE_DIR = Path(__file__).resolve().parents[1]
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+target = _load_module(
+    "smart_construction_scene.services.my_work_scene_targets",
+    SCENE_DIR / "services" / "my_work_scene_targets.py",
+)
+
+
+class TestMyWorkSceneTargets(unittest.TestCase):
+    def test_project_task_records_resolve_to_task_center(self):
+        self.assertEqual(
+            target.resolve_my_work_scene_key(model_name="project.task"),
+            "task.center",
+        )
+        self.assertEqual(
+            target.resolve_my_work_scene_key(source_key="project.task"),
+            "task.center",
+        )
+
+    def test_project_project_records_resolve_to_projects_detail(self):
+        self.assertEqual(
+            target.resolve_my_work_scene_key(model_name="project.project"),
+            "projects.detail",
+        )
+        self.assertEqual(
+            target.resolve_my_work_scene_key(source_key="project.project"),
+            "projects.detail",
+        )
+
+    def test_build_my_work_target_keeps_record_context_for_projects_detail(self):
+        payload = target.build_my_work_target(
+            model_name="project.project",
+            record_id=42,
+            action_id=502,
+            menu_id=202,
+        )
+
+        self.assertEqual(payload.get("kind"), "record")
+        self.assertEqual(payload.get("scene_key"), "projects.detail")
+        self.assertEqual(payload.get("model"), "project.project")
+        self.assertEqual(payload.get("record_id"), 42)
+        self.assertEqual(payload.get("action_id"), 502)
+        self.assertEqual(payload.get("menu_id"), 202)
+
+    def test_build_my_work_target_keeps_record_context_for_task_center(self):
+        payload = target.build_my_work_target(
+            model_name="project.task",
+            record_id=88,
+            action_id=601,
+            menu_id=0,
+        )
+
+        self.assertEqual(payload.get("kind"), "record")
+        self.assertEqual(payload.get("scene_key"), "task.center")
+        self.assertEqual(payload.get("model"), "project.task")
+        self.assertEqual(payload.get("record_id"), 88)
+        self.assertEqual(payload.get("action_id"), 601)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_construction_scene/tests/test_project_list_scene_profile_columns.py
+++ b/addons/smart_construction_scene/tests/test_project_list_scene_profile_columns.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+
+import ast
+from pathlib import Path
+from xml.etree import ElementTree as ET
+
+
+def _projects_list_payload():
+    xml_path = Path(__file__).resolve().parents[1] / "data" / "sc_scene_list_profile.xml"
+    tree = ET.parse(str(xml_path))
+    for record in tree.findall(".//record"):
+        if str(record.get("id") or "").strip() != "sc_scene_version_projects_list_v2":
+            continue
+        field = record.find("./field[@name='payload_json']")
+        if field is None:
+            raise AssertionError("payload_json field missing for projects.list scene profile")
+        payload_eval = str(field.get("eval") or "").strip()
+        if not payload_eval:
+            raise AssertionError("payload_json eval missing for projects.list scene profile")
+        return ast.literal_eval(payload_eval)
+    raise AssertionError("projects.list scene version record not found")
+
+
+def test_projects_list_profile_keeps_canonical_column_order_and_labels():
+    payload = _projects_list_payload()
+    list_profile = (payload.get("list_profile") or {})
+
+    assert (list_profile.get("columns") or []) == [
+        "name",
+        "user_id",
+        "partner_id",
+        "stage_id",
+        "lifecycle_state",
+        "date_start",
+        "date",
+    ]
+    assert (list_profile.get("column_labels") or {}) == {
+        "name": "名称",
+        "user_id": "项目管理员",
+        "partner_id": "客户",
+        "stage_id": "阶段",
+        "lifecycle_state": "项目状态",
+        "date_start": "开始日期",
+        "date": "有效期",
+    }

--- a/addons/smart_construction_scene/tests/test_scene_registry_yaml_asset_merge.py
+++ b/addons/smart_construction_scene/tests/test_scene_registry_yaml_asset_merge.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "scene_registry.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("scene_registry_yaml_asset_merge_under_test", MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+class TestSceneRegistryYamlAssetMerge(unittest.TestCase):
+    def test_load_scene_configs_merges_yaml_asset_fields_into_registry_row(self):
+        target = _load_module()
+        original_load_from_db = target._load_from_db
+        original_load_imported = target._load_imported_scenes
+        original_load_content = target._load_scene_registry_content_entries_with_timings
+        try:
+            target._load_from_db = lambda env, drift=None: []
+            target._load_imported_scenes = lambda env, drift=None: []
+            target._load_scene_registry_content_entries_with_timings = lambda: (
+                [
+                    {
+                        "code": "projects.ledger",
+                        "name": "项目台账",
+                        "target": {
+                            "route": "/s/projects.ledger",
+                            "menu_xmlid": "smart_construction_core.menu_sc_project_project",
+                            "action_xmlid": "smart_construction_core.action_sc_project_kanban_lifecycle",
+                        },
+                    }
+                ],
+                {},
+            )
+            rows, _timings = target.load_scene_configs_with_timings(None)
+        finally:
+            target._load_from_db = original_load_from_db
+            target._load_imported_scenes = original_load_imported
+            target._load_scene_registry_content_entries_with_timings = original_load_content
+
+        ledger = next((row for row in rows if row.get("code") == "projects.ledger"), {})
+        self.assertEqual(((ledger.get("target") or {}).get("route")), "/s/projects.ledger")
+        self.assertEqual(((ledger.get("page") or {}).get("route")), "/s/projects.ledger")
+        self.assertEqual([zone.get("name") for zone in (ledger.get("zones") or [])], ["header", "search", "main"])
+        self.assertEqual(((ledger.get("blocks") or [])[0] or {}).get("source"), "ui_base_contract.views.tree")
+        self.assertEqual(((ledger.get("search_surface") or {}).get("source")), "ui_base_contract.search")
+        self.assertEqual(((ledger.get("permission_surface") or {}).get("source")), "ui_base_contract.permissions")
+
+    def test_load_scene_configs_merges_cost_project_budget_yaml_asset_fields(self):
+        target = _load_module()
+        original_load_from_db = target._load_from_db
+        original_load_imported = target._load_imported_scenes
+        original_load_content = target._load_scene_registry_content_entries_with_timings
+        try:
+            target._load_from_db = lambda env, drift=None: []
+            target._load_imported_scenes = lambda env, drift=None: []
+            target._load_scene_registry_content_entries_with_timings = lambda: (
+                [
+                    {
+                        "code": "cost.project_budget",
+                        "name": "预算管理",
+                        "target": {
+                            "route": "/s/cost.project_budget",
+                        },
+                    }
+                ],
+                {},
+            )
+            rows, _timings = target.load_scene_configs_with_timings(None)
+        finally:
+            target._load_from_db = original_load_from_db
+            target._load_imported_scenes = original_load_imported
+            target._load_scene_registry_content_entries_with_timings = original_load_content
+
+        budget = next((row for row in rows if row.get("code") == "cost.project_budget"), {})
+        self.assertEqual(((budget.get("target") or {}).get("route")), "/s/cost.project_budget")
+        self.assertEqual(((budget.get("page") or {}).get("route")), "/s/cost.project_budget")
+        self.assertEqual([zone.get("name") for zone in (budget.get("zones") or [])], ["header", "search", "main"])
+        self.assertEqual(((budget.get("blocks") or [])[0] or {}).get("source"), "ui_base_contract.views.tree")
+        self.assertEqual(((budget.get("search_surface") or {}).get("source")), "ui_base_contract.search")
+        self.assertEqual(((budget.get("permission_surface") or {}).get("source")), "ui_base_contract.permissions")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-PROVIDER-SUPPLY-PA88.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-PROVIDER-SUPPLY-PA88.yaml
@@ -1,0 +1,69 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-PROVIDER-SUPPLY-PA88
+title: Split residual construction scene provider supply slice from 56b7eba
+objective: >
+  Isolate the scene-layer provider/profile/registry runtime supply slice from
+  commit 56b7eba into a bounded child batch for mainline review.
+context:
+  layer_target: Scene Layer
+  module: smart_construction_scene
+  module_ownership: Industry scene layer
+  kernel_or_scenario: scenario
+  architecture_reason: >
+    This batch supplies construction scene providers, registry helpers, and
+    scene-target runtime composition for generic frontend and smart_core
+    consumers. It must remain separate from platform smart_core orchestration,
+    construction_core semantic carriers, and scene asset data registration.
+scope:
+  allowed_paths:
+    - addons/smart_construction_scene/bootstrap/register_scene_providers.py
+    - addons/smart_construction_scene/core_extension.py
+    - addons/smart_construction_scene/profiles/project_dashboard_scene_content.py
+    - addons/smart_construction_scene/profiles/scene_registry_content.py
+    - addons/smart_construction_scene/providers/approval_workbench_provider.py
+    - addons/smart_construction_scene/providers/contract_center_provider.py
+    - addons/smart_construction_scene/providers/contracts_workspace_provider.py
+    - addons/smart_construction_scene/providers/cost_project_budget_provider.py
+    - addons/smart_construction_scene/providers/enterprise_bootstrap_provider.py
+    - addons/smart_construction_scene/providers/finance_center_provider.py
+    - addons/smart_construction_scene/providers/finance_workspace_provider.py
+    - addons/smart_construction_scene/providers/projects_detail_provider.py
+    - addons/smart_construction_scene/providers/projects_ledger_provider.py
+    - addons/smart_construction_scene/providers/projects_list_provider.py
+    - addons/smart_construction_scene/providers/task_board_provider.py
+    - addons/smart_construction_scene/providers/task_center_provider.py
+    - addons/smart_construction_scene/scene_registry.py
+    - addons/smart_construction_scene/scenes/cost/cost.project_budget.scene.yaml
+    - addons/smart_construction_scene/scenes/projects/projects.ledger.scene.yaml
+    - addons/smart_construction_scene/services/__init__.py
+    - addons/smart_construction_scene/services/capability_scene_targets.py
+    - addons/smart_construction_scene/services/my_work_scene_targets.py
+    - addons/smart_construction_scene/services/workflow_rollout_handoff.py
+    - addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py
+    - addons/smart_construction_scene/tests/test_my_work_scene_targets.py
+    - addons/smart_construction_scene/tests/test_project_list_scene_profile_columns.py
+    - addons/smart_construction_scene/tests/test_scene_registry_yaml_asset_merge.py
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-PROVIDER-SUPPLY-PA88.yaml
+  forbidden_paths:
+    - addons/smart_construction_scene/__init__.py
+    - addons/smart_construction_scene/data/**
+    - addons/smart_construction_core/**
+    - addons/smart_core/**
+    - addons/smart_construction_scene/**/payment*
+    - addons/smart_construction_scene/**/settlement*
+    - addons/smart_construction_scene/**/account*
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_construction_scene/bootstrap/register_scene_providers.py addons/smart_construction_scene/core_extension.py addons/smart_construction_scene/scene_registry.py addons/smart_construction_scene/services/capability_scene_targets.py addons/smart_construction_scene/services/my_work_scene_targets.py addons/smart_construction_scene/services/workflow_rollout_handoff.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Split the third residual slice from `56b7eba` out of residual umbrella PR #577.

This PR isolates `smart_construction_scene` provider supply, registry/profile wiring, scene-target helpers, and focused tests without carrying `smart_core`, `smart_construction_core`, or scene data asset registration files.

## Scope

- `addons/smart_construction_scene/bootstrap/register_scene_providers.py`
- `addons/smart_construction_scene/core_extension.py`
- `addons/smart_construction_scene/profiles/*`
- `addons/smart_construction_scene/providers/*`
- `addons/smart_construction_scene/scene_registry.py`
- `addons/smart_construction_scene/scenes/cost/cost.project_budget.scene.yaml`
- `addons/smart_construction_scene/scenes/projects/projects.ledger.scene.yaml`
- `addons/smart_construction_scene/services/*`
- `addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py`
- `addons/smart_construction_scene/tests/test_my_work_scene_targets.py`
- `addons/smart_construction_scene/tests/test_project_list_scene_profile_columns.py`
- `addons/smart_construction_scene/tests/test_scene_registry_yaml_asset_merge.py`

## Architecture Impact

- Layer Target: Scene Layer
- Affected Modules: `smart_construction_scene`
- Reason: recover scene-provider semantic supply as a bounded industry scene-layer slice while keeping asset registration and domain semantic carriers separate

## Verify

- `python3 -m py_compile addons/smart_construction_scene/bootstrap/register_scene_providers.py addons/smart_construction_scene/core_extension.py addons/smart_construction_scene/scene_registry.py addons/smart_construction_scene/services/capability_scene_targets.py addons/smart_construction_scene/services/my_work_scene_targets.py addons/smart_construction_scene/services/workflow_rollout_handoff.py`

## Relation

- parent residual umbrella: #577
- predecessor merged splits: #578 #579 #580 #581 #582 #583 #584 #585 #586
- predecessor residual slices: #587 #588
- intentionally excluded from this PR: `addons/smart_construction_scene/__init__.py`, `addons/smart_construction_scene/data/**`, `addons/smart_construction_core/**`
