### PR TITLE
[split] construction semantic carriers residual slice

### DIFF
--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -7,134 +7,7 @@ from odoo.exceptions import AccessError
 _logger = logging.getLogger(__name__)
 
 
-ROLE_SURFACE_OVERRIDES = {
-    "owner": {
-        "landing_scene_candidates": ["projects.list", "projects.intake"],
-        "menu_xmlids": [
-            "smart_construction_core.menu_sc_project_center",
-            "smart_construction_core.menu_sc_contract_center",
-        ],
-    },
-    "pm": {
-        "landing_scene_candidates": ["portal.dashboard", "projects.ledger", "projects.list", "projects.intake"],
-        "menu_xmlids": [
-            "smart_construction_core.menu_sc_project_center",
-            "smart_construction_core.menu_sc_contract_center",
-            "smart_construction_core.menu_sc_cost_center",
-        ],
-        "menu_blocklist_xmlids": ["smart_construction_core.menu_sc_project_manage"],
-    },
-    "finance": {
-        "landing_scene_candidates": ["finance.payment_requests", "projects.ledger", "projects.list"],
-        "menu_xmlids": [
-            "smart_construction_core.menu_sc_finance_center",
-            "smart_construction_core.menu_sc_settlement_center",
-            "smart_construction_core.menu_payment_request",
-        ],
-    },
-    "executive": {
-        "landing_scene_candidates": ["portal.dashboard", "project.management", "projects.list", "projects.ledger", "projects.intake"],
-        "menu_xmlids": [
-            "smart_construction_core.menu_sc_root",
-            "smart_construction_core.menu_sc_projection_root",
-            "smart_construction_core.menu_sc_project_center",
-        ],
-    },
-}
-
-ROLE_GROUPS_EXPLICIT = {
-    "executive": {
-        "smart_construction_custom.group_sc_role_executive",
-        "smart_construction_core.group_sc_super_admin",
-        "smart_construction_core.group_sc_cap_config_admin",
-        "base.group_system",
-    },
-    "pm": {
-        "smart_construction_custom.group_sc_role_pm",
-        "smart_construction_custom.group_sc_role_project_manager",
-        "smart_construction_custom.group_sc_role_project_user",
-        "smart_construction_core.group_sc_role_project_manager",
-    },
-    "finance": {
-        "smart_construction_custom.group_sc_role_finance",
-        "smart_construction_custom.group_sc_role_payment_manager",
-        "smart_construction_custom.group_sc_role_payment_user",
-        "smart_construction_custom.group_sc_role_payment_read",
-        "smart_construction_core.group_sc_role_finance_manager",
-        "smart_construction_core.group_sc_role_finance_user",
-    },
-}
-
-ROLE_GROUPS_CAPABILITY_FALLBACK = {
-    "pm": {
-        "smart_construction_core.group_sc_cap_project_manager",
-        "smart_construction_core.group_sc_cap_project_user",
-    },
-    "finance": {
-        "smart_construction_core.group_sc_cap_finance_user",
-        "smart_construction_core.group_sc_cap_finance_manager",
-    },
-}
-
-ROLE_PRECEDENCE = ("executive", "pm", "finance")
-
-NAV_MENU_SCENE_MAP = {
-    "smart_construction_demo.menu_sc_project_list_showcase": "projects.list",
-    "smart_construction_core.menu_sc_project_initiation": "projects.intake",
-    "smart_construction_core.menu_sc_project_project": "projects.ledger",
-    "smart_construction_core.menu_sc_project_management_scene": "project.management",
-    "smart_construction_core.menu_sc_project_cost_code": "config.project_cost_code",
-    "smart_construction_core.menu_sc_root": "projects.list",
-    "smart_construction_core.menu_sc_project_dashboard": "projects.dashboard",
-    "smart_construction_demo.menu_sc_project_dashboard_showcase": "projects.dashboard_showcase",
-    "smart_construction_core.menu_sc_dictionary": "data.dictionary",
-    "smart_construction_core.menu_payment_request": "finance.payment_requests",
-    "smart_construction_portal.menu_sc_portal_lifecycle": "portal.lifecycle",
-    "smart_construction_portal.menu_sc_portal_capability_matrix": "portal.capability_matrix",
-    "smart_construction_portal.menu_sc_portal_dashboard": "portal.dashboard",
-}
-
-NAV_ACTION_SCENE_MAP = {
-    "smart_construction_demo.action_sc_project_list_showcase": "projects.list",
-    "smart_construction_core.action_project_initiation": "projects.intake",
-    "smart_construction_core.action_sc_project_kanban_lifecycle": "projects.ledger",
-    "smart_construction_core.action_sc_project_list": "projects.list",
-    "smart_construction_core.action_project_dashboard": "projects.dashboard",
-    "smart_construction_demo.action_project_dashboard_showcase": "projects.dashboard_showcase",
-    "smart_construction_core.action_project_dictionary": "data.dictionary",
-    "smart_construction_core.action_project_cost_code": "config.project_cost_code",
-    "smart_construction_core.action_payment_request": "finance.payment_requests",
-    "smart_construction_core.action_payment_request_my": "finance.payment_requests",
-    "smart_construction_portal.action_sc_portal_lifecycle": "portal.lifecycle",
-    "smart_construction_portal.action_sc_portal_capability_matrix": "portal.capability_matrix",
-    "smart_construction_portal.action_sc_portal_dashboard": "portal.dashboard",
-}
-
-NAV_MODEL_VIEW_SCENE_MAP = {
-    ("project.project", "list"): "projects.list",
-    ("project.project", "form"): "projects.intake",
-    ("payment.request", "list"): "finance.payment_requests",
-    ("payment.request", "form"): "finance.payment_requests",
-}
-
-SERVER_ACTION_WINDOW_MAP = {
-    "smart_construction_core.action_exec_structure_entry": "smart_construction_core.action_exec_structure_wbs",
-}
-
-FILE_UPLOAD_ALLOWED_MODELS = ["project.project", "project.task"]
-FILE_DOWNLOAD_ALLOWED_MODELS = ["project.project", "project.task"]
-API_DATA_WRITE_ALLOWLIST = {
-    "project.project": ["name", "description", "date_start"],
-    "project.task": ["name", "description", "date_deadline", "project_id"],
-}
-API_DATA_UNLINK_ALLOWED_MODELS = ["project.task"]
-
-MODEL_CODE_MAPPING = {
-    "project": "project.project",
-    "task": "project.task",
-}
-
-CREATE_FIELD_FALLBACKS = {
+INDUSTRY_CREATE_FIELD_FALLBACKS = {
     "project.project": {
         "selection_defaults": {
             "privacy_visibility": "followers",
@@ -144,58 +17,6 @@ CREATE_FIELD_FALLBACKS = {
         }
     }
 }
-
-SURFACE_NAV_ALLOWLIST = {
-    "construction_pm_v1": [
-        "project.management",
-        "projects.dashboard",
-        "projects.ledger",
-        "projects.intake",
-        "my_work.workspace",
-    ]
-}
-SURFACE_DEEP_LINK_ALLOWLIST = {
-    "construction_pm_v1": [
-        "contract.center",
-        "cost.budget_alloc",
-        "cost.cost_compare",
-        "cost.profit_compare",
-        "cost.project_boq",
-        "cost.project_budget",
-        "cost.project_cost_ledger",
-        "cost.project_progress",
-        "data.dictionary",
-        "finance.center",
-        "finance.operating_metrics",
-        "finance.payment_ledger",
-        "finance.payment_requests",
-        "finance.settlement_orders",
-        "finance.treasury_ledger",
-        "config.project_cost_code",
-        "risk.monitor",
-        "task.center",
-    ]
-}
-SURFACE_POLICY_DEFAULT_NAME = "construction_pm_v1"
-SURFACE_POLICY_DEFAULT_FILE = "docs/product/delivery/v1/construction_pm_v1_scene_surface_policy.json"
-
-CRITICAL_SCENE_TARGET_OVERRIDES = {
-    "projects.list",
-    "projects.detail",
-    "projects.intake",
-    "projects.ledger",
-    "projects.execution",
-    "projects.dashboard",
-    "project.management",
-    "my_work.workspace",
-    "portal.dashboard",
-    "finance.payment_requests",
-}
-
-CRITICAL_SCENE_TARGET_ROUTE_OVERRIDES = {
-    "my_work.workspace": "/my-work",
-}
-
 
 def _as_text(value: Any) -> str:
     if isinstance(value, dict):
@@ -224,6 +45,67 @@ def _model_has_field(env, model_name: str, field_name: str) -> bool:
     if model_name not in env:
         return False
     return field_name in env[model_name]._fields
+
+
+def _step_status_label(status: str) -> str:
+    key = str(status or "").strip().lower()
+    if key == "active":
+        return "进行中"
+    if key in {"done", "completed"}:
+        return "已完成"
+    if key in {"pending", "todo", "planned"}:
+        return "待开始"
+    return "后端未提供步骤状态标签"
+
+
+def _build_enterprise_enablement_contract(env, user) -> Dict[str, Any]:
+    company = getattr(user, "company_id", None)
+    company_id = int(getattr(company, "id", 0) or 0)
+    company_name = str(getattr(company, "name", "") or "").strip()
+    steps = [
+        {
+            "key": "enterprise_company",
+            "label": "企业信息",
+            "status": "active" if company_id else "pending",
+            "status_label": _step_status_label("active" if company_id else "pending"),
+            "entry_xmlid": "smart_enterprise_base.action_enterprise_company",
+            "action_xmlid": "smart_enterprise_base.action_enterprise_company",
+            "next_hint": "请先补齐企业基础信息。",
+            "target": {"action_id": 0, "menu_id": 0, "route": ""},
+        },
+        {
+            "key": "enterprise_department",
+            "label": "组织结构",
+            "status": "pending",
+            "status_label": _step_status_label("pending"),
+            "entry_xmlid": "smart_enterprise_base.action_enterprise_department",
+            "action_xmlid": "smart_enterprise_base.action_enterprise_department",
+            "next_hint": "请补齐部门与岗位结构。",
+            "target": {"action_id": 0, "menu_id": 0, "route": ""},
+        },
+        {
+            "key": "enterprise_user",
+            "label": "用户设置",
+            "status": "pending",
+            "status_label": _step_status_label("pending"),
+            "entry_xmlid": "smart_enterprise_base.action_enterprise_user",
+            "action_xmlid": "smart_enterprise_base.action_enterprise_user",
+            "next_hint": "请完成用户、角色和账号初始化。",
+            "target": {"action_id": 0, "menu_id": 0, "route": ""},
+        },
+    ]
+    return {
+        "mainline": {
+            "version": "v1",
+            "phase": "sprint1" if company_id else "bootstrap",
+            "theme": "enterprise_enablement",
+            "entry_root_xmlid": "smart_enterprise_base.menu_enterprise_base_root",
+            "current_company_id": company_id,
+            "current_company_name": company_name,
+            "primary_action": steps[0].get("target") or {},
+            "steps": steps,
+        }
+    }
 
 
 def _build_task_action_rows(env, user) -> List[Dict[str, Any]]:
@@ -274,8 +156,6 @@ def _build_task_action_rows(env, user) -> List[Dict[str, Any]]:
                 "title": task_name,
                 "description": f"项目任务待处理：{project_name}" if project_name else "项目任务待处理",
                 "status": status,
-                "scene_key": "task.center",
-                "route": "/s/task.center",
                 "count": 1,
                 "source_detail": "factual_record",
                 "due_date": row.get("date_deadline"),
@@ -306,8 +186,6 @@ def _build_payment_action_rows(env) -> List[Dict[str, Any]]:
                 "title": f"付款申请待审批 · {req_name}",
                 "description": f"{project_name} 申请金额 {amount}" if project_name else f"申请金额 {amount}",
                 "status": "urgent",
-                "scene_key": "finance.payment_requests",
-                "route": "/s/finance.payment_requests",
                 "amount": amount,
                 "count": 1,
                 "source_detail": "factual_record",
@@ -341,8 +219,6 @@ def _build_risk_action_rows(env) -> List[Dict[str, Any]]:
                     "title": f"风险处置 · {title}",
                     "description": f"{project_name} 风险状态：{state}" if project_name else f"风险状态：{state}",
                     "status": status,
-                    "scene_key": "risk.center",
-                    "route": "/s/risk.center",
                     "count": 1,
                     "risk_action_id": int(row.get("id") or 0),
                     "source_detail": "mutation_record",
@@ -376,8 +252,6 @@ def _build_risk_action_rows(env) -> List[Dict[str, Any]]:
                 "title": f"项目风险预警 · {title}",
                 "description": "项目健康状态异常，请优先跟进。",
                 "status": status,
-                "scene_key": "risk.center",
-                "route": "/s/risk.center",
                 "count": 1,
                 "project_id": int(row.get("id") or 0),
                 "name": title,
@@ -408,8 +282,6 @@ def _build_project_action_rows(env, user) -> List[Dict[str, Any]]:
                     "title": f"项目跟进 · {title}",
                     "description": "项目状态需要关注，请进入项目管理跟进。",
                     "status": status,
-                    "scene_key": "project.management",
-                    "route": "/s/project.management",
                     "count": 1,
                     "source_detail": "factual_record",
                 }
@@ -417,10 +289,137 @@ def _build_project_action_rows(env, user) -> List[Dict[str, Any]]:
     return result
 
 
-def smart_core_register(registry):
-    """
-    Register construction demo intent into smart_core registry.
-    """
+def _build_role_entry_contract_rows(env) -> List[Dict[str, Any]]:
+    rows = _safe_search_read(
+        env,
+        "sc.dictionary",
+        domain=[("type", "=", "role_entry"), ("active", "=", True)],
+        fields=["code", "name", "scope_type", "scope_ref", "value_json", "sequence"],
+        limit=200,
+    )
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        scope_type = _as_text(row.get("scope_type")) or "global"
+        scope_ref = _as_text(row.get("scope_ref"))
+        role_code = ""
+        if scope_type == "role":
+            role_code = scope_ref
+        elif scope_type in {"global", "company"}:
+            role_code = "__global__"
+        if not role_code:
+            continue
+
+        value_json = row.get("value_json") if isinstance(row.get("value_json"), dict) else {}
+        entry_key = (
+            _as_text(row.get("code"))
+            or _as_text(value_json.get("entry_key"))
+            or _as_text(row.get("name"))
+        )
+        if not entry_key:
+            continue
+
+        entry_type = _as_text(value_json.get("entry_type")) or "menu"
+        is_enabled = value_json.get("is_enabled")
+        if isinstance(is_enabled, bool):
+            enabled = is_enabled
+        else:
+            enabled = True
+        sequence = int(row.get("sequence") or 10)
+
+        grouped.setdefault(role_code, []).append(
+            {
+                "entry_key": entry_key,
+                "entry_type": entry_type,
+                "is_enabled": enabled,
+                "sequence": sequence,
+            }
+        )
+
+    contract_rows: List[Dict[str, Any]] = []
+    for role_code, entries in grouped.items():
+        sorted_entries = sorted(
+            entries,
+            key=lambda item: (
+                int(item.get("sequence") or 10),
+                str(item.get("entry_key") or ""),
+            ),
+        )
+        contract_rows.append(
+            {
+                "role_code": role_code,
+                "entries": sorted_entries,
+            }
+        )
+
+    return sorted(contract_rows, key=lambda item: str(item.get("role_code") or ""))
+
+
+def _build_home_block_contract_rows(env) -> List[Dict[str, Any]]:
+    rows = _safe_search_read(
+        env,
+        "sc.dictionary",
+        domain=[("type", "=", "home_block"), ("active", "=", True)],
+        fields=["code", "name", "scope_type", "scope_ref", "value_json", "sequence"],
+        limit=200,
+    )
+    grouped: Dict[str, List[Dict[str, Any]]] = {}
+    for row in rows:
+        scope_type = _as_text(row.get("scope_type")) or "global"
+        scope_ref = _as_text(row.get("scope_ref"))
+        role_code = ""
+        if scope_type == "role":
+            role_code = scope_ref
+        elif scope_type == "global":
+            role_code = "__global__"
+        if not role_code:
+            continue
+
+        value_json = row.get("value_json") if isinstance(row.get("value_json"), dict) else {}
+        block_key = (
+            _as_text(row.get("code"))
+            or _as_text(value_json.get("block_key"))
+            or _as_text(row.get("name"))
+        )
+        if not block_key:
+            continue
+
+        is_enabled = value_json.get("is_enabled")
+        if isinstance(is_enabled, bool):
+            enabled = is_enabled
+        else:
+            enabled = True
+        if not enabled:
+            continue
+
+        sequence = int(row.get("sequence") or 10)
+        grouped.setdefault(role_code, []).append(
+            {
+                "block_key": block_key,
+                "sequence": sequence,
+            }
+        )
+
+    contract_rows: List[Dict[str, Any]] = []
+    for role_code, blocks in grouped.items():
+        sorted_blocks = sorted(
+            blocks,
+            key=lambda item: (
+                int(item.get("sequence") or 10),
+                str(item.get("block_key") or ""),
+            ),
+        )
+        contract_rows.append(
+            {
+                "role_code": role_code,
+                "blocks": [str(item.get("block_key") or "") for item in sorted_blocks if str(item.get("block_key") or "")],
+            }
+        )
+
+    return sorted(contract_rows, key=lambda item: str(item.get("role_code") or ""))
+
+
+def get_intent_handler_contributions():
+    """Return construction intent handler contributions for platform loader."""
     try:
         from odoo.addons.smart_construction_core.handlers.system_ping_construction import (
             SystemPingConstructionHandler,
@@ -468,6 +467,69 @@ def smart_core_register(registry):
         from odoo.addons.smart_construction_core.handlers.risk_action_execute import (
             RiskActionExecuteHandler,
         )
+        from odoo.addons.smart_construction_core.handlers.project_initiation_enter import (
+            ProjectInitiationEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_dashboard_open import (
+            ProjectDashboardOpenHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_dashboard_enter import (
+            ProjectDashboardEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_entry_context_resolve import (
+            ProjectEntryContextResolveHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_entry_context_options import (
+            ProjectEntryContextOptionsHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.business_evidence_trace import (
+            BusinessEvidenceTraceHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_dashboard_block_fetch import (
+            ProjectDashboardBlockFetchHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_plan_bootstrap_enter import (
+            ProjectPlanBootstrapEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_plan_bootstrap_block_fetch import (
+            ProjectPlanBootstrapBlockFetchHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_execution_enter import (
+            ProjectExecutionEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_execution_block_fetch import (
+            ProjectExecutionBlockFetchHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_execution_advance import (
+            ProjectExecutionAdvanceHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.project_connection_transition import (
+            ProjectConnectionTransitionHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.cost_tracking_enter import (
+            CostTrackingEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.cost_tracking_block_fetch import (
+            CostTrackingBlockFetchHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.cost_tracking_record_create import (
+            CostTrackingRecordCreateHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.payment_slice_enter import (
+            PaymentSliceEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.payment_slice_block_fetch import (
+            PaymentSliceBlockFetchHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.payment_slice_record_create import (
+            PaymentSliceRecordCreateHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.settlement_slice_enter import (
+            SettlementSliceEnterHandler,
+        )
+        from odoo.addons.smart_construction_core.handlers.settlement_slice_block_fetch import (
+            SettlementSliceBlockFetchHandler,
+        )
         from odoo.addons.smart_construction_core.handlers.app_catalog import (
             AppCatalogHandler,
         )
@@ -478,238 +540,331 @@ def smart_core_register(registry):
             AppOpenHandler,
         )
     except Exception as e:
-        _logger.warning("[smart_core_register] import handler failed: %s", e)
-        return
+        _logger.warning("[get_intent_handler_contributions] import handler failed: %s", e)
+        return []
 
-    registry["system.ping.construction"] = SystemPingConstructionHandler
-    registry["capability.describe"] = CapabilityDescribeHandler
-    registry["my.work.summary"] = MyWorkSummaryHandler
-    registry["my.work.complete"] = MyWorkCompleteHandler
-    registry["my.work.complete_batch"] = MyWorkCompleteBatchHandler
-    registry["usage.track"] = UsageTrackHandler
-    registry["telemetry.track"] = TelemetryTrackHandler
-    registry["usage.report"] = UsageReportHandler
-    registry["usage.export.csv"] = UsageExportCsvHandler
-    registry["capability.visibility.report"] = CapabilityVisibilityReportHandler
-    registry["payment.request.submit"] = PaymentRequestSubmitHandler
-    registry["payment.request.approve"] = PaymentRequestApproveHandler
-    registry["payment.request.reject"] = PaymentRequestRejectHandler
-    registry["payment.request.done"] = PaymentRequestDoneHandler
-    registry["payment.request.available_actions"] = PaymentRequestAvailableActionsHandler
-    registry["payment.request.execute"] = PaymentRequestExecuteHandler
-    registry["project.dashboard"] = ProjectDashboardHandler
-    registry["risk.action.execute"] = RiskActionExecuteHandler
-    registry["app.catalog"] = AppCatalogHandler
-    registry["app.nav"] = AppNavHandler
-    registry["app.open"] = AppOpenHandler
-    _logger.info("[smart_core_register] registered system.ping.construction")
-    _logger.info("[smart_core_register] registered capability.describe")
-    _logger.info("[smart_core_register] registered my.work.summary")
-    _logger.info("[smart_core_register] registered my.work.complete")
-    _logger.info("[smart_core_register] registered my.work.complete_batch")
-    _logger.info("[smart_core_register] registered usage.track")
-    _logger.info("[smart_core_register] registered telemetry.track")
-    _logger.info("[smart_core_register] registered usage.report")
-    _logger.info("[smart_core_register] registered usage.export.csv")
-    _logger.info("[smart_core_register] registered capability.visibility.report")
-    _logger.info("[smart_core_register] registered payment.request.submit")
-    _logger.info("[smart_core_register] registered payment.request.approve")
-    _logger.info("[smart_core_register] registered payment.request.reject")
-    _logger.info("[smart_core_register] registered payment.request.done")
-    _logger.info("[smart_core_register] registered payment.request.available_actions")
-    _logger.info("[smart_core_register] registered payment.request.execute")
-    _logger.info("[smart_core_register] registered project.dashboard")
-    _logger.info("[smart_core_register] registered risk.action.execute")
-    _logger.info("[smart_core_register] registered app.catalog")
-    _logger.info("[smart_core_register] registered app.nav")
-    _logger.info("[smart_core_register] registered app.open")
+    mapping = [
+        ("system.ping.construction", SystemPingConstructionHandler),
+        ("capability.describe", CapabilityDescribeHandler),
+        ("my.work.summary", MyWorkSummaryHandler),
+        ("my.work.complete", MyWorkCompleteHandler),
+        ("my.work.complete_batch", MyWorkCompleteBatchHandler),
+        ("usage.track", UsageTrackHandler),
+        ("telemetry.track", TelemetryTrackHandler),
+        ("usage.report", UsageReportHandler),
+        ("usage.export.csv", UsageExportCsvHandler),
+        ("capability.visibility.report", CapabilityVisibilityReportHandler),
+        ("payment.request.submit", PaymentRequestSubmitHandler),
+        ("payment.request.approve", PaymentRequestApproveHandler),
+        ("payment.request.reject", PaymentRequestRejectHandler),
+        ("payment.request.done", PaymentRequestDoneHandler),
+        ("payment.request.available_actions", PaymentRequestAvailableActionsHandler),
+        ("payment.request.execute", PaymentRequestExecuteHandler),
+        ("project.dashboard", ProjectDashboardHandler),
+        ("project.dashboard.open", ProjectDashboardOpenHandler),
+        ("project.dashboard.enter", ProjectDashboardEnterHandler),
+        ("project.entry.context.resolve", ProjectEntryContextResolveHandler),
+        ("project.entry.context.options", ProjectEntryContextOptionsHandler),
+        ("business.evidence.trace", BusinessEvidenceTraceHandler),
+        ("project.dashboard.block.fetch", ProjectDashboardBlockFetchHandler),
+        ("project.plan_bootstrap.enter", ProjectPlanBootstrapEnterHandler),
+        ("project.plan_bootstrap.block.fetch", ProjectPlanBootstrapBlockFetchHandler),
+        ("project.execution.enter", ProjectExecutionEnterHandler),
+        ("project.execution.block.fetch", ProjectExecutionBlockFetchHandler),
+        ("project.execution.advance", ProjectExecutionAdvanceHandler),
+        ("project.connection.transition", ProjectConnectionTransitionHandler),
+        ("cost.tracking.enter", CostTrackingEnterHandler),
+        ("cost.tracking.block.fetch", CostTrackingBlockFetchHandler),
+        ("cost.tracking.record.create", CostTrackingRecordCreateHandler),
+        ("payment.enter", PaymentSliceEnterHandler),
+        ("payment.block.fetch", PaymentSliceBlockFetchHandler),
+        ("payment.record.create", PaymentSliceRecordCreateHandler),
+        ("settlement.enter", SettlementSliceEnterHandler),
+        ("settlement.block.fetch", SettlementSliceBlockFetchHandler),
+        ("project.initiation.enter", ProjectInitiationEnterHandler),
+        ("risk.action.execute", RiskActionExecuteHandler),
+        ("app.catalog", AppCatalogHandler),
+        ("app.nav", AppNavHandler),
+        ("app.open", AppOpenHandler),
+    ]
+    return [
+        {
+            "intent": intent,
+            "handler": handler,
+            "source_module": "smart_construction_core",
+            "domain": "construction",
+            "status": "active",
+        }
+        for intent, handler in mapping
+    ]
 
 
-def smart_core_identity_profile(env):
-    del env
-    return {
-        "role_surface_map": ROLE_SURFACE_OVERRIDES,
-        "role_groups_explicit": ROLE_GROUPS_EXPLICIT,
-        "role_groups_capability_fallback": ROLE_GROUPS_CAPABILITY_FALLBACK,
-        "role_precedence": ROLE_PRECEDENCE,
-    }
-
-
-def smart_core_list_capabilities_for_user(env, user):
+def get_capability_contributions(env, user):
     try:
         from odoo.addons.smart_construction_core.services.capability_registry import (
             list_capabilities_for_user as registry_list_capabilities_for_user,
         )
     except Exception:
-        return None
+        return []
     try:
         capabilities = registry_list_capabilities_for_user(env, user)
     except Exception:
-        return None
-    return capabilities if isinstance(capabilities, list) and capabilities else None
+        return []
+    if not isinstance(capabilities, list) or not capabilities:
+        return []
+
+    out = []
+    for row in capabilities:
+        if not isinstance(row, dict):
+            continue
+        key = str(row.get("key") or "").strip()
+        if not key:
+            continue
+        identity_name = str(row.get("name") or row.get("ui_label") or key).strip() or key
+        group_key = str(row.get("group_key") or "others").strip() or "others"
+        intent_name = str(row.get("intent") or "ui.contract").strip() or "ui.contract"
+        entry_target = row.get("entry_target") if isinstance(row.get("entry_target"), dict) else {}
+        entry_scene_key = str(entry_target.get("scene_key") or "").strip()
+        item = {
+            "key": key,
+            "name": identity_name,
+            "domain": str(key.split(".")[0] if "." in key else "construction").strip() or "construction",
+            "type": "entry",
+            "source_module": "smart_construction_core",
+            "owner_module": "smart_core",
+            "status": str(row.get("status") or "ga").strip().lower() or "ga",
+            "group_key": group_key,
+            "group_label": str(row.get("group_label") or "").strip(),
+            "group_icon": str(row.get("group_icon") or "").strip(),
+            "group_sequence": int(row.get("group_sequence") or 0),
+            "ui_label": str(row.get("ui_label") or identity_name).strip(),
+            "ui_hint": str(row.get("ui_hint") or "").strip(),
+            "intent": intent_name,
+            "required_roles": [str(x).strip() for x in (row.get("required_roles") or []) if str(x).strip()],
+            "required_groups": [str(x).strip() for x in (row.get("required_groups") or []) if str(x).strip()],
+            "entry_target": dict(entry_target),
+            "sequence": int(row.get("sequence") or 0),
+            "tags": list(row.get("tags") or []),
+            "identity": {
+                "key": key,
+                "name": identity_name,
+                "domain": str(key.split(".")[0] if "." in key else "construction").strip() or "construction",
+                "type": "entry",
+                "version": "v1",
+            },
+            "ownership": {
+                "owner_module": "smart_core",
+                "source_module": "smart_construction_core",
+                "source_kind": "industry_contribution",
+            },
+            "ui": {
+                "label": str(row.get("ui_label") or identity_name).strip(),
+                "hint": str(row.get("ui_hint") or "").strip(),
+                "group_key": group_key,
+                "icon": str(row.get("group_icon") or "").strip(),
+                "sequence": int(row.get("sequence") or 0),
+                "tags": list(row.get("tags") or []),
+            },
+            "binding": {
+                "scene": {
+                    "entry_scene_key": entry_scene_key,
+                    "target_mode": str(entry_target.get("target_mode") or "scene").strip() or "scene",
+                },
+                "intent": {
+                    "primary_intent": intent_name,
+                },
+                "contract": {
+                    "subject": "scene",
+                    "contract_type": "entry_contract",
+                    "contract_version": "v1",
+                },
+                "exposure": {
+                    "group_key": group_key,
+                },
+            },
+            "permission": {
+                "required_roles": [str(x).strip() for x in (row.get("required_roles") or []) if str(x).strip()],
+                "required_groups": [str(x).strip() for x in (row.get("required_groups") or []) if str(x).strip()],
+                "access_mode": "execute",
+                "data_scope": "user_env",
+            },
+            "release": {
+                "tier": "standard",
+                "slice": "",
+                "exposure_mode": "default",
+                "approval_required": False,
+                "feature_flag": "",
+            },
+            "lifecycle": {
+                "status": str(row.get("status") or "ga").strip().lower() or "ga",
+                "deprecated": False,
+                "replacement_key": "",
+                "introduced_in": "",
+                "sunset_after": "",
+            },
+            "runtime": {
+                "supports_entry": True,
+                "supports_execute": False,
+                "supports_batch": False,
+                "safe_fallback": "workspace.home",
+            },
+            "audit": {
+                "audit_enabled": True,
+                "policy_trace_enabled": True,
+                "owner_trace": "smart_construction_core.get_capability_contributions",
+            },
+        }
+        out.append(item)
+    return out
 
 
-def smart_core_capability_groups(env):
+def get_capability_contributions_with_timings(env, user):
+    try:
+        from odoo.addons.smart_construction_core.services.capability_registry import (
+            list_capabilities_for_user_with_timings as registry_list_capabilities_for_user_with_timings,
+        )
+    except Exception:
+        return [], {}
+    try:
+        capabilities, timings_ms = registry_list_capabilities_for_user_with_timings(env, user)
+    except Exception:
+        return [], {}
+    if not isinstance(capabilities, list) or not capabilities:
+        return [], timings_ms if isinstance(timings_ms, dict) else {}
+
+    out = []
+    for row in capabilities:
+        if not isinstance(row, dict):
+            continue
+        key = str(row.get("key") or "").strip()
+        if not key:
+            continue
+        identity_name = str(row.get("name") or row.get("ui_label") or key).strip() or key
+        group_key = str(row.get("group_key") or "others").strip() or "others"
+        intent_name = str(row.get("intent") or "ui.contract").strip() or "ui.contract"
+        entry_target = row.get("entry_target") if isinstance(row.get("entry_target"), dict) else {}
+        entry_scene_key = str(entry_target.get("scene_key") or "").strip()
+        item = {
+            "key": key,
+            "name": identity_name,
+            "domain": str(key.split(".")[0] if "." in key else "construction").strip() or "construction",
+            "type": "entry",
+            "source_module": "smart_construction_core",
+            "owner_module": "smart_core",
+            "status": str(row.get("status") or "ga").strip().lower() or "ga",
+            "group_key": group_key,
+            "group_label": str(row.get("group_label") or "").strip(),
+            "group_icon": str(row.get("group_icon") or "").strip(),
+            "group_sequence": int(row.get("group_sequence") or 0),
+            "ui_label": str(row.get("ui_label") or identity_name).strip(),
+            "ui_hint": str(row.get("ui_hint") or "").strip(),
+            "intent": intent_name,
+            "required_roles": [str(x).strip() for x in (row.get("required_roles") or []) if str(x).strip()],
+            "required_groups": [str(x).strip() for x in (row.get("required_groups") or []) if str(x).strip()],
+            "entry_target": dict(entry_target),
+            "sequence": int(row.get("sequence") or 0),
+            "tags": list(row.get("tags") or []),
+            "identity": {
+                "key": key,
+                "name": identity_name,
+                "domain": str(key.split(".")[0] if "." in key else "construction").strip() or "construction",
+                "type": "entry",
+                "version": "v1",
+            },
+            "ownership": {
+                "owner_module": "smart_core",
+                "source_module": "smart_construction_core",
+                "source_kind": "industry_contribution",
+            },
+            "ui": {
+                "label": str(row.get("ui_label") or identity_name).strip(),
+                "hint": str(row.get("ui_hint") or "").strip(),
+                "group_key": group_key,
+                "icon": str(row.get("group_icon") or "").strip(),
+                "sequence": int(row.get("sequence") or 0),
+                "tags": list(row.get("tags") or []),
+            },
+            "binding": {
+                "scene": {
+                    "entry_scene_key": entry_scene_key,
+                    "target_mode": str(entry_target.get("target_mode") or "scene").strip() or "scene",
+                },
+                "intent": {
+                    "primary_intent": intent_name,
+                },
+                "contract": {
+                    "subject": "scene",
+                    "contract_type": "entry_contract",
+                    "contract_version": "v1",
+                },
+                "exposure": {
+                    "group_key": group_key,
+                },
+            },
+            "permission": {
+                "required_roles": [str(x).strip() for x in (row.get("required_roles") or []) if str(x).strip()],
+                "required_groups": [str(x).strip() for x in (row.get("required_groups") or []) if str(x).strip()],
+                "access_mode": "execute",
+                "data_scope": "user_env",
+            },
+            "release": {
+                "tier": "standard",
+                "slice": "",
+                "exposure_mode": "default",
+                "approval_required": False,
+                "feature_flag": "",
+            },
+            "lifecycle": {
+                "status": str(row.get("status") or "ga").strip().lower() or "ga",
+                "deprecated": False,
+                "replacement_key": "",
+                "introduced_in": "",
+                "sunset_after": "",
+            },
+            "runtime": {
+                "supports_entry": True,
+                "supports_execute": False,
+                "supports_batch": False,
+                "safe_fallback": "workspace.home",
+            },
+            "audit": {
+                "audit_enabled": True,
+                "policy_trace_enabled": True,
+                "owner_trace": "smart_construction_core.get_capability_contributions",
+            },
+        }
+        out.append(item)
+    return out, timings_ms if isinstance(timings_ms, dict) else {}
+
+
+def get_capability_group_contributions(env):
     del env
     try:
         from odoo.addons.smart_construction_core.services.capability_registry import CAPABILITY_GROUPS
     except Exception:
-        return None
-    return [dict(item) for item in CAPABILITY_GROUPS if isinstance(item, dict)]
+        return []
+    out = []
+    for item in CAPABILITY_GROUPS:
+        if not isinstance(item, dict):
+            continue
+        row = dict(item)
+        row.setdefault("source_module", "smart_construction_core")
+        out.append(row)
+    return out
 
 
-def smart_core_nav_scene_maps(env):
+def get_create_field_fallback_contributions(env, model_name):
     del env
-    return {
-        "menu_scene_map": NAV_MENU_SCENE_MAP,
-        "action_xmlid_scene_map": NAV_ACTION_SCENE_MAP,
-        "model_view_scene_map": NAV_MODEL_VIEW_SCENE_MAP,
-    }
+    return dict(INDUSTRY_CREATE_FIELD_FALLBACKS.get(str(model_name or ""), {}))
 
 
-def smart_core_scene_package_service_class(env):
-    del env
-    try:
-        from odoo.addons.smart_construction_scene.services.scene_package_service import ScenePackageService
-    except Exception:
-        return None
-    return ScenePackageService
-
-
-def smart_core_scene_governance_service_class(env):
-    del env
-    try:
-        from odoo.addons.smart_construction_scene.services.scene_governance_service import SceneGovernanceService
-    except Exception:
-        return None
-    return SceneGovernanceService
-
-
-def smart_core_load_scene_configs(env, *, drift=None):
-    try:
-        from odoo.addons.smart_construction_scene.scene_registry import load_scene_configs
-    except Exception:
-        return None
-    try:
-        return load_scene_configs(env, drift=drift)
-    except Exception:
-        return None
-
-
-def smart_core_has_db_scenes(env):
-    try:
-        from odoo.addons.smart_construction_scene.scene_registry import has_db_scenes
-    except Exception:
-        return None
-    try:
-        return bool(has_db_scenes(env))
-    except Exception:
-        return None
-
-
-def smart_core_get_scene_version(env):
-    del env
-    try:
-        from odoo.addons.smart_construction_scene.scene_registry import get_scene_version
-    except Exception:
-        return None
-    try:
-        return get_scene_version()
-    except Exception:
-        return None
-
-
-def smart_core_get_schema_version(env):
-    del env
-    try:
-        from odoo.addons.smart_construction_scene.scene_registry import get_schema_version
-    except Exception:
-        return None
-    try:
-        return get_schema_version()
-    except Exception:
-        return None
-
-
-def smart_core_server_action_window_map(env):
-    del env
-    return dict(SERVER_ACTION_WINDOW_MAP)
-
-
-def smart_core_file_upload_allowed_models(env):
-    del env
-    return list(FILE_UPLOAD_ALLOWED_MODELS)
-
-
-def smart_core_file_download_allowed_models(env):
-    del env
-    return list(FILE_DOWNLOAD_ALLOWED_MODELS)
-
-
-def smart_core_api_data_write_allowlist(env):
-    del env
-    return {str(model): list(fields) for model, fields in API_DATA_WRITE_ALLOWLIST.items()}
-
-
-def smart_core_api_data_unlink_allowed_models(env):
-    del env
-    return list(API_DATA_UNLINK_ALLOWED_MODELS)
-
-
-def smart_core_model_code_mapping(env):
-    del env
-    return dict(MODEL_CODE_MAPPING)
-
-
-def smart_core_create_field_fallbacks(env, model_name):
-    del env
-    return dict(CREATE_FIELD_FALLBACKS.get(str(model_name or ""), {}))
-
-
-def smart_core_surface_nav_allowlist(env):
-    del env
-    return {str(surface): list(codes) for surface, codes in SURFACE_NAV_ALLOWLIST.items()}
-
-
-def smart_core_surface_deep_link_allowlist(env):
-    del env
-    return {str(surface): list(codes) for surface, codes in SURFACE_DEEP_LINK_ALLOWLIST.items()}
-
-
-def smart_core_surface_policy_default_name(env):
-    del env
-    return SURFACE_POLICY_DEFAULT_NAME
-
-
-def smart_core_surface_policy_file_default(env):
-    del env
-    return SURFACE_POLICY_DEFAULT_FILE
-
-
-def smart_core_critical_scene_target_overrides(env):
-    del env
-    return list(CRITICAL_SCENE_TARGET_OVERRIDES)
-
-
-def smart_core_critical_scene_target_route_overrides(env):
-    del env
-    return dict(CRITICAL_SCENE_TARGET_ROUTE_OVERRIDES)
-
-
-def smart_core_extend_system_init(data, env, user):
-    """
-    Enrich smart_core system.init response with construction facts only.
-    Contract shape fields (e.g. scenes/capabilities) are owned by smart_core.
-    """
+def get_system_init_fact_contributions(env, user, context=None):
+    """Return construction system.init facts contribution payload."""
+    del context
     try:
         Entitlement = env.get("sc.entitlement")
         Usage = env.get("sc.usage.counter")
-        ext_facts = data.get("ext_facts")
-        if not isinstance(ext_facts, dict):
-            ext_facts = {}
-        module_facts = ext_facts.get("smart_construction_core")
-        if not isinstance(module_facts, dict):
-            module_facts = {}
+        module_facts = {}
         if Entitlement:
             module_facts["entitlements"] = Entitlement.get_payload(user)
         if Usage:
@@ -734,17 +889,136 @@ def smart_core_extend_system_init(data, env, user):
             "project_actions": len(project_rows),
         }
 
-        module_facts["role_surface_override_provider"] = {
-            "key": "smart_construction_core",
-            "enabled": True,
-            "priority": 100,
-            "domain_key": "construction",
-            "root_xmlids": ["smart_construction_core.menu_sc_root"],
-            "scene_codes": ["portal.dashboard", "project.management", "projects.list", "projects.intake"],
-            "role_surface_overrides": ROLE_SURFACE_OVERRIDES,
-        }
+        role_entries = _build_role_entry_contract_rows(env)
+        if role_entries:
+            module_facts["role_entries"] = role_entries
 
-        ext_facts["smart_construction_core"] = module_facts
-        data["ext_facts"] = ext_facts
+        home_blocks = _build_home_block_contract_rows(env)
+        if home_blocks:
+            module_facts["home_blocks"] = home_blocks
+
+        enterprise_enablement = _build_enterprise_enablement_contract(env, user)
+        if enterprise_enablement:
+            module_facts["enterprise_enablement"] = enterprise_enablement
+
+        return {
+            "module": "smart_construction_core",
+            "facts": module_facts,
+            "collections": module_facts.get("workspace_collections") or {},
+            "meta": {
+                "source": "smart_construction_core",
+                "status": "active",
+            },
+        }
     except Exception as exc:
-        _logger.warning("[smart_core_extend_system_init] failed: %s", exc)
+        _logger.warning("[get_system_init_fact_contributions] failed: %s", exc)
+        return None
+
+
+def smart_core_extend_system_init(data, env, user):
+    """Legacy hook shim: write construction facts only under data['ext_facts']."""
+    if not isinstance(data, dict):
+        return data
+
+    contribution = get_system_init_fact_contributions(env, user)
+    ext_facts = data.get("ext_facts")
+    if not isinstance(ext_facts, dict):
+        ext_facts = {}
+    if isinstance(contribution, dict):
+        module_key = str(contribution.get("module") or "smart_construction_core").strip() or "smart_construction_core"
+        facts_payload = contribution.get("facts") if isinstance(contribution.get("facts"), dict) else {}
+        ext_facts[module_key] = dict(facts_payload)
+    data["ext_facts"] = ext_facts
+    return data
+
+
+def smart_core_describe_project_capabilities(env, project):
+    from odoo.addons.smart_construction_core.services.lifecycle_capability_service import (
+        LifecycleCapabilityService,
+    )
+
+    return LifecycleCapabilityService(env).describe_project(project)
+
+
+def smart_core_build_portal_dashboard(env):
+    from odoo.addons.smart_construction_core.services.portal_dashboard_service import (
+        PortalDashboardService,
+    )
+
+    return PortalDashboardService(env).build_dashboard()
+
+
+def smart_core_build_capability_matrix(env):
+    from odoo.addons.smart_construction_core.services.capability_matrix_service import (
+        CapabilityMatrixService,
+    )
+
+    return CapabilityMatrixService(env).build_matrix()
+
+
+def smart_core_get_project_insight(env, record, scene):
+    from odoo.addons.smart_construction_core.services.insight.project_insight_service import (
+        ProjectInsightService,
+    )
+
+    return ProjectInsightService(env).get_insight(record, scene=scene)
+
+
+def smart_core_build_portal_execute_button_contract(env, model, res_id, method):
+    from odoo.addons.smart_construction_core.services.portal_execute_button_service import (
+        PortalExecuteButtonService,
+    )
+
+    return PortalExecuteButtonService(env).build_contract(
+        model=model,
+        res_id=res_id,
+        method=method,
+    )
+
+
+def smart_core_build_project_execution_service(env):
+    from odoo.addons.smart_construction_core.services.project_execution_service import (
+        ProjectExecutionService,
+    )
+
+    return ProjectExecutionService(env)
+
+
+def smart_core_build_project_dashboard_service(env):
+    from odoo.addons.smart_construction_core.services.project_dashboard_service import (
+        ProjectDashboardService,
+    )
+
+    return ProjectDashboardService(env)
+
+
+def smart_core_build_project_plan_bootstrap_service(env):
+    from odoo.addons.smart_construction_core.services.project_plan_bootstrap_service import (
+        ProjectPlanBootstrapService,
+    )
+
+    return ProjectPlanBootstrapService(env)
+
+
+def smart_core_build_cost_tracking_service(env):
+    from odoo.addons.smart_construction_core.services.cost_tracking_service import (
+        CostTrackingService,
+    )
+
+    return CostTrackingService(env)
+
+
+def smart_core_build_payment_slice_service(env):
+    from odoo.addons.smart_construction_core.services.payment_slice_service import (
+        PaymentSliceService,
+    )
+
+    return PaymentSliceService(env)
+
+
+def smart_core_build_settlement_slice_service(env):
+    from odoo.addons.smart_construction_core.services.settlement_slice_service import (
+        SettlementSliceService,
+    )
+
+    return SettlementSliceService(env)

--- a/addons/smart_construction_core/handlers/my_work_summary.py
+++ b/addons/smart_construction_core/handlers/my_work_summary.py
@@ -21,6 +21,14 @@ from odoo.addons.smart_core.utils.reason_codes import (
 )
 from odoo.addons.smart_construction_core.services.my_work_aggregate_service import WorkItemAggregateService
 from odoo.exceptions import AccessError
+from odoo.addons.smart_construction_core.services.project_execution_item_projection_service import (
+    ProjectExecutionItemProjectionService,
+)
+from odoo.addons.smart_construction_scene.services.my_work_scene_targets import (
+    build_my_work_section_rows,
+    build_my_work_summary_rows,
+    build_my_work_target,
+)
 
 
 class MyWorkSummaryHandler(BaseIntentHandler):
@@ -39,6 +47,17 @@ class MyWorkSummaryHandler(BaseIntentHandler):
     STATUS_EMPTY = "EMPTY"
     STATUS_FILTER_EMPTY = "FILTER_EMPTY"
     SORT_FIELDS = WorkItemAggregateService.SORT_FIELDS
+    SOURCE_LABELS = {
+        "mail.activity": "待办提醒",
+        "tier.review": "审批复核",
+        "sc.workflow.workitem": "流程待办",
+        "project.task": "项目任务",
+        "project.risk": "项目风险",
+        "project.project": "负责项目",
+        "construction.contract": "合同执行事项",
+        "payment.request": "付款执行事项",
+        "sc.settlement.order": "结算执行事项",
+    }
 
     def _get_model(self, model_name, *, sudo=False):
         try:
@@ -73,17 +92,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
         except Exception:
             return {"model": model_name, "readable": False, "reason": "ACCESS_CHECK_FAILED"}
 
-    def _scene_for_model(self, model_name):
-        mapping = {
-            "project.project": "projects.list",
-            "project.task": "projects.list",
-            "payment.request": "finance.payment_requests",
-            "sc.workflow.instance": "projects.list",
-            "sale.order": "contracts.list",
-            "account.move": "finance.vouchers.list",
-        }
-        return mapping.get(model_name, "projects.list")
-
     def _resolve_action_context_for_model(self, model_name):
         model = str(model_name or "").strip()
         if not model:
@@ -117,24 +125,75 @@ class MyWorkSummaryHandler(BaseIntentHandler):
         for row in attached:
             model = str(row.get("model") or "").strip()
             record_id = self._coerce_record_id(row.get("record_id"))
-            scene_key = str(row.get("scene_key") or self._scene_for_model(model)).strip() or "projects.list"
-            target = {
-                "kind": "record" if model and record_id else "scene",
-                "scene_key": scene_key,
-            }
-            if model:
-                target["model"] = model
-            if record_id:
-                target["record_id"] = record_id
             action_ctx = self._resolve_action_context_for_model(model)
             action_id = int(action_ctx.get("action_id") or 0)
             menu_id = int(action_ctx.get("menu_id") or 0)
-            if action_id > 0:
-                target["action_id"] = action_id
-            if menu_id > 0:
-                target["menu_id"] = menu_id
+            target = build_my_work_target(
+                model_name=model,
+                record_id=record_id,
+                action_id=action_id,
+                menu_id=menu_id,
+                explicit_scene_key=str(row.get("scene_key") or ""),
+                source_key=str(row.get("source") or ""),
+                section_key=str(row.get("section") or ""),
+            )
+            row["scene_key"] = str(target.get("scene_key") or "")
             row["target"] = target
+            row.setdefault("source_label", self._source_label(row))
+            row.setdefault("project_name", self._row_project_name(model, record_id, row))
+            row.setdefault("action_summary", self._action_summary(row))
+            row["can_complete"] = self._can_complete(row)
+            complete_action = self._complete_action(row)
+            if complete_action:
+                row["complete_action"] = complete_action
         return attached
+
+    def _can_complete(self, row):
+        return str(row.get("source") or "").strip() == "mail.activity"
+
+    def _complete_action(self, row):
+        if not self._can_complete(row):
+            return None
+        return {
+            "intent": "my.work.complete",
+            "label": "完成",
+            "enabled": True,
+            "source": "mail.activity",
+        }
+
+    def _source_label(self, row):
+        source = str(row.get("source") or "").strip()
+        model = str(row.get("model") or "").strip()
+        return self.SOURCE_LABELS.get(source) or self.SOURCE_LABELS.get(model) or source or model or "执行事项"
+
+    def _row_project_name(self, model_name, record_id, row):
+        existing = str(row.get("project_name") or "").strip()
+        if existing:
+            return existing
+        model = str(model_name or "").strip()
+        rid = int(record_id or 0)
+        if not model or not rid:
+            return ""
+        Model = self._get_model(model, sudo=True)
+        if Model is None:
+            return ""
+        try:
+            rec = Model.browse(rid).exists()
+            if not rec:
+                return ""
+            project = getattr(rec, "project_id", False)
+            return str(getattr(project, "display_name", "") or getattr(project, "name", "") or "").strip()
+        except Exception:
+            return ""
+
+    def _action_summary(self, row):
+        label = str(row.get("action_label") or "").strip()
+        if label:
+            return label
+        reason = str(row.get("reason_code") or "").strip()
+        if reason:
+            return reason
+        return "进入处理"
 
     def _coerce_record_id(self, raw):
         value = raw
@@ -265,7 +324,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": rec.res_model,
                     "record_id": rec.res_id,
                     "deadline": fields.Date.to_string(rec.date_deadline) if rec.date_deadline else "",
-                    "scene_key": self._scene_for_model(rec.res_model),
                     "source": "mail.activity",
                     "action_label": followup.get("action_label") or "",
                     "action_key": followup.get("action_key") or "",
@@ -315,7 +373,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": model,
                     "record_id": record_id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model(model),
                     "source": "tier.review",
                     "action_label": "审批处理",
                     "action_key": "tier.review.approve",
@@ -363,7 +420,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": model,
                     "record_id": record_id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model(model),
                     "source": "sc.workflow.workitem",
                     "action_label": node_name or "流程处理",
                     "action_key": "sc.workflow.approve",
@@ -400,7 +456,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": "project.task",
                     "record_id": rec.id,
                     "deadline": fields.Date.to_string(rec.date_deadline) if getattr(rec, "date_deadline", False) else "",
-                    "scene_key": self._scene_for_model("project.task"),
                     "source": "project.task",
                     "action_label": "任务处理",
                     "action_key": "project.task.open",
@@ -409,6 +464,14 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                 })
         except Exception:
             return []
+        return self._attach_targets(rows)
+
+    def _load_project_execution_items(self, user, limit):
+        try:
+            service = ProjectExecutionItemProjectionService(self.env)
+            rows = service.user_items(user, limit=limit)
+        except Exception:
+            rows = []
         return self._attach_targets(rows)
 
     def _project_risk_domain_for_user(self, user):
@@ -454,7 +517,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": "project.project",
                     "record_id": rec.id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model("project.project"),
                     "source": "project.risk",
                     "action_label": "风险处理",
                     "action_key": "project.risk.resolve",
@@ -497,7 +559,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": "project.project",
                     "record_id": rec.id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model("project.project"),
                     "source": "project.project",
                     "reason_code": REASON_RESPONSIBLE_OWNER,
                     "priority": "medium",
@@ -525,7 +586,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": model,
                     "record_id": record_id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model(model),
                     "source": "mail.message",
                     "reason_code": REASON_MENTIONED,
                     "priority": "low",
@@ -552,7 +612,6 @@ class MyWorkSummaryHandler(BaseIntentHandler):
                     "model": model,
                     "record_id": record_id,
                     "deadline": "",
-                    "scene_key": self._scene_for_model(model),
                     "source": "mail.followers",
                     "reason_code": REASON_FOLLOWING,
                     "priority": "low",
@@ -590,12 +649,20 @@ class MyWorkSummaryHandler(BaseIntentHandler):
             self._task_domain_for_user(user) or [("id", "=", -1)],
             ["id"],
         )
+        projected_execution_count = len(self._load_project_execution_items(user, limit_each))
         risk_todo_count = self._safe_count(
             "project.project",
             self._project_risk_domain_for_user(user) or [("id", "=", -1)],
             ["health_state"],
         )
-        todo_count = int(mail_todo_count + tier_review_count + workflow_todo_count + task_todo_count + risk_todo_count)
+        todo_count = int(
+            mail_todo_count
+            + tier_review_count
+            + workflow_todo_count
+            + task_todo_count
+            + projected_execution_count
+            + risk_todo_count
+        )
         project_responsible_domain = self._project_responsible_domain(user)
         responsible_count = self._safe_count(
             "project.project",
@@ -610,6 +677,7 @@ class MyWorkSummaryHandler(BaseIntentHandler):
         self._append_items(items, "todo", self._load_tier_review_items(user, limit_each))
         self._append_items(items, "todo", self._load_workflow_todo_items(user, limit_each))
         self._append_items(items, "todo", self._load_task_items(user, limit_each))
+        self._append_items(items, "todo", self._load_project_execution_items(user, limit_each))
         self._append_items(items, "todo", self._load_project_risk_items(user, limit_each))
         self._append_items(items, "owned", self._load_owned_items(user, limit_each))
         self._append_items(items, "mentions", self._load_mention_items(partner, limit_each))
@@ -642,6 +710,9 @@ class MyWorkSummaryHandler(BaseIntentHandler):
             "sc.workflow.workitem",
             "project.task",
             "project.project",
+            "construction.contract",
+            "payment.request",
+            "sc.settlement.order",
             "mail.message",
             "mail.followers",
         )
@@ -661,18 +732,15 @@ class MyWorkSummaryHandler(BaseIntentHandler):
 
         data = {
             "generated_at": fields.Datetime.now(),
-            "sections": [
-                {"key": "todo", "label": self.SECTION_LABELS["todo"], "scene_key": "projects.list"},
-                {"key": "owned", "label": self.SECTION_LABELS["owned"], "scene_key": "projects.list"},
-                {"key": "mentions", "label": self.SECTION_LABELS["mentions"], "scene_key": "projects.list"},
-                {"key": "following", "label": self.SECTION_LABELS["following"], "scene_key": "projects.list"},
-            ],
-            "summary": [
-                {"key": "todo", "label": "待我处理", "count": todo_count, "scene_key": "projects.list"},
-                {"key": "owned", "label": "我负责", "count": responsible_count, "scene_key": "projects.list"},
-                {"key": "mentions", "label": "@我的", "count": mentioned_count, "scene_key": "projects.list"},
-                {"key": "following", "label": "我关注的", "count": following_count, "scene_key": "projects.list"},
-            ],
+            "sections": build_my_work_section_rows(self.SECTION_LABELS),
+            "summary": build_my_work_summary_rows(
+                [
+                    {"key": "todo", "label": "待我处理", "count": todo_count},
+                    {"key": "owned", "label": "我负责", "count": responsible_count},
+                    {"key": "mentions", "label": "@我的", "count": mentioned_count},
+                    {"key": "following", "label": "我关注的", "count": following_count},
+                ]
+            ),
             "items": items,
             "facets": facets,
             "filters": {

--- a/addons/smart_construction_core/services/capability_registry.py
+++ b/addons/smart_construction_core/services/capability_registry.py
@@ -2,13 +2,24 @@
 from __future__ import annotations
 
 import re
+import time
 from typing import Any
 
 from odoo import _
-
 from odoo.addons.smart_construction_scene import scene_registry
+from odoo.addons.smart_construction_scene.services.capability_scene_targets import (
+    build_capability_entry_target,
+    resolve_capability_entry_scene_key,
+    resolve_capability_entry_target_payload,
+    resolve_capability_entry_target_payload_with_timings,
+)
 
 CAPABILITY_KEY_REGEX = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*\.[a-z][a-z0-9_]*$")
+
+RUNTIME_ORCHESTRATION_SCENE_KEYS = {
+    "project.plan_bootstrap",
+    "project.execution",
+}
 
 CAPABILITY_GROUPS: list[dict[str, Any]] = [
     {"key": "project_management", "label": "项目管理", "icon": "briefcase", "sequence": 10},
@@ -39,7 +50,6 @@ def _cap(
     label: str,
     hint: str,
     group_key: str,
-    scene_key: str,
     *,
     required_roles: list[str] | None = None,
     required_groups: list[str] | None = None,
@@ -50,7 +60,6 @@ def _cap(
         "label": label,
         "hint": hint,
         "group_key": group_key,
-        "entry_target": {"scene_key": scene_key},
         "required_roles": list(required_roles or []),
         "required_groups": list(required_groups or []),
         "status": status,
@@ -59,55 +68,59 @@ def _cap(
 
 
 _CAPABILITIES: list[dict[str, Any]] = [
-    _cap("project.initiation.enter", "项目立项", "创建并发起项目立项流程", "project_management", "projects.intake", required_roles=["pm", "executive"]),
-    _cap("project.list.open", "项目列表", "查看项目列表与筛选", "project_management", "projects.list", required_roles=["owner", "pm", "finance", "executive"]),
-    _cap("project.board.open", "项目看板", "查看项目看板与状态分布", "project_management", "projects.ledger", required_roles=["owner", "pm", "executive"]),
-    _cap("project.dashboard.open", "项目驾驶舱", "查看项目核心指标和异常", "project_management", "projects.dashboard", required_roles=["pm", "executive"]),
-    _cap("project.lifecycle.open", "生命周期视图", "查看项目生命周期与阻塞项", "project_management", "portal.lifecycle", required_roles=["pm", "executive"]),
-    _cap("project.task.list", "任务列表", "查看项目任务与待办", "project_management", "projects.ledger", required_roles=["owner", "pm", "executive"]),
-    _cap("project.task.board", "任务看板", "按状态查看任务推进", "project_management", "projects.ledger", required_roles=["pm", "executive"]),
-    _cap("project.document.open", "项目文档", "进入项目文档视图", "project_management", "projects.ledger", required_roles=["pm", "executive"]),
-    _cap("project.structure.manage", "执行结构", "进入执行结构与WBS能力", "project_management", "cost.project_boq", required_roles=["pm", "executive"]),
-    _cap("project.risk.list", "风险清单", "查看项目风险清单", "project_management", "projects.ledger", required_roles=["pm", "executive"]),
-    _cap("project.weekly_report.open", "周报入口", "进入项目周报与周度复盘", "project_management", "projects.ledger", required_roles=["pm", "executive"]),
-    _cap("project.lifecycle.transition", "生命周期流转", "执行项目生命周期流转动作", "project_management", "portal.lifecycle", required_roles=["pm", "executive"]),
+    _cap("project.initiation.enter", "项目立项", "创建并发起项目立项流程", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.list.open", "项目列表", "查看项目列表与筛选", "project_management", required_roles=["owner", "pm", "finance", "executive"]),
+    _cap("project.board.open", "项目看板", "查看项目看板与状态分布", "project_management", required_roles=["owner", "pm", "executive"]),
+    _cap("project.dashboard.enter", "项目驾驶舱", "进入项目驾驶舱最小入口", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.dashboard.open", "项目驾驶舱（兼容）", "兼容旧入口，转发到项目驾驶舱最小入口", "project_management", required_roles=["pm", "executive"], status="deprecated"),
+    _cap("project.plan_bootstrap.enter", "计划编排入口", "进入项目计划编排最小入口", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.execution.enter", "项目执行入口", "进入项目执行最小入口", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.execution.advance", "推进执行", "执行最小推进动作", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.lifecycle.open", "生命周期视图", "查看项目生命周期与阻塞项", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.task.list", "任务列表", "查看项目任务与待办", "project_management", required_roles=["owner", "pm", "executive"]),
+    _cap("project.task.board", "任务看板", "按状态查看任务推进", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.document.open", "项目文档", "进入项目文档视图", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.structure.manage", "执行结构", "进入执行结构与WBS能力", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.risk.list", "风险清单", "查看项目风险清单", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.weekly_report.open", "周报入口", "进入项目周报与周度复盘", "project_management", required_roles=["pm", "executive"]),
+    _cap("project.lifecycle.transition", "生命周期流转", "执行项目生命周期流转动作", "project_management", required_roles=["pm", "executive"]),
 
-    _cap("finance.payment_request.list", "付款申请列表", "查看付款申请列表", "finance_management", "finance.payment_requests", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_finance_read"]),
-    _cap("finance.payment_request.form", "付款申请表单", "进入付款申请详情与编辑", "finance_management", "finance.payment_requests", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_finance_read"]),
-    _cap("finance.approval.center", "审批中心入口", "进入财务审批工作台", "finance_management", "finance.center", required_roles=["finance", "executive"]),
-    _cap("finance.ledger.payment", "收付款台账", "查看收付款台账", "finance_management", "finance.payment_ledger", required_roles=["finance", "executive"]),
-    _cap("finance.ledger.treasury", "资金台账", "查看资金余额与流水", "finance_management", "finance.treasury_ledger", required_roles=["finance", "executive"]),
-    _cap("finance.settlement.order", "结算单", "查看结算单流程", "finance_management", "finance.settlement_orders", required_roles=["finance", "executive"]),
-    _cap("finance.invoice.list", "发票列表", "进入发票相关清单", "finance_management", "finance.center", required_roles=["finance", "executive"]),
-    _cap("finance.plan.funding", "资金计划", "查看资金计划与安排", "finance_management", "finance.center", required_roles=["finance", "executive"]),
-    _cap("finance.metrics.operating", "经营指标", "查看经营指标看板", "finance_management", "finance.operating_metrics", required_roles=["finance", "executive"]),
-    _cap("finance.exception.monitor", "财务异常", "查看财务异常清单", "finance_management", "finance.operating_metrics", required_roles=["finance", "executive"]),
+    _cap("finance.payment_request.list", "付款申请列表", "查看付款申请列表", "finance_management", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_finance_read"]),
+    _cap("finance.payment_request.form", "付款申请表单", "进入付款申请详情与编辑", "finance_management", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_finance_read"]),
+    _cap("finance.approval.center", "审批中心入口", "进入财务审批工作台", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.ledger.payment", "收付款台账", "查看收付款台账", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.ledger.treasury", "资金台账", "查看资金余额与流水", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.settlement.order", "结算单", "查看结算单流程", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.invoice.list", "发票列表", "进入发票相关清单", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.plan.funding", "资金计划", "查看资金计划与安排", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.metrics.operating", "经营指标", "查看经营指标看板", "finance_management", required_roles=["finance", "executive"]),
+    _cap("finance.exception.monitor", "财务异常", "查看财务异常清单", "finance_management", required_roles=["finance", "executive"]),
 
-    _cap("cost.ledger.open", "成本台账", "进入成本台账", "cost_management", "cost.project_cost_ledger", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_cost_read"]),
-    _cap("cost.budget.manage", "预算管理", "进入预算与控制能力", "cost_management", "cost.project_budget", required_roles=["pm", "finance", "executive"]),
-    _cap("cost.boq.manage", "工程量清单", "进入工程量清单能力", "cost_management", "cost.project_boq", required_roles=["pm", "executive"]),
-    _cap("cost.progress.report", "进度填报", "进入进度填报与对比", "cost_management", "cost.project_progress", required_roles=["pm", "executive"]),
-    _cap("cost.profit.compare", "盈亏对比", "查看盈亏对比分析", "cost_management", "cost.profit_compare", required_roles=["finance", "executive"]),
+    _cap("cost.ledger.open", "成本台账", "进入成本台账", "cost_management", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_cost_read"]),
+    _cap("cost.budget.manage", "预算管理", "进入预算与控制能力", "cost_management", required_roles=["pm", "finance", "executive"]),
+    _cap("cost.boq.manage", "工程量清单", "进入工程量清单能力", "cost_management", required_roles=["pm", "executive"]),
+    _cap("cost.progress.report", "进度填报", "进入进度填报与对比", "cost_management", required_roles=["pm", "executive"]),
+    _cap("cost.profit.compare", "盈亏对比", "查看盈亏对比分析", "cost_management", required_roles=["finance", "executive"]),
 
-    _cap("contract.center.open", "合同中心", "进入合同中心", "contract_management", "projects.ledger", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
-    _cap("contract.income.track", "收入合同", "查看收入合同进展", "contract_management", "projects.ledger", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
-    _cap("contract.expense.track", "支出合同", "查看支出合同与付款", "contract_management", "projects.ledger", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
-    _cap("contract.settlement.audit", "结算审核", "查看结算审核视图", "contract_management", "finance.settlement_orders", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
+    _cap("contract.center.open", "合同中心", "进入合同中心", "contract_management", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
+    _cap("contract.income.track", "收入合同", "查看收入合同进展", "contract_management", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
+    _cap("contract.expense.track", "支出合同", "查看支出合同与付款", "contract_management", required_roles=["pm", "finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
+    _cap("contract.settlement.audit", "结算审核", "查看结算审核视图", "contract_management", required_roles=["finance", "executive"], required_groups=["smart_construction_core.group_sc_cap_contract_read"]),
 
-    _cap("analytics.dashboard.executive", "经营驾驶舱", "高层经营看板", "analytics", "projects.dashboard", required_roles=["executive"]),
-    _cap("analytics.lifecycle.monitor", "生命周期监控", "监控生命周期推进效率", "analytics", "portal.lifecycle", required_roles=["pm", "executive"]),
-    _cap("analytics.exception.list", "异常列表", "查看经营与执行异常", "analytics", "finance.operating_metrics", required_roles=["executive"]),
-    _cap("analytics.project.focus", "我关注的项目", "查看重点关注项目", "analytics", "projects.list", required_roles=["executive"]),
+    _cap("analytics.dashboard.executive", "经营驾驶舱", "高层经营看板", "analytics", required_roles=["executive"]),
+    _cap("analytics.lifecycle.monitor", "生命周期监控", "监控生命周期推进效率", "analytics", required_roles=["pm", "executive"]),
+    _cap("analytics.exception.list", "异常列表", "查看经营与执行异常", "analytics", required_roles=["executive"]),
+    _cap("analytics.project.focus", "我关注的项目", "查看重点关注项目", "analytics", required_roles=["executive"]),
 
-    _cap("governance.capability.matrix", "能力矩阵", "查看角色能力覆盖", "governance", "portal.capability_matrix", required_roles=["pm", "finance", "executive"]),
-    _cap("governance.scene.openability", "场景可打开性", "查看场景可打开性状态", "governance", "portal.capability_matrix", required_roles=["executive"]),
-    _cap("governance.runtime.audit", "运行态审计", "查看运行态治理审计", "governance", "portal.dashboard", required_roles=["executive"]),
+    _cap("governance.capability.matrix", "能力矩阵", "查看角色能力覆盖", "governance", required_roles=["pm", "finance", "executive"]),
+    _cap("governance.scene.openability", "场景可打开性", "查看场景可打开性状态", "governance", required_roles=["executive"]),
+    _cap("governance.runtime.audit", "运行态审计", "查看运行态治理审计", "governance", required_roles=["executive"]),
 
-    _cap("material.catalog.open", "物资目录", "查看物资目录与分类", "material_management", "projects.ledger", required_roles=["pm", "finance", "executive"]),
-    _cap("material.procurement.list", "采购清单", "查看采购与供应入口", "material_management", "projects.ledger", required_roles=["pm", "finance", "executive"]),
+    _cap("material.catalog.open", "物资目录", "查看物资目录与分类", "material_management", required_roles=["pm", "finance", "executive"]),
+    _cap("material.procurement.list", "采购清单", "查看采购与供应入口", "material_management", required_roles=["pm", "finance", "executive"]),
 
-    _cap("workspace.today.focus", "今日关键动作", "今日关键动作工作台", "others", "portal.dashboard", required_roles=["owner", "pm", "finance", "executive"]),
-    _cap("workspace.project.watch", "我关注的项目", "从工作台进入关注项目", "others", "projects.list", required_roles=["owner", "pm", "finance", "executive"]),
+    _cap("workspace.today.focus", "今日关键动作", "今日关键动作工作台", "others", required_roles=["owner", "pm", "finance", "executive"]),
+    _cap("workspace.project.watch", "我关注的项目", "从工作台进入关注项目", "others", required_roles=["owner", "pm", "finance", "executive"]),
 ]
 
 
@@ -133,8 +146,6 @@ def _resolve_role_codes_for_user(user) -> set[str]:
         return {"owner"}
     roles: set[str] = set()
     group_xmlids = set(user.groups_id.get_external_id().values())
-    if user.has_group("base.group_system"):
-        roles.add("executive")
     for xmlid in group_xmlids:
         text = str(xmlid or "").strip()
         if text.startswith(ROLE_GROUP_PREFIX):
@@ -153,12 +164,6 @@ def _resolve_role_codes_for_user(user) -> set[str]:
             "smart_construction_core.group_sc_cap_finance_manager"
         ):
             roles.add("finance")
-        if (
-            user.has_group("smart_construction_core.group_sc_super_admin")
-            or user.has_group("smart_construction_core.group_sc_cap_config_admin")
-            or user.has_group("smart_construction_core.group_sc_business_full")
-        ):
-            roles.add("executive")
     except Exception:
         pass
     if "finance" in roles:
@@ -189,59 +194,6 @@ def _normalize_bool(value: Any) -> bool:
     if isinstance(value, str):
         return value.strip().lower() in {"1", "true", "yes", "y", "on"}
     return False
-
-
-def _resolve_scene_map(env) -> dict[str, dict[str, Any]]:
-    scenes = scene_registry.load_scene_configs(env)
-    out: dict[str, dict[str, Any]] = {}
-    for scene in scenes or []:
-        if not isinstance(scene, dict):
-            continue
-        key = str(scene.get("code") or scene.get("key") or "").strip()
-        if not key:
-            continue
-        out[key] = dict(scene)
-    return out
-
-
-def _resolve_ref_id(env, xmlid: str) -> int | None:
-    value = str(xmlid or "").strip()
-    if not value:
-        return None
-    rec = env.ref(value, raise_if_not_found=False)
-    if not rec:
-        return None
-    return int(rec.id)
-
-
-def _resolve_entry_target_payload(env, entry_target: dict[str, Any], scene_map: dict[str, dict[str, Any]]) -> dict[str, Any]:
-    target = dict(entry_target or {})
-    scene_key = str(target.get("scene_key") or "").strip()
-    payload: dict[str, Any] = {}
-    if scene_key:
-        payload["scene_key"] = scene_key
-        payload["route"] = f"/workbench?scene={scene_key}"
-        scene = scene_map.get(scene_key) or {}
-        scene_target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
-        for key in ("route", "model", "view_type", "view_mode", "record_id"):
-            if key in scene_target and scene_target.get(key) not in (None, ""):
-                payload[key] = scene_target.get(key)
-        action_xmlid = str(scene_target.get("action_xmlid") or "").strip()
-        menu_xmlid = str(scene_target.get("menu_xmlid") or "").strip()
-        action_id = scene_target.get("action_id")
-        menu_id = scene_target.get("menu_id")
-        if action_xmlid and not action_id:
-            action_id = _resolve_ref_id(env, action_xmlid)
-        if menu_xmlid and not menu_id:
-            menu_id = _resolve_ref_id(env, menu_xmlid)
-        if action_id:
-            payload["action_id"] = int(action_id)
-        if menu_id:
-            payload["menu_id"] = int(menu_id)
-    for key in ("route", "model", "view_type", "view_mode", "record_id", "action_id", "menu_id"):
-        if key in target and target.get(key) not in (None, ""):
-            payload[key] = target.get(key)
-    return payload
 
 
 def _is_group_member(user, group_xmlid: str) -> bool:
@@ -281,27 +233,64 @@ def _capability_state(defn: dict[str, Any], allowed: bool) -> tuple[str, str]:
 
 
 def list_capabilities_for_user(env, user) -> list[dict[str, Any]]:
+    rows, _timings = list_capabilities_for_user_with_timings(env, user)
+    return rows
+
+
+def list_capabilities_for_user_with_timings(env, user) -> tuple[list[dict[str, Any]], dict[str, int]]:
+    timings_ms: dict[str, int] = {}
+
+    def _mark(stage: str, started_at: float) -> float:
+        timings_ms[stage] = int((time.perf_counter() - started_at) * 1000)
+        return time.perf_counter()
+
+    stage_ts = time.perf_counter()
     group_meta = _group_meta_map()
+    stage_ts = _mark("group_meta_map", stage_ts)
     role_codes = _resolve_role_codes_for_user(user)
-    scene_map = _resolve_scene_map(env)
+    stage_ts = _mark("resolve_role_codes_for_user", stage_ts)
+    definitions = capability_definitions()
+    stage_ts = _mark("capability_definitions", stage_ts)
 
     out: list[dict[str, Any]] = []
-    for idx, defn in enumerate(capability_definitions(), start=1):
+    access_state_total_ms = 0
+    entry_target_total_ms = 0
+    resolve_payload_total_ms = 0
+    for idx, defn in enumerate(definitions, start=1):
+        iter_ts = time.perf_counter()
         visible, allowed, reason_code, reason = _capability_access(defn, role_codes, user)
+        cap_state, cap_state_reason = _capability_state(defn, allowed)
+        access_state_total_ms += int((time.perf_counter() - iter_ts) * 1000)
         if not visible:
             continue
         group_key = str(defn.get("group_key") or "others").strip() or "others"
         group = group_meta.get(group_key) or group_meta["others"]
-        cap_state, cap_state_reason = _capability_state(defn, allowed)
         state = "READY"
         if cap_state in {"pending", "coming_soon"}:
             state = "PREVIEW"
         if cap_state == "deny":
             state = "LOCKED"
 
-        payload = _resolve_entry_target_payload(env, defn.get("entry_target") or {}, scene_map)
+        capability_key = str(defn.get("key") or "").strip()
+        iter_ts = time.perf_counter()
+        entry_target = build_capability_entry_target(
+            capability_key,
+            explicit_target=defn.get("entry_target") or {},
+            env=env,
+        )
+        entry_target_total_ms += int((time.perf_counter() - iter_ts) * 1000)
+        iter_ts = time.perf_counter()
+        payload, payload_timings_ms = resolve_capability_entry_target_payload_with_timings(
+            env,
+            capability_key,
+            explicit_target=defn.get("entry_target") or {},
+        )
+        resolve_payload_total_ms += int((time.perf_counter() - iter_ts) * 1000)
+        if isinstance(payload_timings_ms, dict):
+            for key, value in payload_timings_ms.items():
+                timings_ms[f"payload.{key}"] = int(timings_ms.get(f"payload.{key}", 0) + int(value))
         item = {
-            "key": str(defn.get("key") or "").strip(),
+            "key": capability_key,
             "name": str(defn.get("label") or defn.get("key") or "").strip(),
             "ui_label": str(defn.get("label") or defn.get("key") or "").strip(),
             "ui_hint": str(defn.get("hint") or "").strip(),
@@ -320,14 +309,19 @@ def list_capabilities_for_user(env, user) -> list[dict[str, Any]]:
             "default_payload": payload,
             "required_roles": [str(x).strip() for x in (defn.get("required_roles") or []) if str(x).strip()],
             "required_groups": [str(x).strip() for x in (defn.get("required_groups") or []) if str(x).strip()],
-            "entry_target": dict(defn.get("entry_target") or {}),
+            "entry_target": entry_target,
             "sequence": int(defn.get("sequence") or idx * 10),
             "tags": [group_key, "registry"],
         }
         out.append(item)
 
+    timings_ms["loop_access_and_state"] = access_state_total_ms
+    timings_ms["loop_build_capability_entry_target"] = entry_target_total_ms
+    timings_ms["loop_resolve_capability_entry_target_payload"] = resolve_payload_total_ms
+    stage_ts = time.perf_counter()
     out.sort(key=lambda row: (int(row.get("group_sequence") or 0), int(row.get("sequence") or 0), str(row.get("key") or "")))
-    return out
+    _mark("final_sort", stage_ts)
+    return out, timings_ms
 
 
 def build_capability_matrix_for_user(env, user) -> dict[str, Any]:
@@ -392,8 +386,7 @@ def lint_registry(env=None) -> list[dict[str, Any]]:
         elif group_key not in group_keys:
             issues.append({"code": "GROUP_KEY_UNKNOWN", "capability_key": key, "group_key": group_key})
 
-        entry_target = item.get("entry_target") if isinstance(item.get("entry_target"), dict) else {}
-        scene_key = str(entry_target.get("scene_key") or "").strip()
+        scene_key = resolve_capability_entry_scene_key(key)
         if not scene_key:
             issues.append({"code": "ENTRY_TARGET_SCENE_REQUIRED", "capability_key": key})
 
@@ -401,12 +394,16 @@ def lint_registry(env=None) -> list[dict[str, Any]]:
         issues.append({"code": "CAPABILITY_COUNT_TOO_LOW", "count": len(capability_definitions()), "min": 30})
 
     if env is not None:
-        scene_map = _resolve_scene_map(env)
+        scene_keys = {
+            str(row.get("code") or row.get("key") or "").strip()
+            for row in (scene_registry.load_scene_configs(env) or [])
+            if isinstance(row, dict) and str(row.get("code") or row.get("key") or "").strip()
+        }
+        scene_keys.update(RUNTIME_ORCHESTRATION_SCENE_KEYS)
         for item in capability_definitions():
             key = str(item.get("key") or "").strip()
-            entry_target = item.get("entry_target") if isinstance(item.get("entry_target"), dict) else {}
-            scene_key = str(entry_target.get("scene_key") or "").strip()
-            if scene_key and scene_key not in scene_map:
+            scene_key = resolve_capability_entry_scene_key(key)
+            if scene_key and scene_key not in scene_keys:
                 issues.append({"code": "ENTRY_TARGET_SCENE_NOT_FOUND", "capability_key": key, "scene_key": scene_key})
 
     return issues

--- a/addons/smart_construction_core/services/contract_governance_overrides.py
+++ b/addons/smart_construction_core/services/contract_governance_overrides.py
@@ -5,8 +5,79 @@ from odoo.addons.smart_core.utils.contract_governance import (
 )
 
 
+_PROJECT_INTAKE_SCENE_KEY = "projects.intake"
+_PROJECT_INTAKE_STANDARD_ROUTE = "/s/project.management"
+_PROJECT_INTAKE_STANDARD_MENU_XMLID = "smart_construction_core.menu_sc_project_initiation"
+_PROJECT_INTAKE_QUICK_MENU_XMLID = "smart_construction_core.menu_sc_project_quick_create"
+
+
+def _text(value):
+    return str(value or "").strip()
+
+
+def _as_dict(value):
+    return value if isinstance(value, dict) else {}
+
+
+def _is_project_intake_create_contract(data: dict) -> bool:
+    if not isinstance(data, dict):
+        return False
+    head = _as_dict(data.get("head"))
+    model = _text(head.get("model") or data.get("model"))
+    render_profile = _text(head.get("render_profile") or data.get("render_profile")).lower()
+    scene_key = _text(head.get("scene_key") or data.get("scene_key"))
+    menu_xmlid = _text(head.get("menu_xmlid") or data.get("menu_xmlid"))
+    return (
+        model == "project.project"
+        and render_profile == "create"
+        and (
+            scene_key == _PROJECT_INTAKE_SCENE_KEY
+            or menu_xmlid in {
+                _PROJECT_INTAKE_STANDARD_MENU_XMLID,
+                _PROJECT_INTAKE_QUICK_MENU_XMLID,
+            }
+        )
+    )
+
+
+def _resolve_project_intake_mode(data: dict) -> str:
+    head = _as_dict(data.get("head"))
+    menu_xmlid = _text(head.get("menu_xmlid") or data.get("menu_xmlid"))
+    if menu_xmlid == _PROJECT_INTAKE_QUICK_MENU_XMLID:
+        return "quick"
+    return "standard"
+
+
+def _apply_project_intake_form_governance(data: dict, contract_mode: str) -> None:
+    if contract_mode != "user":
+        return
+    if not _is_project_intake_create_contract(data):
+        return
+    intake_mode = _resolve_project_intake_mode(data)
+    governance = _as_dict(data.get("form_governance"))
+    governance.update(
+        {
+            "surface": "project_intake",
+            "create_flow_mode": intake_mode,
+            "autosave_scope": f"project_intake_{intake_mode}",
+            "primary_action_label": "创建并进入项目驾驶舱" if intake_mode == "quick" else "创建项目",
+            "post_create_target": {
+                "intent": "project.dashboard.enter",
+                "route": _PROJECT_INTAKE_STANDARD_ROUTE,
+            },
+        }
+    )
+    data["form_governance"] = governance
+
+
 register_contract_domain_override(
     "smart_construction_core.project_form",
     apply_project_form_domain_override,
     priority=10,
+)
+
+register_contract_domain_override(
+    "smart_construction_core.project_intake_form",
+    _apply_project_intake_form_governance,
+    priority=20,
 )

--- a/addons/smart_construction_core/services/cost_tracking_service.py
+++ b/addons/smart_construction_core/services/cost_tracking_service.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo import fields
+
+from odoo.addons.smart_construction_core.services.project_state_explain_service import lifecycle_state_label
+from odoo.addons.smart_construction_core.services.cost_tracking_entry_service import CostTrackingEntryService
+from odoo.addons.smart_construction_core.services.cost_tracking_builders import BUILDERS
+from odoo.addons.smart_construction_core.services.cost_tracking_native_adapter import CostTrackingNativeAdapter
+
+
+class CostTrackingService:
+    """Prepared cost tracking service backed by account.move facts."""
+
+    RUNTIME_BLOCK_MAP = {
+        "cost_entry": "block.cost.tracking_entry_form",
+        "cost_list": "block.cost.tracking_list",
+        "cost_summary": "block.cost.tracking_summary",
+        "next_actions": "block.cost.tracking_next_actions",
+        "summary": "block.cost.tracking_summary",
+        "recent_moves": "block.cost.tracking_move_list",
+    }
+
+    def __init__(self, env):
+        self.env = env
+        self._adapter = CostTrackingNativeAdapter(env)
+        self._entry_service = CostTrackingEntryService(env)
+        self._builders = [builder_cls(env) for builder_cls in BUILDERS]
+        self._builder_map = {builder.block_key: builder for builder in self._builders}
+
+    def build_block(self, block_key, project=None, context=None):
+        normalized_key = str(block_key or "").strip().lower()
+        builder_key = self.RUNTIME_BLOCK_MAP.get(normalized_key)
+        if not builder_key:
+            return self.error_block(normalized_key or "unknown", "UNSUPPORTED_BLOCK_KEY")
+        builder = self._builder_map.get(builder_key)
+        if builder is None:
+            return self.error_block(builder_key, "BLOCK_BUILDER_NOT_FOUND")
+        try:
+            block = builder.build(project=project, context=dict(context or {}))
+        except Exception:
+            block = self.error_block(builder_key, "BLOCK_BUILD_FAILED")
+        return block if isinstance(block, dict) else self.error_block(builder_key, "INVALID_BLOCK_PAYLOAD")
+
+    def _model(self, model_name):
+        try:
+            return self.env[model_name]
+        except Exception:
+            return None
+
+    def _project_domain_for_user(self):
+        model = self._model("project.project")
+        if model is None:
+            return []
+        field_map = getattr(model, "_fields", {})
+        uid = int(self.env.user.id)
+        ors = []
+        for field_name in ("manager_id", "owner_id", "user_id"):
+            if field_name in field_map:
+                ors.append((field_name, "=", uid))
+        if "create_uid" in field_map:
+            ors.append(("create_uid", "=", uid))
+        for field_name in ("user_ids", "member_ids", "member_user_ids"):
+            if field_name in field_map:
+                ors.append((field_name, "in", [uid]))
+        if not ors:
+            return []
+        if len(ors) == 1:
+            return [ors[0]]
+        return (["|"] * (len(ors) - 1)) + ors
+
+    def resolve_project_with_diagnostics(self, project_id):
+        Project = self._model("project.project")
+        if Project is None:
+            return None, {"resolved_project_id": 0, "reason": "project.project model not available"}
+        requested_project_id = int(project_id or 0) if str(project_id or "").strip() else 0
+        if requested_project_id > 0:
+            try:
+                record = Project.browse(requested_project_id).exists()
+                if record:
+                    return record, {"resolved_project_id": int(record.id), "reason": "explicit_project_id"}
+            except Exception:
+                pass
+        try:
+            if "create_uid" in getattr(Project, "_fields", {}):
+                record = Project.search([("create_uid", "=", int(self.env.user.id))], order="create_date desc,id desc", limit=1)
+                if record:
+                    return record, {"resolved_project_id": int(record.id), "reason": "creator_domain"}
+        except Exception:
+            pass
+        domain = self._project_domain_for_user()
+        try:
+            record = Project.search(domain, order="write_date desc,id desc", limit=1)
+            if record:
+                return record, {"resolved_project_id": int(record.id), "reason": "user_domain"}
+        except Exception:
+            pass
+        try:
+            record = Project.search([], order="write_date desc,id desc", limit=1)
+            if record:
+                return record, {"resolved_project_id": int(record.id), "reason": "global_search"}
+        except Exception:
+            pass
+        return None, {"resolved_project_id": 0, "reason": "no project resolved"}
+
+    def project_payload(self, project):
+        def _safe_text(value):
+            try:
+                return str(value or "")
+            except Exception:
+                return ""
+
+        def _safe_rel_name(record, field_name):
+            try:
+                relation = getattr(record, field_name, None)
+            except Exception:
+                return ""
+            return _safe_text(getattr(relation, "display_name", ""))
+
+        def _safe_field(record, field_name):
+            try:
+                return getattr(record, field_name, "")
+            except Exception:
+                return ""
+
+        if not project:
+            return {
+                "id": 0,
+                "name": "",
+                "project_code": "",
+                "manager_name": "",
+                "stage_name": "",
+                "date_start": "",
+                "date_end": "",
+                "today": str(fields.Date.today()),
+            }
+        summary = self._adapter.summary(project)
+        record_count = int(summary.get("ledger_count") or summary.get("move_count") or 0)
+        return {
+            "id": int(project.id),
+            "name": _safe_text(_safe_field(project, "name")),
+            "project_code": _safe_text(_safe_field(project, "project_code")),
+            "manager_name": _safe_rel_name(project, "user_id"),
+            "stage_name": lifecycle_state_label(project),
+            "date_start": str(_safe_field(project, "date_start") or ""),
+            "date_end": str(_safe_field(project, "date") or _safe_field(project, "date_end") or ""),
+            "move_count": int(summary.get("move_count") or 0),
+            "draft_move_count": int(summary.get("draft_move_count") or 0),
+            "cost_record_count": record_count,
+            "cost_total_amount": str(summary.get("total_cost_amount") or 0.0),
+            "draft_cost_amount": str(summary.get("draft_cost_amount") or 0.0),
+            "currency_name": _safe_text(summary.get("currency_name") or ""),
+            "today": str(fields.Date.today()),
+        }
+
+    def build_summary_rows(self, project):
+        summary = self.project_payload(project)
+        currency_name = str(summary.get("currency_name") or "").strip()
+
+        def _amount(value):
+            text = str(value or 0)
+            return "%s %s" % (text, currency_name) if currency_name else text
+
+        return [
+            {
+                "key": "project_code",
+                "label": "项目编码",
+                "value": str(summary.get("project_code") or "--"),
+            },
+            {
+                "key": "manager_name",
+                "label": "项目经理",
+                "value": str(summary.get("manager_name") or "--"),
+            },
+            {
+                "key": "stage_name",
+                "label": "当前阶段",
+                "value": str(summary.get("stage_name") or "--"),
+            },
+            {
+                "key": "cost_record_count",
+                "label": "成本记录数",
+                "value": "%s 条" % str(summary.get("cost_record_count") or 0),
+            },
+            {
+                "key": "cost_total_amount",
+                "label": "成本合计",
+                "value": _amount(summary.get("cost_total_amount")),
+            },
+            {
+                "key": "draft_cost_amount",
+                "label": "草稿金额",
+                "value": _amount(summary.get("draft_cost_amount")),
+            },
+        ]
+
+    def create_cost_entry(self, project=None, values=None, context=None):
+        return self._entry_service.create(project=project, values=values, context=context)
+
+    @staticmethod
+    def error_block(block_key, code):
+        return {
+            "block_key": block_key,
+            "block_type": "unknown",
+            "title": block_key,
+            "state": "error",
+            "visibility": {"allowed": True, "reason_code": "OK", "reason": ""},
+            "data": {},
+            "error": {"code": code, "message": code},
+        }

--- a/addons/smart_construction_core/services/project_context_contract.py
+++ b/addons/smart_construction_core/services/project_context_contract.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_core.services.project_state_explain_service import lifecycle_state_label
+
+
+def build_project_context(project):
+    if not project:
+        return {
+            "project_id": 0,
+            "project_name": "",
+            "execution_stage": "",
+            "execution_stage_label": "",
+            "stage": "",
+            "stage_label": "",
+            "milestone": "",
+            "milestone_label": "",
+            "project_condition": "",
+            "status": "",
+        }
+    execution_stage = str(getattr(project, "lifecycle_state", "") or "").strip()
+    execution_stage_label = lifecycle_state_label(execution_stage, default="")
+    milestone = str(getattr(project, "sc_execution_state", "") or "").strip()
+    milestone_label = str(getattr(project, "sc_execution_state_label", "") or "").strip()
+    project_condition = str(getattr(project, "health_state", "") or getattr(project, "state", "") or "").strip()
+    return {
+        "project_id": int(getattr(project, "id", 0) or 0),
+        "project_name": str(getattr(project, "display_name", "") or getattr(project, "name", "") or "").strip(),
+        "execution_stage": execution_stage,
+        "execution_stage_label": execution_stage_label or execution_stage,
+        "stage": execution_stage,
+        "stage_label": execution_stage_label or execution_stage,
+        "milestone": milestone,
+        "milestone_label": milestone_label or milestone,
+        "project_condition": project_condition,
+        "status": project_condition,
+    }
+
+
+def attach_project_context_to_scene_payload(data, project):
+    payload = dict(data or {})
+    project_context = build_project_context(project)
+    payload["project_context"] = project_context
+    runtime_fetch_hints = payload.get("runtime_fetch_hints")
+    blocks = runtime_fetch_hints.get("blocks") if isinstance(runtime_fetch_hints, dict) else None
+    if isinstance(blocks, dict):
+        for row in blocks.values():
+            if not isinstance(row, dict):
+                continue
+            params = dict(row.get("params") or {})
+            params.setdefault("project_id", project_context.get("project_id") or 0)
+            params["project_context"] = project_context
+            row["params"] = params
+    return payload
+
+
+def attach_project_context_to_runtime_payload(data, project):
+    payload = dict(data or {})
+    payload["project_context"] = build_project_context(project)
+    return payload

--- a/addons/smart_construction_core/services/project_dashboard_service.py
+++ b/addons/smart_construction_core/services/project_dashboard_service.py
@@ -1,195 +1,68 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
-from importlib.util import module_from_spec, spec_from_file_location
-from pathlib import Path
-
 from odoo import fields
+
+from odoo.addons.smart_construction_core.services.evidence_chain_service import EvidenceChainService
+from odoo.addons.smart_construction_core.services.project_decision_engine_service import ProjectDecisionEngineService
+from odoo.addons.smart_construction_core.services.project_metrics_explain_service import ProjectMetricsExplainService
+from odoo.addons.smart_construction_core.services.project_state_explain_service import (
+    ProjectStateExplainService,
+    lifecycle_state_label,
+)
+from odoo.addons.smart_construction_core.services.project_task_state_support import (
+    ProjectTaskStateSupport,
+)
 
 from .project_dashboard_builders import BUILDERS
 
 
-_SCENE_CONTENT_MODULE = None
-_KERNEL_MODULE = None
-_SCENE_ENGINE_MODULE = None
-
-
-def _load_scene_content_module():
-    global _SCENE_CONTENT_MODULE
-    if _SCENE_CONTENT_MODULE is not None:
-        return _SCENE_CONTENT_MODULE
-    content_path = None
-    try:
-        registry_path = Path(__file__).resolve().parents[2] / "smart_scene" / "core" / "scene_provider_registry.py"
-        locator_spec = spec_from_file_location("smart_scene_provider_registry_project_dashboard", registry_path)
-        if locator_spec is not None and locator_spec.loader is not None:
-            locator_module = module_from_spec(locator_spec)
-            locator_spec.loader.exec_module(locator_module)
-            resolver = getattr(locator_module, "resolve_scene_provider_path", None)
-            if callable(resolver):
-                content_path = resolver("project.dashboard", Path(__file__))
-    except Exception:
-        content_path = None
-    if content_path is None:
-        _SCENE_CONTENT_MODULE = False
-        return None
-    try:
-        spec = spec_from_file_location("smart_construction_project_dashboard_scene_content", content_path)
-        if spec is None or spec.loader is None:
-            raise RuntimeError("spec unavailable")
-        module = module_from_spec(spec)
-        spec.loader.exec_module(module)
-        _SCENE_CONTENT_MODULE = module
-        return module
-    except Exception:
-        _SCENE_CONTENT_MODULE = False
-        return None
-
-
-def _load_orchestration_kernel_module():
-    global _KERNEL_MODULE
-    if _KERNEL_MODULE is not None:
-        return _KERNEL_MODULE
-    kernel_path = Path(__file__).resolve().parents[2] / "smart_scene" / "core" / "dashboard_orchestration_kernel.py"
-    try:
-        spec = spec_from_file_location("smart_scene_dashboard_orchestration_kernel", kernel_path)
-        if spec is None or spec.loader is None:
-            raise RuntimeError("spec unavailable")
-        module = module_from_spec(spec)
-        spec.loader.exec_module(module)
-        _KERNEL_MODULE = module
-        return module
-    except Exception:
-        _KERNEL_MODULE = False
-        return None
-
-
-def _load_scene_engine_module():
-    global _SCENE_ENGINE_MODULE
-    if _SCENE_ENGINE_MODULE is not None:
-        return _SCENE_ENGINE_MODULE
-    engine_path = Path(__file__).resolve().parents[2] / "smart_scene" / "core" / "scene_engine.py"
-    try:
-        spec = spec_from_file_location("smart_scene_core_scene_engine", engine_path)
-        if spec is None or spec.loader is None:
-            raise RuntimeError("spec unavailable")
-        module = module_from_spec(spec)
-        spec.loader.exec_module(module)
-        _SCENE_ENGINE_MODULE = module
-        return module
-    except Exception:
-        _SCENE_ENGINE_MODULE = False
-        return None
+class _NullEvidenceSummaryService:
+    def summary_for_project(self, _project):
+        return {}
 
 
 class ProjectDashboardService:
-    """Assemble project.dashboard contract using block builders."""
+    """Provide business-truth-backed dashboard data for orchestration carriers."""
 
-    ZONE_BLOCKS = (
-        ("header", "项目头部信息", "hero", "stack", "block.project.header"),
-        ("metrics", "关键指标", "primary", "grid", "block.project.metrics"),
-        ("progress", "项目进度", "primary", "stack", "block.project.progress"),
-        ("contract", "合同执行", "secondary", "stack", "block.project.contract"),
-        ("cost", "成本控制", "secondary", "stack", "block.project.cost"),
-        ("finance", "资金情况", "secondary", "stack", "block.project.finance"),
-        ("risk", "风险提醒", "supporting", "stack", "block.project.risk"),
+    ENTRY_BLOCKS = (
+        ("progress", "项目进度", "deferred"),
+        ("risks", "风险提醒", "deferred"),
+        ("next_actions", "下一步动作", "deferred"),
     )
+    RUNTIME_BLOCK_MAP = {
+        "progress": "block.project.progress",
+        "risks": "block.project.risk",
+        "risk": "block.project.risk",
+        "next_actions": "block.project.next_actions",
+    }
 
     def __init__(self, env):
         self.env = env
+        self._evidence_chain_service = EvidenceChainService(env)
+        evidence_summary_service = self._model("sc.evidence.summary.service")
+        self._evidence_summary_service = evidence_summary_service or _NullEvidenceSummaryService()
+        self._decision_engine = ProjectDecisionEngineService(env)
+        self._state_explain_service = ProjectStateExplainService(env)
+        self._metrics_explain_service = ProjectMetricsExplainService(env)
         self._builders = [builder_cls(env) for builder_cls in BUILDERS]
         self._builder_map = {builder.block_key: builder for builder in self._builders}
-        self._scene_content = self._scene_content_payload()
 
-    def _scene_content_payload(self):
-        module = _load_scene_content_module()
-        fn = getattr(module, "build_project_dashboard_scene_content", None) if module else None
-        if callable(fn):
+    def build_block(self, block_key, project=None, context=None):
+        normalized_key = str(block_key or "").strip().lower()
+        builder_key = self.RUNTIME_BLOCK_MAP.get(normalized_key)
+        if not builder_key:
+            return self.error_block(normalized_key or "unknown", "UNSUPPORTED_BLOCK_KEY")
+
+        builder = self._builder_map.get(builder_key)
+        if builder is None:
+            block = self.error_block(builder_key, "BLOCK_BUILDER_NOT_FOUND")
+        else:
             try:
-                payload = fn()
-                if isinstance(payload, dict) and payload:
-                    return payload
+                block = builder.build(project=project, context=dict(context or {}))
             except Exception:
-                pass
-        return {
-            "scene": {"key": "project.management", "page": "project.management.dashboard"},
-            "page": {"key": "project.management.dashboard", "title": "项目驾驶舱", "route": "/s/project.management"},
-            "zone_blocks": [
-                {"key": key, "title": title, "zone_type": zone_type, "display_mode": display_mode, "block_key": block_key}
-                for key, title, zone_type, display_mode, block_key in self.ZONE_BLOCKS
-            ],
-        }
-
-    def build(self, project_id=None, context=None):
-        ctx = dict(context or {})
-        project, project_resolution = self._resolve_project_with_diagnostics(project_id)
-        project_payload = self._project_payload(project)
-        zones = self._build_zones(project=project, context=ctx)
-        scene = self._scene_content.get("scene") if isinstance(self._scene_content.get("scene"), dict) else {}
-        page = self._scene_content.get("page") if isinstance(self._scene_content.get("page"), dict) else {}
-        diagnostics = {
-            "project_resolution": project_resolution,
-        }
-        scene_engine = _load_scene_engine_module()
-        engine_fn = getattr(scene_engine, "build_scene_contract_from_specs", None) if scene_engine else None
-        if callable(engine_fn):
-            contract = engine_fn(
-                scene_hint=scene,
-                page_hint=page,
-                zone_specs=self._scene_content.get("zone_blocks") if isinstance(self._scene_content.get("zone_blocks"), list) else [],
-                built_zones=zones,
-                record={"project": project_payload},
-                diagnostics=diagnostics,
-            )
-            contract["route_context"] = self._route_context(project)
-            contract["project"] = project_payload
-            return contract
-
-        return {
-            "scene": {
-                "key": str(scene.get("key") or "project.management"),
-                "page": str(scene.get("page") or "project.management.dashboard"),
-            },
-            "page": {
-                "key": str(page.get("key") or "project.management.dashboard"),
-                "title": str(page.get("title") or "项目驾驶舱"),
-                "route": str(page.get("route") or "/s/project.management"),
-            },
-            "route_context": self._route_context(project),
-            "project": project_payload,
-            "diagnostics": diagnostics,
-            "zones": zones,
-        }
-
-    def _build_zones(self, project, context):
-        zone_specs = self._scene_content.get("zone_blocks") if isinstance(self._scene_content.get("zone_blocks"), list) else []
-        kernel = _load_orchestration_kernel_module()
-        fn = getattr(kernel, "build_single_block_zones", None) if kernel else None
-        if callable(fn):
-            try:
-                payload = fn(zone_specs, self._builder_map, project, context, self._error_block)
-                if isinstance(payload, dict) and payload:
-                    return payload
-            except Exception:
-                pass
-        zones = {}
-        for spec in zone_specs:
-            if not isinstance(spec, dict):
-                continue
-            key = str(spec.get("key") or "").strip()
-            if not key:
-                continue
-            block_key = str(spec.get("block_key") or "").strip()
-            builder = self._builder_map.get(block_key)
-            block = builder.build(project=project, context=context) if builder else self._error_block(block_key, "BLOCK_BUILDER_NOT_FOUND")
-            zones[key] = {
-                "zone_key": str(spec.get("zone_key") or ("zone.%s" % key)),
-                "title": str(spec.get("title") or key),
-                "zone_type": str(spec.get("zone_type") or "secondary"),
-                "display_mode": str(spec.get("display_mode") or "stack"),
-                "blocks": [block],
-            }
-        return zones
+                block = self.error_block(builder_key, "BLOCK_BUILD_FAILED")
+        return block if isinstance(block, dict) else self.error_block(builder_key, "INVALID_BLOCK_PAYLOAD")
 
     def _model(self, model_name):
         try:
@@ -207,6 +80,8 @@ class ProjectDashboardService:
         for field in ("manager_id", "owner_id", "user_id"):
             if field in f:
                 ors.append((field, "=", uid))
+        if "create_uid" in f:
+            ors.append(("create_uid", "=", uid))
         for field in ("user_ids", "member_ids", "member_user_ids"):
             if field in f:
                 ors.append((field, "in", [uid]))
@@ -217,10 +92,10 @@ class ProjectDashboardService:
         return (["|"] * (len(ors) - 1)) + ors
 
     def _resolve_project(self, project_id):
-        project, _diag = self._resolve_project_with_diagnostics(project_id)
+        project, _diag = self.resolve_project_with_diagnostics(project_id)
         return project
 
-    def _resolve_project_with_diagnostics(self, project_id):
+    def resolve_project_with_diagnostics(self, project_id):
         model_in_env = False
         model_error = ""
         try:
@@ -268,6 +143,25 @@ class ProjectDashboardService:
                 diagnostics["reason"] = "explicit project_id not found or inaccessible"
             except Exception:
                 diagnostics["reason"] = "explicit project_id browse failed"
+        try:
+            if "create_uid" in getattr(Project, "_fields", {}):
+                creator_domain = [("create_uid", "=", int(self.env.user.id))]
+                diagnostics["candidate_counts"]["creator_domain"] = int(Project.search_count(creator_domain))
+                record = Project.search(creator_domain, order="create_date desc,id desc", limit=1)
+                if record:
+                    diagnostics.update(
+                        {
+                            "resolved_project_id": int(record.id),
+                            "resolution_path": "creator_domain",
+                            "reason": "matched latest project created by current user",
+                        }
+                    )
+                    return record, diagnostics
+            else:
+                diagnostics["candidate_counts"]["creator_domain"] = 0
+        except Exception:
+            diagnostics["candidate_counts"]["creator_domain"] = -1
+            diagnostics["reason"] = "creator_domain search failed"
         domain = self._project_domain_for_user()
         diagnostics["user_domain"] = domain
         try:
@@ -334,7 +228,32 @@ class ProjectDashboardService:
         )
         return None, diagnostics
 
-    def _project_payload(self, project):
+    def project_payload(self, project):
+        if project:
+            try:
+                project = project.sudo()
+            except Exception:
+                pass
+
+        def _safe_text(value):
+            try:
+                return str(value or "")
+            except Exception:
+                return ""
+
+        def _safe_rel_name(record, field_name):
+            try:
+                relation = getattr(record, field_name, None)
+            except Exception:
+                return ""
+            return _safe_text(getattr(relation, "display_name", ""))
+
+        def _safe_field(record, field_name):
+            try:
+                return getattr(record, field_name, "")
+            except Exception:
+                return ""
+
         if not project:
             return {
                 "id": 0,
@@ -343,37 +262,308 @@ class ProjectDashboardService:
                 "partner_name": "",
                 "manager_name": "",
                 "stage_name": "",
+                "lifecycle_state": "",
+                "milestone": "",
                 "state": "empty",
+                "progress_percent": "0",
+                "cost_total": "0",
+                "payment_total": "0",
+                "status": "",
                 "date": str(fields.Date.today()),
             }
+        progress_percent = 0.0
+        try:
+            task_model = self._model("project.task")
+            if task_model is not None:
+                total = int(task_model.search_count([("project_id", "=", int(project.id))]))
+                done = int(
+                    task_model.search_count(
+                        [("project_id", "=", int(project.id))] + ProjectTaskStateSupport.done_domain()
+                    )
+                )
+                if total > 0:
+                    progress_percent = round((done / float(total)) * 100.0, 2)
+        except Exception:
+            progress_percent = 0.0
+        evidence_summary = self._evidence_summary_service.summary_for_project(project)
+        evidence_chain = self._evidence_chain_service.build_project_chain(int(project.id), limit=20)
+        risk_analysis = self._decision_engine.analyze(project)
+        risk_count = int(risk_analysis.get("risk_count") or 0)
+        exception_model = self._model("sc.evidence.exception")
+        exception_open_count = 0
+        exception_resolved_count = 0
+        if exception_model is not None:
+            try:
+                exception_open_count = int(
+                    exception_model.search_count([("project_id", "=", int(project.id)), ("status", "in", ["open", "processing"])])
+                )
+                exception_resolved_count = int(
+                    exception_model.search_count([("project_id", "=", int(project.id)), ("status", "=", "resolved")])
+                )
+            except Exception:
+                exception_open_count = 0
+                exception_resolved_count = 0
+        fact_metrics = [
+            {
+                "key": "payment_total",
+                "label": "已付款",
+                "value": float(evidence_summary.get("pay_total") or 0.0),
+                "unit": "元",
+                "trace_action": {
+                    "intent": "business.evidence.trace",
+                    "payload": {
+                        "business_model": "project.project",
+                        "business_id": int(project.id),
+                        "evidence_type": "payment",
+                    },
+                },
+            },
+            {
+                "key": "cost_total",
+                "label": "已发生成本",
+                "value": float(evidence_summary.get("cost_total") or 0.0),
+                "unit": "元",
+                "trace_action": {
+                    "intent": "business.evidence.trace",
+                    "payload": {
+                        "business_model": "project.project",
+                        "business_id": int(project.id),
+                        "evidence_type": "cost",
+                    },
+                },
+            },
+            {
+                "key": "settlement_total",
+                "label": "已结算",
+                "value": float(evidence_summary.get("settlement_total") or 0.0),
+                "unit": "元",
+                "trace_action": {
+                    "intent": "business.evidence.trace",
+                    "payload": {
+                        "business_model": "project.project",
+                        "business_id": int(project.id),
+                        "evidence_type": "settlement",
+                    },
+                },
+            },
+            {
+                "key": "risk_count",
+                "label": "风险事项",
+                "value": risk_count,
+                "unit": "项",
+                "trace_action": {
+                    "intent": "business.evidence.trace",
+                    "payload": {
+                        "business_model": "project.project",
+                        "business_id": int(project.id),
+                        "evidence_type": "risk",
+                    },
+                },
+            },
+        ]
         return {
             "id": int(project.id),
-            "name": str(getattr(project, "name", "") or ""),
-            "project_code": str(getattr(project, "project_code", "") or ""),
-            "partner_name": str(getattr(getattr(project, "partner_id", None), "display_name", "") or ""),
-            "manager_name": str(getattr(getattr(project, "user_id", None), "display_name", "") or ""),
-            "stage_name": str(getattr(getattr(project, "stage_id", None), "display_name", "") or ""),
+            "name": _safe_text(_safe_field(project, "name")),
+            "project_code": _safe_text(_safe_field(project, "project_code")),
+            "partner_name": _safe_rel_name(project, "partner_id"),
+            "manager_name": _safe_rel_name(project, "user_id"),
+            "stage_name": lifecycle_state_label(project),
+            "health_state": _safe_text(_safe_field(project, "health_state")),
+            "lifecycle_state": _safe_text(_safe_field(project, "lifecycle_state")),
+            "milestone": _safe_text(_safe_field(project, "sc_execution_state")),
             "state": "ready",
+            "progress_percent": str(progress_percent),
+            "cost_total": str(evidence_summary.get("cost_total") or 0.0),
+            "payment_total": str(evidence_summary.get("pay_total") or 0.0),
+            "payment_executed_total": str(evidence_summary.get("pay_done_total") or 0.0),
+            "payment_executed_record_count": str(evidence_summary.get("pay_done_count") or 0),
+            "evidence_refs": evidence_chain.get("evidence_refs") or [],
+            "evidence_summary": evidence_summary,
+            "fact_metrics": fact_metrics,
+            "facts": {
+                "cost_total": str(evidence_summary.get("cost_total") or 0.0),
+                "payment_total": str(evidence_summary.get("pay_total") or 0.0),
+                "payment_executed_total": str(evidence_summary.get("pay_done_total") or 0.0),
+                "evidence_count": int(evidence_summary.get("evidence_count") or 0),
+                "cost_evidence_count": int(evidence_summary.get("cost_count") or 0),
+                "payment_evidence_count": int(evidence_summary.get("payment_count") or 0),
+                "settlement_evidence_count": int(evidence_summary.get("settlement_count") or 0),
+                "risk_count": risk_count,
+                "exception_open_count": exception_open_count,
+                "exception_resolved_count": exception_resolved_count,
+            },
+            "status": _safe_text(_safe_field(project, "health_state") or _safe_field(project, "state")),
             "date": str(fields.Date.today()),
         }
 
-    @staticmethod
-    def _route_context(project):
-        route = "/s/project.management"
-        query_key = "project_id"
-        out = {
-            "primary_protocol": "/s/project.management?project_id=<id>",
-            "query_key": query_key,
-            "scene_route": route,
-            "project_route_template": "/s/project.management?project_id={project_id}",
-            "project_route": route,
+    def build_state_explain(self, project):
+        state_explain = self._state_explain_service.build(project)
+        if not project:
+            return {
+                "execution_stage_label": state_explain.get("execution_stage_label") or state_explain.get("stage_label") or "未选择项目",
+                "stage_label": state_explain.get("stage_label") or "未选择项目",
+                "execution_stage_explain": state_explain.get("execution_stage_explain") or state_explain.get("stage_explain") or "当前没有可用项目，无法进入项目驾驶舱。",
+                "stage_explain": state_explain.get("stage_explain") or state_explain.get("execution_stage_explain") or "当前没有可用项目，无法进入项目驾驶舱。",
+                "milestone_explain": "暂无项目里程碑。",
+                "project_condition_explain": state_explain.get("project_condition_explain") or state_explain.get("status_explain") or "请先选择项目或创建项目。",
+                "status_explain": state_explain.get("status_explain") or state_explain.get("project_condition_explain") or "请先选择项目或创建项目。",
+            }
+        milestone = str(getattr(project, "sc_execution_state", "") or "").strip().lower()
+        milestone_explain_map = {
+            "ready": "当前执行准备已完成，可以进入执行推进。",
+            "in_progress": "当前执行正在推进，建议优先补齐成本与付款事实。",
+            "done": "当前执行动作已完成，可继续检查成本、付款与结算结果。",
         }
-        if project:
-            out["project_route"] = "/s/project.management?project_id=%s" % int(project.id)
-        return out
+        return {
+            "execution_stage_label": state_explain.get("execution_stage_label") or state_explain.get("stage_label") or "未设置阶段",
+            "stage_label": state_explain.get("stage_label") or "未设置阶段",
+            "execution_stage_explain": state_explain.get("execution_stage_explain") or state_explain.get("stage_explain") or "当前项目处于已发布主线中，请按下一步动作推进。",
+            "stage_explain": state_explain.get("stage_explain") or state_explain.get("execution_stage_explain") or "当前项目处于已发布主线中，请按下一步动作推进。",
+            "milestone_explain": milestone_explain_map.get(milestone, "当前里程碑尚未进入显式执行状态。"),
+            "project_condition_explain": state_explain.get("project_condition_explain") or state_explain.get("status_explain") or "当前项目整体正常。",
+            "status_explain": state_explain.get("status_explain") or state_explain.get("project_condition_explain") or "当前项目整体正常。",
+        }
+
+    def build_summary_rows(self, project):
+        project_payload = self.project_payload(project)
+        state_explain = self.build_state_explain(project)
+        metrics_explain = self.build_metrics_explain(project)
+        metrics_map = {}
+        for item in metrics_explain or []:
+            if not isinstance(item, dict):
+                continue
+            key = str(item.get("key") or "").strip()
+            if not key:
+                continue
+            metrics_map[key] = item
+        return [
+            {
+                "key": "stage_label",
+                "label": "项目执行阶段",
+                "value": str(state_explain.get("execution_stage_label") or "未设置阶段"),
+                "copy": "主流程位置",
+            },
+            {
+                "key": "milestone_label",
+                "label": "当前里程碑",
+                "value": str(project_payload.get("milestone") or ""),
+                "copy": "执行推进节点",
+            },
+            {
+                "key": "progress_percent",
+                "label": "执行进度",
+                "value": "%s%%" % str(project_payload.get("progress_percent") or 0),
+                "copy": str((metrics_map.get("progress") or {}).get("explain") or "任务与里程碑综合进度"),
+            },
+            {
+                "key": "cost_total",
+                "label": "成本合计",
+                "value": str(project_payload.get("cost_total") or 0),
+                "copy": str((metrics_map.get("cost") or {}).get("explain") or "当前经营事实"),
+            },
+            {
+                "key": "payment_total",
+                "label": "付款合计",
+                "value": str(project_payload.get("payment_total") or 0),
+                "copy": str((metrics_map.get("payment") or {}).get("explain") or "当前资金事实"),
+            },
+            {
+                "key": "payment_executed_total",
+                "label": "已支付证据",
+                "value": str(project_payload.get("payment_executed_total") or 0),
+                "copy": "%s 条 payment.ledger 台账" % str(project_payload.get("payment_executed_record_count") or 0),
+            },
+        ]
+
+    def build_metrics_explain(self, project):
+        return self._metrics_explain_service.build(self.project_payload(project))
+
+    def build_flow_map(self, project):
+        project_payload = self.project_payload(project)
+        decision = self._decision_engine.decide(project)
+        signals = (decision.get("facts") or {}).get("signals") or {}
+        lifecycle_state = str(project_payload.get("lifecycle_state") or "").strip().lower()
+        facts = decision.get("facts") or {}
+        payment_count = int(facts.get("payment_count") or 0)
+        cost_count = int(facts.get("cost_count") or 0)
+
+        current_stage = "initiation"
+        is_completed = bool(signals.get("settlement_completed"))
+        if lifecycle_state == "draft":
+            current_stage = "initiation"
+        elif lifecycle_state in {"closing", "warranty", "done"}:
+            current_stage = "settlement"
+        elif payment_count > 0:
+            current_stage = "payment"
+        elif cost_count > 0:
+            current_stage = "cost"
+        elif lifecycle_state in {"in_progress"}:
+            current_stage = "execution"
+        elif signals.get("payment_exceeds_cost") or signals.get("ready_for_settlement"):
+            current_stage = "settlement"
+
+        stage_order = ["initiation", "execution", "cost", "payment", "settlement"]
+        stage_labels = {
+            "initiation": "立项",
+            "execution": "执行",
+            "cost": "成本",
+            "payment": "付款",
+            "settlement": "结算",
+        }
+        current_index = stage_order.index(current_stage)
+        items = []
+        for index, key in enumerate(stage_order):
+            if is_completed:
+                status = "done"
+            else:
+                status = "done" if index < current_index else "current" if index == current_index else "todo"
+            items.append(
+                {
+                    "key": key,
+                    "label": stage_labels.get(key) or key,
+                    "status": status,
+                }
+            )
+        return {
+            "current_stage": current_stage,
+            "items": items,
+        }
+
+    def build_completion(self, project):
+        decision = self._decision_engine.decide(project)
+        facts = decision.get("facts") or {}
+        signals = facts.get("signals") or {}
+        lifecycle_state = str(facts.get("lifecycle_state") or "").strip().lower()
+        percent = 20
+        next_target = "进入执行"
+        if signals.get("settlement_completed"):
+            percent = 100
+            next_target = "项目已完成"
+        elif signals.get("is_draft"):
+            percent = 20
+            next_target = "开始执行"
+        elif lifecycle_state in {"closing", "warranty", "done"}:
+            percent = 90
+            next_target = "完成结算确认"
+        elif signals.get("no_tasks"):
+            percent = 35
+            next_target = "创建任务"
+        elif signals.get("no_cost"):
+            percent = 50
+            next_target = "完成成本录入"
+        elif signals.get("no_payment"):
+            percent = 70
+            next_target = "完成付款记录"
+        elif signals.get("ready_for_settlement") or signals.get("payment_exceeds_cost"):
+            percent = 85
+            next_target = "完成结算检查"
+        return {
+            "percent": percent,
+            "next_target": next_target,
+        }
 
     @staticmethod
-    def _error_block(block_key, code):
+    def error_block(block_key, code):
         return {
             "block_key": block_key,
             "block_type": "unknown",

--- a/addons/smart_construction_core/services/project_entry_context_service.py
+++ b/addons/smart_construction_core/services/project_entry_context_service.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_construction_core.services.project_context_contract import (
+    build_project_context,
+)
+from odoo.addons.smart_construction_core.services.project_dashboard_service import (
+    ProjectDashboardService,
+)
+
+
+class ProjectEntryContextService:
+    ENTRY_ROUTE = "/s/project.management"
+    _NOISY_NAME_PREFIXES = (
+        "SCENE-CONTRACT-",
+        "SCENE-AUDIT-",
+        "RAW-",
+    )
+
+    def __init__(self, env):
+        self.env = env
+        self._dashboard_service = ProjectDashboardService(env)
+
+    @staticmethod
+    def _source_from_reason(resolution_path):
+        normalized = str(resolution_path or "").strip().lower()
+        if normalized == "explicit_project_id":
+            return "current", "high"
+        if normalized == "creator_domain":
+            return "recent", "high"
+        if normalized == "user_domain":
+            return "current", "medium"
+        if normalized in {"global_search", "active_search_read"}:
+            return "fallback", "low"
+        return "fallback", "low"
+
+    @staticmethod
+    def _build_lifecycle_guidance(*, available=False, project_context=None):
+        project_id = int((project_context or {}).get("project_id") or 0)
+        if available and project_id > 0:
+            return {
+                "suggested_action": {
+                    "intent": "project.dashboard.enter",
+                    "reason_code": "PROJECT_CONTEXT_READY",
+                    "params": {"project_id": project_id},
+                },
+                "lifecycle_hints": {
+                    "stage": "project_context_ready",
+                    "project_id": project_id,
+                    "primary_action_label": "进入项目管理",
+                    "suggested_action_intent": "project.dashboard.enter",
+                    "suggested_action_title": "进入项目管理",
+                },
+            }
+        return {
+            "suggested_action": {
+                "intent": "project.initiation.enter",
+                "reason_code": "PROJECT_CONTEXT_MISSING",
+                "params": {},
+            },
+            "lifecycle_hints": {
+                "stage": "no_project_context",
+                "project_id": 0,
+                "primary_action_label": "创建项目",
+                "suggested_action_intent": "project.initiation.enter",
+                "suggested_action_title": "创建项目",
+            },
+        }
+
+    def resolve(self, project_id=0):
+        project, diagnostics = self._dashboard_service.resolve_project_with_diagnostics(project_id)
+        project_context = build_project_context(project)
+        source, confidence = self._source_from_reason((diagnostics or {}).get("resolution_path"))
+        available = int(project_context.get("project_id") or 0) > 0
+        guidance = self._build_lifecycle_guidance(available=available, project_context=project_context)
+        diagnostics_summary = self._build_diagnostics_summary(
+            resolution_path=(diagnostics or {}).get("resolution_path"),
+            available=available,
+            option_count=0,
+        )
+        return {
+            "available": available,
+            "project_context": project_context,
+            "source": source if available else "none",
+            "confidence": confidence if available else "low",
+            "route": self.ENTRY_ROUTE if available else "/my-work",
+            "suggested_action": dict(guidance.get("suggested_action") or {}),
+            "lifecycle_hints": dict(guidance.get("lifecycle_hints") or {}),
+            "diagnostics": diagnostics or {},
+            "diagnostics_summary": dict(diagnostics_summary or {}),
+        }
+
+    @classmethod
+    def _is_noisy_project_name(cls, name):
+        normalized = str(name or "").strip().upper()
+        if not normalized:
+            return False
+        return any(normalized.startswith(prefix) for prefix in cls._NOISY_NAME_PREFIXES)
+
+    @classmethod
+    def _is_demo_showroom_project(cls, name):
+        normalized = str(name or "").strip()
+        return normalized.startswith("展厅-")
+
+    @classmethod
+    def _project_rank(cls, project, active_project_id=0):
+        context = build_project_context(project)
+        project_id = int(context.get("project_id") or 0)
+        project_name = str(context.get("project_name") or "")
+        lifecycle_state = str(getattr(project, "lifecycle_state", "") or "").strip().lower()
+        showcase = bool(getattr(project, "sc_demo_showcase", False))
+        showcase_ready = bool(getattr(project, "sc_demo_showcase_ready", False))
+        noisy = cls._is_noisy_project_name(project_name)
+        rank = 0
+        if project_id and project_id == int(active_project_id or 0):
+            rank += 800 if showcase_ready or not noisy else 25
+        if showcase_ready:
+            rank += 500
+        if showcase:
+            rank += 150
+        if cls._is_demo_showroom_project(project_name):
+            rank += 200
+        if not noisy:
+            rank += 100
+        if lifecycle_state in {"in_progress", "closing", "warranty", "done"}:
+            rank += 40
+        elif lifecycle_state and lifecycle_state != "draft":
+            rank += 20
+        return rank, context
+
+    @staticmethod
+    def _build_options_guidance(options, active_project_id=0):
+        normalized_options = list(options or [])
+        active_id = int(active_project_id or 0)
+        if normalized_options:
+            target_id = active_id if any(int(item.get("project_id") or 0) == active_id for item in normalized_options) else int(
+                (normalized_options[0] or {}).get("project_id") or 0
+            )
+            return {
+                "suggested_action": {
+                    "intent": "project.dashboard.enter",
+                    "reason_code": "PROJECT_OPTIONS_AVAILABLE",
+                    "params": {"project_id": int(target_id or 0)},
+                },
+                "lifecycle_hints": {
+                    "stage": "project_options_available",
+                    "project_id": int(target_id or 0),
+                    "primary_action_label": "进入项目管理",
+                    "suggested_action_intent": "project.dashboard.enter",
+                    "suggested_action_title": "进入项目管理",
+                },
+            }
+        return {
+            "suggested_action": {
+                "intent": "project.initiation.enter",
+                "reason_code": "PROJECT_OPTIONS_EMPTY",
+                "params": {},
+            },
+            "lifecycle_hints": {
+                "stage": "no_project_options",
+                "project_id": 0,
+                "primary_action_label": "创建项目",
+                "suggested_action_intent": "project.initiation.enter",
+                "suggested_action_title": "创建项目",
+            },
+        }
+
+    @staticmethod
+    def _build_diagnostics_summary(*, resolution_path="", available=False, option_count=0):
+        normalized_path = str(resolution_path or "").strip().lower()
+        if int(option_count or 0) > 0:
+            return {
+                "status": "options_available",
+                "message": "已提供可切换项目列表，可直接进入项目管理。",
+                "resolution_path": normalized_path or "options_ranked",
+                "option_count": int(option_count or 0),
+                "available": bool(available),
+            }
+        if bool(available):
+            return {
+                "status": "context_ready",
+                "message": "已解析到当前项目，可直接进入项目管理。",
+                "resolution_path": normalized_path or "context_resolved",
+                "option_count": 0,
+                "available": True,
+            }
+        return {
+            "status": "context_missing",
+            "message": "当前未解析到可用项目，建议先创建项目。",
+            "resolution_path": normalized_path or "context_missing",
+            "option_count": 0,
+            "available": False,
+        }
+
+    @staticmethod
+    def _safe_search(Project, domain, *, order="", limit=0):
+        try:
+            return Project.search(domain or [], order=order, limit=limit)
+        except Exception:
+            return Project.browse([])
+
+    @staticmethod
+    def _append_unique_records(target, records, seen_ids):
+        for record in records:
+            project_id = int(getattr(record, "id", 0) or 0)
+            if project_id <= 0 or project_id in seen_ids:
+                continue
+            seen_ids.add(project_id)
+            target += record
+        return target
+
+    @staticmethod
+    def _showroom_candidate_domain():
+        return [
+            "|",
+            ("name", "like", "展厅-%"),
+            "|",
+            ("sc_demo_showcase", "=", True),
+            ("sc_demo_showcase_ready", "=", True),
+        ]
+
+    def _option_candidate_records(self, Project, active_project_id=0, limit=12):
+        fetch_limit = max(int(limit or 12) * 6, 24)
+        candidates = Project.browse([])
+        seen_ids = set()
+
+        if int(active_project_id or 0) > 0:
+            active_record = self._safe_search(
+                Project,
+                [("id", "=", int(active_project_id or 0))],
+                limit=1,
+            )
+            candidates = self._append_unique_records(candidates, active_record, seen_ids)
+
+        user_domain = self._dashboard_service._project_domain_for_user()
+        user_records = self._safe_search(
+            Project,
+            user_domain,
+            order="write_date desc,id desc",
+            limit=fetch_limit,
+        )
+        candidates = self._append_unique_records(candidates, user_records, seen_ids)
+
+        showroom_records = self._safe_search(
+            Project,
+            self._showroom_candidate_domain(),
+            order="write_date desc,id desc",
+            limit=max(int(limit or 12), 6),
+        )
+        candidates = self._append_unique_records(candidates, showroom_records, seen_ids)
+
+        if len(candidates) >= min(fetch_limit, 2):
+            return candidates
+
+        fallback_records = self._safe_search(
+            Project,
+            [],
+            order="write_date desc,id desc",
+            limit=fetch_limit,
+        )
+        candidates = self._append_unique_records(candidates, fallback_records, seen_ids)
+        return candidates
+
+    def list_options(self, active_project_id=0, limit=12):
+        Project = self.env["project.project"]
+        records = self._option_candidate_records(Project, active_project_id=active_project_id, limit=limit)
+        ranked_rows = []
+        for project in records:
+            rank, context = self._project_rank(project, active_project_id=active_project_id)
+            if rank <= 0:
+                continue
+            ranked_rows.append((rank, project.id, context))
+        ranked_rows.sort(key=lambda item: (-int(item[0]), -int(item[1])))
+        options = []
+        seen_project_ids = set()
+        for _rank, _project_id, context in ranked_rows:
+            project_id = int(context.get("project_id") or 0)
+            if project_id <= 0 or project_id in seen_project_ids:
+                continue
+            seen_project_ids.add(project_id)
+            options.append(
+                {
+                    "project_id": project_id,
+                    "project_name": str(context.get("project_name") or ""),
+                    "stage_label": str(context.get("stage_label") or ""),
+                    "milestone_label": str(context.get("milestone_label") or ""),
+                    "status": str(context.get("status") or ""),
+                    "active": project_id == int(active_project_id or 0),
+                    "project_context": context,
+                }
+            )
+            if len(options) >= int(limit or 12):
+                break
+        guidance = self._build_options_guidance(options, active_project_id=active_project_id)
+        diagnostics_summary = self._build_diagnostics_summary(
+            resolution_path="options_ranked",
+            available=bool(options),
+            option_count=len(options),
+        )
+        return {
+            "options": options,
+            "active_project_id": int(active_project_id or 0),
+            "suggested_action": dict(guidance.get("suggested_action") or {}),
+            "lifecycle_hints": dict(guidance.get("lifecycle_hints") or {}),
+            "diagnostics_summary": dict(diagnostics_summary or {}),
+        }

--- a/addons/smart_construction_core/services/project_state_explain_service.py
+++ b/addons/smart_construction_core/services/project_state_explain_service.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+
+LIFECYCLE_STATE_LABELS = {
+    "draft": "筹备中",
+    "in_progress": "在建",
+    "paused": "暂停",
+    "closing": "收口",
+    "warranty": "质保",
+    "done": "完工",
+    "closed": "关闭",
+}
+
+
+def lifecycle_state_label(project_or_state, default="未设置阶段"):
+    state = getattr(project_or_state, "lifecycle_state", project_or_state)
+    state = str(state or "").strip().lower()
+    if not state:
+        return default
+    return LIFECYCLE_STATE_LABELS.get(state, state)
+
+
+class ProjectStateExplainService:
+    def __init__(self, env):
+        self.env = env
+
+    def build(self, project):
+        if not project:
+            return {
+                "execution_stage_label": "未选择项目",
+                "stage_label": "未选择项目",
+                "execution_stage_explain": "当前没有可用项目，无法进入项目驾驶舱。",
+                "stage_explain": "当前没有可用项目，无法进入项目驾驶舱。",
+                "project_condition_explain": "请先选择项目或创建项目。",
+                "status_explain": "请先选择项目或创建项目。",
+            }
+        lifecycle_state = str(getattr(project, "lifecycle_state", "") or "").strip().lower()
+        execution_stage_label = lifecycle_state_label(lifecycle_state)
+        project_condition = str(getattr(project, "health_state", "") or getattr(project, "state", "") or "").strip()
+        stage_explain_map = {
+            "draft": "项目已完成创建与立项准备，下一步应进入执行主线。",
+            "in_progress": "项目已进入施工执行阶段，需要持续推进任务、成本与付款事实。",
+            "closing": "项目处于收口阶段，重点是检查成本、付款与结算前置条件。",
+            "warranty": "项目处于收尾或质保阶段，需要继续跟踪尾项和经营事实。",
+            "done": "项目主线已完成，当前以结果复核与经营回看为主。",
+        }
+        execution_stage_explain = stage_explain_map.get(lifecycle_state, "当前项目处于已发布主线中，请按推荐动作继续推进。")
+        project_condition_explain = project_condition or "整体正常"
+        return {
+            "execution_stage_label": execution_stage_label,
+            "stage_label": execution_stage_label,
+            "execution_stage_explain": execution_stage_explain,
+            "stage_explain": execution_stage_explain,
+            "project_condition_explain": project_condition_explain,
+            "status_explain": project_condition_explain,
+        }

--- a/addons/smart_construction_core/tests/test_my_work_backend.py
+++ b/addons/smart_construction_core/tests/test_my_work_backend.py
@@ -20,6 +20,17 @@ from odoo.addons.smart_construction_core.handlers.my_work_summary import MyWorkS
 
 @tagged("sc_smoke", "my_work_backend")
 class TestMyWorkBackend(TransactionCase):
+    def _create_project_with_partner(self, name):
+        project = self.env["project.project"].create(
+            {
+                "name": name,
+                "manager_id": self.env.user.id,
+                "user_id": self.env.user.id,
+            }
+        )
+        partner = self.env["res.partner"].create({"name": "%s Partner" % name})
+        return project, partner
+
     def test_summary_filters_apply_server_side(self):
         handler = MyWorkSummaryHandler(self.env, payload={})
         rows = [
@@ -248,6 +259,33 @@ class TestMyWorkBackend(TransactionCase):
         self.assertEqual(safe_page, 2)
         self.assertEqual([item["id"] for item in page_rows], [4, 5])
 
+    def test_summary_attaches_completion_capability(self):
+        handler = MyWorkSummaryHandler(self.env, payload={})
+        rows = handler._attach_targets(
+            [
+                {
+                    "id": 11,
+                    "title": "Todo row",
+                    "model": "project.task",
+                    "record_id": 11,
+                    "source": "mail.activity",
+                },
+                {
+                    "id": 12,
+                    "title": "Task row",
+                    "model": "project.task",
+                    "record_id": 12,
+                    "source": "project.task",
+                },
+            ]
+        )
+        self.assertEqual(len(rows), 2)
+        self.assertTrue(bool(rows[0].get("can_complete")))
+        self.assertEqual((rows[0].get("complete_action") or {}).get("intent"), "my.work.complete")
+        self.assertEqual((rows[0].get("complete_action") or {}).get("source"), "mail.activity")
+        self.assertFalse(bool(rows[1].get("can_complete")))
+        self.assertFalse(bool(rows[1].get("complete_action")))
+
         self.assertEqual(handler._normalize_sort_by("unknown"), "id")
         self.assertEqual(handler._normalize_sort_dir("up"), "desc")
 
@@ -260,6 +298,40 @@ class TestMyWorkBackend(TransactionCase):
         ]
         sorted_rows = handler._apply_sort(rows, sort_by="priority", sort_dir="desc")
         self.assertEqual([item["id"] for item in sorted_rows], [3, 1, 2])
+
+    def test_summary_includes_project_execution_projection_items(self):
+        project, partner = self._create_project_with_partner("My Work Projection Test")
+        self.env["payment.request"].create(
+            {
+                "name": "PR-MYWORK-001",
+                "project_id": project.id,
+                "partner_id": partner.id,
+                "amount": 888.0,
+            }
+        )
+        self.env["sc.settlement.order"].create(
+            {
+                "name": "SO-MYWORK-001",
+                "project_id": project.id,
+                "partner_id": partner.id,
+            }
+        )
+        self.env["construction.contract"].create(
+            {
+                "subject": "我的工作合同事项",
+                "type": "out",
+                "project_id": project.id,
+                "partner_id": partner.id,
+            }
+        )
+
+        handler = MyWorkSummaryHandler(self.env, payload={})
+        items = handler._load_project_execution_items(self.env.user, 20)
+        sources = {str(item.get("source") or "") for item in items}
+
+        self.assertIn("payment.request", sources)
+        self.assertIn("sc.settlement.order", sources)
+        self.assertIn("construction.contract", sources)
 
     def test_retryable_summary_counts(self):
         summary = _retryable_summary(

--- a/addons/smart_construction_core/tests/test_project_dashboard_entry_backend.py
+++ b/addons/smart_construction_core/tests/test_project_dashboard_entry_backend.py
@@ -1,0 +1,135 @@
+# -*- coding: utf-8 -*-
+
+from unittest.mock import patch
+
+from odoo.tests.common import TransactionCase, tagged
+
+from odoo.addons.smart_construction_core.handlers.project_dashboard_block_fetch import (
+    ProjectDashboardBlockFetchHandler,
+)
+from odoo.addons.smart_construction_core.handlers.project_dashboard_enter import (
+    ProjectDashboardEnterHandler,
+)
+from odoo.addons.smart_construction_core.handlers.project_dashboard_open import (
+    ProjectDashboardOpenHandler,
+)
+from odoo.addons.smart_core.orchestration.project_dashboard_scene_orchestrator import (
+    ProjectDashboardSceneOrchestrator,
+)
+from odoo.addons.smart_construction_core.services.project_dashboard_service import (
+    ProjectDashboardService,
+)
+
+
+@tagged("sc_smoke", "project_dashboard_entry_backend")
+class TestProjectDashboardEntryBackend(TransactionCase):
+    def test_entry_requires_project_id(self):
+        handler = ProjectDashboardEnterHandler(self.env, payload={})
+        result = handler.handle(payload={}, ctx={})
+        self.assertFalse(result.get("ok"))
+        self.assertEqual(((result.get("error") or {}).get("code")), "PROJECT_CONTEXT_MISSING")
+
+    def test_entry_returns_minimal_shape(self):
+        fake_entry = {
+            "project_id": 11,
+            "scene_key": "project.management",
+            "scene_label": "项目驾驶舱",
+            "state_fallback_text": "当前状态：已完成立项，正在查看项目驾驶舱。",
+            "title": "Demo",
+            "summary": {"project_code": "P-11"},
+            "blocks": [{"key": "progress"}, {"key": "risks"}, {"key": "next_actions"}],
+            "suggested_action": {"intent": "project.dashboard.block.fetch"},
+            "runtime_fetch_hints": {"blocks": {"progress": {"intent": "project.dashboard.block.fetch"}}},
+        }
+        handler = ProjectDashboardEnterHandler(self.env, payload={"project_id": 11})
+        with patch(
+            "odoo.addons.smart_construction_core.handlers.project_dashboard_enter.ProjectDashboardSceneOrchestrator.build_entry",
+            return_value=fake_entry,
+        ):
+            result = handler.handle(payload={"project_id": 11}, ctx={})
+        self.assertTrue(result.get("ok"))
+        self.assertEqual(set((result.get("data") or {}).keys()), set(fake_entry.keys()))
+
+    def test_runtime_block_fetch_keeps_block_level_payload(self):
+        fake_block = {
+            "project_id": 11,
+            "block_key": "progress",
+            "block": {"block_type": "progress_summary", "state": "ready", "data": {}},
+            "degraded": False,
+        }
+        handler = ProjectDashboardBlockFetchHandler(self.env, payload={"project_id": 11, "block_key": "progress"})
+        with patch(
+            "odoo.addons.smart_construction_core.handlers.project_dashboard_block_fetch.ProjectDashboardSceneOrchestrator.build_runtime_block",
+            return_value=fake_block,
+        ):
+            result = handler.handle(payload={"project_id": 11, "block_key": "progress"}, ctx={})
+        self.assertTrue(result.get("ok"))
+        self.assertEqual((((result.get("data") or {}).get("block") or {}).get("block_type")), "progress_summary")
+
+    def test_open_is_deprecated_alias_wrapper(self):
+        fake_entry = {
+            "project_id": 11,
+            "title": "Demo",
+            "summary": {"project_code": "P-11"},
+            "blocks": [{"key": "progress"}, {"key": "risks"}, {"key": "next_actions"}],
+            "suggested_action": {"intent": "project.dashboard.block.fetch"},
+            "runtime_fetch_hints": {"blocks": {"progress": {"intent": "project.dashboard.block.fetch"}}},
+        }
+        handler = ProjectDashboardOpenHandler(self.env, payload={"project_id": 11})
+        with patch(
+            "odoo.addons.smart_construction_core.handlers.project_dashboard_open.ProjectDashboardEnterHandler.handle",
+            return_value={"ok": True, "data": fake_entry, "meta": {"intent": "project.dashboard.enter"}},
+        ):
+            result = handler.handle(payload={"project_id": 11}, ctx={})
+        self.assertTrue(result.get("ok"))
+        self.assertTrue(((result.get("meta") or {}).get("deprecated")))
+        self.assertEqual((((result.get("data") or {}).get("entry") or {}).get("project_id")), 11)
+
+    def test_dashboard_enter_uses_orchestration_carrier_shape(self):
+        fake_entry = {
+            "project_id": 11,
+            "scene_key": "project.management",
+            "scene_label": "项目驾驶舱",
+            "state_fallback_text": "当前状态：已完成立项，正在查看项目驾驶舱。",
+            "title": "项目驾驶舱：Demo",
+            "summary": {"project_code": "P-11"},
+            "blocks": [{"key": "progress"}, {"key": "risks"}, {"key": "next_actions"}],
+            "suggested_action": {"intent": "project.dashboard.block.fetch"},
+            "runtime_fetch_hints": {"blocks": {"progress": {"intent": "project.dashboard.block.fetch"}}},
+        }
+        handler = ProjectDashboardEnterHandler(self.env, payload={"project_id": 11})
+        with patch(
+            "odoo.addons.smart_construction_core.handlers.project_dashboard_enter.ProjectDashboardSceneOrchestrator.build_entry",
+            return_value=fake_entry,
+        ):
+            result = handler.handle(payload={"project_id": 11}, ctx={})
+        self.assertTrue(result.get("ok"))
+        self.assertEqual(((result.get("data") or {}).get("scene_key")), "project.management")
+
+    def test_dashboard_orchestrator_runtime_block_shape(self):
+        project = self.env["project.project"].create(
+            {
+                "name": "Dashboard Orchestrator Test",
+                "manager_id": self.env.user.id,
+                "user_id": self.env.user.id,
+            }
+        )
+        orchestrator = ProjectDashboardSceneOrchestrator(self.env)
+        result = orchestrator.build_runtime_block("progress", project_id=project.id, context={})
+        block = result.get("block") if isinstance(result.get("block"), dict) else {}
+
+        self.assertEqual(result.get("block_key"), "progress")
+        self.assertTrue(isinstance(block, dict))
+
+    def test_dashboard_service_build_block_returns_block_payload(self):
+        project = self.env["project.project"].create(
+            {
+                "name": "Dashboard Build Block Test",
+                "manager_id": self.env.user.id,
+                "user_id": self.env.user.id,
+            }
+        )
+        service = ProjectDashboardService(self.env)
+        block = service.build_block("progress", project=project, context={})
+        self.assertTrue(isinstance(block, dict))
+        self.assertTrue(str(block.get("block_type") or "").strip())

--- a/addons/smart_construction_core/tests/test_project_intake_contract_governance.py
+++ b/addons/smart_construction_core/tests/test_project_intake_contract_governance.py
@@ -1,0 +1,99 @@
+# -*- coding: utf-8 -*-
+import unittest
+
+from odoo.addons.smart_core.utils.contract_governance import apply_contract_governance
+from odoo.addons.smart_construction_core.services import contract_governance_overrides  # noqa: F401
+
+
+def _payload(scene_key="projects.intake", render_profile="create", menu_xmlid=None):
+    return {
+        "head": {
+            "model": "project.project",
+            "view_type": "form",
+            "scene_key": scene_key,
+            "render_profile": render_profile,
+            "menu_xmlid": menu_xmlid,
+        },
+        "model": "project.project",
+        "scene_key": scene_key,
+        "render_profile": render_profile,
+        "menu_xmlid": menu_xmlid,
+        "views": {
+            "form": {
+                "layout": [
+                    {"type": "sheet"},
+                    {"type": "field", "name": "name"},
+                    {"type": "field", "name": "manager_id"},
+                ]
+            }
+        },
+        "fields": {
+            "name": {"string": "名称", "type": "char", "required": True, "readonly": False},
+            "manager_id": {
+                "string": "项目管理员",
+                "type": "many2one",
+                "required": False,
+                "readonly": False,
+            },
+        },
+    }
+
+
+class ProjectIntakeContractGovernanceCase(unittest.TestCase):
+    def test_project_intake_create_contract_receives_scene_governance(self):
+        governed = apply_contract_governance(_payload(), "user")
+
+        governance = governed.get("form_governance") or {}
+        self.assertEqual(governance.get("surface"), "project_intake")
+        self.assertEqual(governance.get("create_flow_mode"), "standard")
+        self.assertEqual(governance.get("autosave_scope"), "project_intake_standard")
+        self.assertEqual(governance.get("primary_action_label"), "创建项目")
+        self.assertEqual(
+            governance.get("post_create_target"),
+            {
+                "intent": "project.dashboard.enter",
+                "route": "/s/project.management",
+            },
+        )
+
+    def test_project_quick_create_contract_receives_quick_governance(self):
+        governed = apply_contract_governance(
+            _payload(
+                scene_key="",
+                menu_xmlid="smart_construction_core.menu_sc_project_quick_create",
+            ),
+            "user",
+        )
+
+        governance = governed.get("form_governance") or {}
+        self.assertEqual(governance.get("surface"), "project_intake")
+        self.assertEqual(governance.get("create_flow_mode"), "quick")
+        self.assertEqual(governance.get("autosave_scope"), "project_intake_quick")
+        self.assertEqual(governance.get("primary_action_label"), "创建并进入项目驾驶舱")
+        self.assertEqual(
+            governance.get("post_create_target"),
+            {
+                "intent": "project.dashboard.enter",
+                "route": "/s/project.management",
+            },
+        )
+
+    def test_non_intake_project_contract_is_not_overridden(self):
+        governed = apply_contract_governance(_payload(scene_key="projects.list"), "user")
+
+        governance = governed.get("form_governance") or {}
+        self.assertNotEqual(governance.get("surface"), "project_intake")
+        self.assertIsNone(governance.get("create_flow_mode"))
+        self.assertIsNone(governance.get("post_create_target"))
+
+    def test_non_create_project_contract_is_not_overridden(self):
+        governed = apply_contract_governance(_payload(render_profile="edit"), "user")
+
+        governance = governed.get("form_governance") or {}
+        self.assertNotEqual(governance.get("surface"), "project_intake")
+        self.assertIsNone(governance.get("create_flow_mode"))
+        self.assertIsNone(governance.get("post_create_target"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/addons/smart_construction_core/tests/test_project_semantic_carriers.py
+++ b/addons/smart_construction_core/tests/test_project_semantic_carriers.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(module_name: str, relative_path: str):
+    target = ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(module_name, target)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    assert spec and spec.loader
+    spec.loader.exec_module(module)
+    return module
+
+
+STATE_EXPLAIN_MODULE = _load_module(
+    "odoo.addons.smart_construction_core.services.project_state_explain_service",
+    "addons/smart_construction_core/services/project_state_explain_service.py",
+)
+PROJECT_CONTEXT_MODULE = _load_module(
+    "odoo.addons.smart_construction_core.services.project_context_contract",
+    "addons/smart_construction_core/services/project_context_contract.py",
+)
+CONTRACT_GOVERNANCE_MODULE = _load_module(
+    "smart_core_contract_governance_test_module",
+    "addons/smart_core/utils/contract_governance.py",
+)
+
+build_project_context = PROJECT_CONTEXT_MODULE.build_project_context
+ProjectStateExplainService = STATE_EXPLAIN_MODULE.ProjectStateExplainService
+apply_project_form_domain_override = CONTRACT_GOVERNANCE_MODULE.apply_project_form_domain_override
+
+
+class TestProjectSemanticCarriers(unittest.TestCase):
+    def test_build_project_context_adds_explicit_execution_stage_and_condition_aliases(self):
+        project = SimpleNamespace(
+            id=7,
+            display_name="项目-A",
+            name="项目-A",
+            lifecycle_state="in_progress",
+            sc_execution_state="ready",
+            sc_execution_state_label="准备完成",
+            health_state="attention",
+            state="legacy",
+        )
+
+        result = build_project_context(project)
+
+        self.assertEqual(result.get("execution_stage"), "in_progress")
+        self.assertEqual(result.get("execution_stage_label"), "在建")
+        self.assertEqual(result.get("stage"), "in_progress")
+        self.assertEqual(result.get("stage_label"), "在建")
+        self.assertEqual(result.get("project_condition"), "attention")
+        self.assertEqual(result.get("status"), "attention")
+
+    def test_state_explain_adds_execution_stage_and_project_condition_aliases(self):
+        project = SimpleNamespace(
+            lifecycle_state="closing",
+            health_state="risk",
+            state="legacy",
+        )
+
+        result = ProjectStateExplainService(env=None).build(project)
+
+        self.assertEqual(result.get("execution_stage_label"), "收口")
+        self.assertEqual(result.get("stage_label"), "收口")
+        self.assertIn("收口阶段", result.get("execution_stage_explain") or "")
+        self.assertEqual(result.get("execution_stage_explain"), result.get("stage_explain"))
+        self.assertEqual(result.get("project_condition_explain"), "risk")
+        self.assertEqual(result.get("status_explain"), "risk")
+
+    def test_state_explain_empty_case_keeps_compat_and_new_fields(self):
+        result = ProjectStateExplainService(env=None).build(None)
+
+        self.assertEqual(result.get("execution_stage_label"), "未选择项目")
+        self.assertEqual(result.get("stage_label"), "未选择项目")
+        self.assertEqual(result.get("project_condition_explain"), "请先选择项目或创建项目。")
+        self.assertEqual(result.get("status_explain"), "请先选择项目或创建项目。")
+
+    def test_project_list_label_uses_project_execution_stage(self):
+        self.assertEqual(
+            CONTRACT_GOVERNANCE_MODULE._PROJECT_LIST_COLUMN_LABELS.get("lifecycle_state"),
+            "项目执行阶段",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-CORE-SEMANTIC-CARRIERS-PA89.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-CORE-SEMANTIC-CARRIERS-PA89.yaml
@@ -1,0 +1,55 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-CORE-SEMANTIC-CARRIERS-PA89
+title: Split residual construction core semantic carriers slice from 56b7eba
+objective: >
+  Isolate the domain-layer construction semantic carrier slice from commit
+  56b7eba into a bounded child batch for mainline review.
+context:
+  layer_target: Domain Layer
+  module: smart_construction_core
+  module_ownership: Industry domain layer
+  kernel_or_scenario: scenario
+  architecture_reason: >
+    This batch carries project dashboard, project context, my-work, and
+    capability-registry semantic supply that belongs to construction domain
+    services. It must remain separate from smart_core platform orchestration
+    and smart_construction_scene provider/runtime supply.
+scope:
+  allowed_paths:
+    - addons/smart_construction_core/core_extension.py
+    - addons/smart_construction_core/handlers/my_work_summary.py
+    - addons/smart_construction_core/services/capability_registry.py
+    - addons/smart_construction_core/services/contract_governance_overrides.py
+    - addons/smart_construction_core/services/cost_tracking_service.py
+    - addons/smart_construction_core/services/project_context_contract.py
+    - addons/smart_construction_core/services/project_dashboard_service.py
+    - addons/smart_construction_core/services/project_entry_context_service.py
+    - addons/smart_construction_core/services/project_state_explain_service.py
+    - addons/smart_construction_core/tests/test_my_work_backend.py
+    - addons/smart_construction_core/tests/test_project_dashboard_entry_backend.py
+    - addons/smart_construction_core/tests/test_project_intake_contract_governance.py
+    - addons/smart_construction_core/tests/test_project_semantic_carriers.py
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-CORE-SEMANTIC-CARRIERS-PA89.yaml
+  forbidden_paths:
+    - addons/smart_construction_core/handlers/cost_tracking_enter.py
+    - addons/smart_construction_core/handlers/project_dashboard_enter.py
+    - addons/smart_construction_scene/**
+    - addons/smart_core/**
+    - addons/smart_construction_core/**/payment*
+    - addons/smart_construction_core/**/settlement*
+    - addons/smart_construction_core/**/account*
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_construction_core/core_extension.py addons/smart_construction_core/handlers/my_work_summary.py addons/smart_construction_core/services/capability_registry.py addons/smart_construction_core/services/contract_governance_overrides.py addons/smart_construction_core/services/cost_tracking_service.py addons/smart_construction_core/services/project_context_contract.py addons/smart_construction_core/services/project_dashboard_service.py addons/smart_construction_core/services/project_entry_context_service.py addons/smart_construction_core/services/project_state_explain_service.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Split the fourth residual slice from `56b7eba` out of residual umbrella PR #577.

This PR isolates `smart_construction_core` semantic carriers and project/dashboard semantic supply without carrying `smart_core`, `smart_construction_scene`, or handler entry-path residual files.

## Scope

- `addons/smart_construction_core/core_extension.py`
- `addons/smart_construction_core/handlers/my_work_summary.py`
- `addons/smart_construction_core/services/capability_registry.py`
- `addons/smart_construction_core/services/contract_governance_overrides.py`
- `addons/smart_construction_core/services/cost_tracking_service.py`
- `addons/smart_construction_core/services/project_context_contract.py`
- `addons/smart_construction_core/services/project_dashboard_service.py`
- `addons/smart_construction_core/services/project_entry_context_service.py`
- `addons/smart_construction_core/services/project_state_explain_service.py`
- `addons/smart_construction_core/tests/test_my_work_backend.py`
- `addons/smart_construction_core/tests/test_project_dashboard_entry_backend.py`
- `addons/smart_construction_core/tests/test_project_intake_contract_governance.py`
- `addons/smart_construction_core/tests/test_project_semantic_carriers.py`

## Architecture Impact

- Layer Target: Domain Layer
- Affected Modules: `smart_construction_core`
- Reason: recover construction domain semantic carriers as a bounded child slice while keeping scene/provider supply and platform orchestration separate

## Verify

- `python3 -m py_compile addons/smart_construction_core/core_extension.py addons/smart_construction_core/handlers/my_work_summary.py addons/smart_construction_core/services/capability_registry.py addons/smart_construction_core/services/contract_governance_overrides.py addons/smart_construction_core/services/cost_tracking_service.py addons/smart_construction_core/services/project_context_contract.py addons/smart_construction_core/services/project_dashboard_service.py addons/smart_construction_core/services/project_entry_context_service.py addons/smart_construction_core/services/project_state_explain_service.py`

## Relation

- parent residual umbrella: #577
- predecessor merged splits: #578 #579 #580 #581 #582 #583 #584 #585 #586
- predecessor residual slices: #587 #588 #589
- intentionally excluded from this PR: `addons/smart_construction_core/handlers/cost_tracking_enter.py`, `addons/smart_construction_core/handlers/project_dashboard_enter.py`, `addons/smart_construction_scene/**`, `addons/smart_core/**`
