### PR TITLE
[split] smart core delivery orchestration tail

### DIFF
--- a/addons/smart_core/__init__.py
+++ b/addons/smart_core/__init__.py
@@ -13,16 +13,24 @@ Smart Core Engine Module
 import logging
 
 # 导入子模块
-from . import controllers
-from . import app_config_engine
-from . import core
-from . import handlers
-from . import view
-from . import utils
-from . import models
+try:
+    from . import controllers
+    from . import app_config_engine
+    from . import core
+    from . import handlers
+    from . import view
+    from . import utils
+    from . import models
+    from . import delivery
 
-# Ensure intent controllers are registered on module load
-from .controllers import intent_dispatcher
+    # Ensure intent controllers are registered on module load
+    from .controllers import intent_dispatcher
+except ModuleNotFoundError as exc:
+    # Pure-Python bridge tests import smart_core without a live Odoo runtime.
+    # In that mode the package must still be importable so isolated bridge
+    # modules can be executed directly from their test loaders.
+    if exc.name != "odoo":
+        raise
 
 # 设置日志
 _logger = logging.getLogger(__name__)

--- a/addons/smart_core/delivery/product_policy_service.py
+++ b/addons/smart_core/delivery/product_policy_service.py
@@ -1,0 +1,434 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import copy
+
+
+DEFAULT_PRODUCT_POLICY = {
+    "product_key": "construction.standard",
+    "base_product_key": "construction",
+    "edition_key": "standard",
+    "state": "stable",
+    "access_level": "public",
+    "allowed_role_codes": [],
+    "label": "Construction Standard",
+    "version": "v1",
+    "scene_version_bindings": {
+        "projects.intake": {"version": "v1", "channel": "stable"},
+        "project.management": {"version": "v1", "channel": "stable"},
+        "cost": {"version": "v1", "channel": "stable"},
+        "payment": {"version": "v1", "channel": "stable"},
+        "settlement": {"version": "v1", "channel": "stable"},
+        "my_work.workspace": {"version": "v1", "channel": "stable"},
+    },
+    "menu_groups": [
+        {
+            "group_key": "released_products",
+            "group_label": "已发布产品",
+            "menus": [
+                {
+                    "menu_key": "release.fr1.project_intake",
+                    "label": "FR-1 项目立项",
+                    "route": "/s/projects.intake",
+                    "scene_key": "projects.intake",
+                    "product_key": "fr1",
+                    "capability_key": "delivery.fr1.project_intake",
+                },
+                {
+                    "menu_key": "release.fr2.project_flow",
+                    "label": "FR-2 项目推进",
+                    "route": "/release/fr2",
+                    "scene_key": "project.management",
+                    "product_key": "fr2",
+                    "capability_key": "delivery.fr2.project_flow",
+                },
+                {
+                    "menu_key": "release.fr3.cost_tracking",
+                    "label": "FR-3 成本记录",
+                    "route": "/release/fr3",
+                    "scene_key": "cost",
+                    "product_key": "fr3",
+                    "capability_key": "delivery.fr3.cost_tracking",
+                },
+                {
+                    "menu_key": "release.fr4.payment_tracking",
+                    "label": "FR-4 付款记录",
+                    "route": "/release/fr4",
+                    "scene_key": "payment",
+                    "product_key": "fr4",
+                    "capability_key": "delivery.fr4.payment_tracking",
+                },
+                {
+                    "menu_key": "release.fr5.settlement_summary",
+                    "label": "FR-5 结算结果",
+                    "route": "/release/fr5",
+                    "scene_key": "settlement",
+                    "product_key": "fr5",
+                    "capability_key": "delivery.fr5.settlement_summary",
+                },
+            ],
+        },
+        {
+            "group_key": "released_utilities",
+            "group_label": "工作辅助",
+            "menus": [
+                {
+                    "menu_key": "release.my_work",
+                    "label": "我的工作",
+                    "route": "/my-work",
+                    "scene_key": "my_work.workspace",
+                    "product_key": "my_work",
+                    "capability_key": "delivery.my_work.workspace",
+                },
+            ],
+        },
+    ],
+    "scenes": [
+        {
+            "scene_key": "projects.intake",
+            "label": "项目立项",
+            "route": "/s/projects.intake",
+            "product_key": "fr1",
+            "capability_key": "delivery.fr1.project_intake",
+            "description": "提供项目立项入口与基础资料创建。",
+            "scope": "项目创建 -> 立项资料 -> 项目入口。",
+        },
+        {
+            "scene_key": "project.management",
+            "label": "项目推进",
+            "route": "/s/project.management",
+            "product_key": "fr2",
+            "capability_key": "delivery.fr2.project_flow",
+            "requires_project_context": True,
+            "description": "进入项目驾驶舱、计划与执行主线。",
+            "scope": "项目驾驶舱 -> 计划准备 -> 执行推进。",
+        },
+        {
+            "scene_key": "cost",
+            "label": "成本记录",
+            "route": "/s/cost",
+            "product_key": "fr3",
+            "capability_key": "delivery.fr3.cost_tracking",
+            "requires_project_context": True,
+            "description": "查看与记录项目成本事实。",
+            "scope": "项目执行 -> 成本记录 -> 成本汇总。",
+        },
+        {
+            "scene_key": "payment",
+            "label": "付款记录",
+            "route": "/s/payment",
+            "product_key": "fr4",
+            "capability_key": "delivery.fr4.payment_tracking",
+            "requires_project_context": True,
+            "description": "查看与记录项目付款事实。",
+            "scope": "项目执行 -> 成本 -> 付款记录 -> 付款汇总。",
+        },
+        {
+            "scene_key": "settlement",
+            "label": "结算结果",
+            "route": "/s/settlement",
+            "product_key": "fr5",
+            "capability_key": "delivery.fr5.settlement_summary",
+            "requires_project_context": True,
+            "description": "查看项目级成本与付款汇总后的结算结果。",
+            "scope": "项目执行 -> 成本 -> 付款 -> 结算结果。",
+        },
+        {
+            "scene_key": "my_work.workspace",
+            "label": "我的工作",
+            "route": "/my-work",
+            "product_key": "my_work",
+            "capability_key": "delivery.my_work.workspace",
+            "description": "聚合当前用户的待办、风险与动作入口。",
+            "scope": "工作台 -> 待办 -> 风险 -> 场景入口。",
+        },
+    ],
+    "capabilities": [
+        {
+            "capability_key": "delivery.fr1.project_intake",
+            "label": "FR-1 项目立项",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "projects.intake",
+            "product_key": "fr1",
+            "delivery_level": "exclusive",
+            "entry_kind": "exclusive",
+        },
+        {
+            "capability_key": "delivery.fr2.project_flow",
+            "label": "FR-2 项目推进",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "project.management",
+            "product_key": "fr2",
+            "delivery_level": "exclusive",
+            "entry_kind": "exclusive",
+        },
+        {
+            "capability_key": "delivery.fr3.cost_tracking",
+            "label": "FR-3 成本记录",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "cost",
+            "product_key": "fr3",
+            "delivery_level": "exclusive",
+            "entry_kind": "exclusive",
+        },
+        {
+            "capability_key": "delivery.fr4.payment_tracking",
+            "label": "FR-4 付款记录",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "payment",
+            "product_key": "fr4",
+            "delivery_level": "exclusive",
+            "entry_kind": "exclusive",
+        },
+        {
+            "capability_key": "delivery.fr5.settlement_summary",
+            "label": "FR-5 结算结果",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "settlement",
+            "product_key": "fr5",
+            "delivery_level": "exclusive",
+            "entry_kind": "exclusive",
+        },
+        {
+            "capability_key": "delivery.my_work.workspace",
+            "label": "我的工作",
+            "group_key": "delivery",
+            "group_label": "产品交付",
+            "target_scene_key": "my_work.workspace",
+            "product_key": "my_work",
+            "delivery_level": "shared",
+            "entry_kind": "exclusive",
+        },
+    ],
+}
+
+
+class ProductPolicyService:
+    RELEASEABLE_STATES = {"preview", "stable"}
+
+    def __init__(self, env):
+        self.env = env
+
+    def _stable_policy_domain(self, *, base_product_key: str):
+        return [
+            ("base_product_key", "=", str(base_product_key or "").strip() or "construction"),
+            ("state", "=", "stable"),
+            ("access_level", "=", "public"),
+            ("active", "=", True),
+        ]
+
+    def resolve_policy_identity(
+        self,
+        *,
+        product_key: str | None = None,
+        edition_key: str | None = None,
+        base_product_key: str | None = None,
+    ) -> tuple[str, str, str]:
+        explicit_product_key = str(product_key or "").strip()
+        explicit_edition_key = str(edition_key or "").strip()
+        explicit_base_product_key = str(base_product_key or "").strip() or "construction"
+        if explicit_product_key:
+            parts = explicit_product_key.split(".", 1)
+            if len(parts) == 2 and parts[0] and parts[1]:
+                return explicit_product_key, parts[0], parts[1]
+            return explicit_product_key, explicit_base_product_key, explicit_edition_key or "standard"
+        resolved_edition_key = explicit_edition_key or DEFAULT_PRODUCT_POLICY["edition_key"]
+        resolved_base_product_key = explicit_base_product_key or DEFAULT_PRODUCT_POLICY["base_product_key"]
+        return (
+            f"{resolved_base_product_key}.{resolved_edition_key}",
+            resolved_base_product_key,
+            resolved_edition_key,
+        )
+
+    def _snapshot_binding_is_releaseable(self, *, scene_key: str, product_key: str, binding: dict | None) -> bool:
+        row = binding if isinstance(binding, dict) else {}
+        version = str(row.get("version") or "").strip() or "v1"
+        channel = str(row.get("channel") or "").strip() or "stable"
+        rec = self.env["sc.scene.snapshot"].sudo().search(
+            [
+                ("scene_key", "=", scene_key),
+                ("product_key", "=", product_key),
+                ("version", "=", version),
+                ("channel", "=", channel),
+                ("state", "=", "stable"),
+                ("is_active", "=", True),
+                ("active", "=", True),
+            ],
+            limit=1,
+        )
+        return bool(rec)
+
+    def _access_allowed(self, payload: dict, *, role_code: str) -> bool:
+        access_level = str(payload.get("access_level") or "").strip() or "public"
+        if access_level == "public":
+            return True
+        if access_level == "internal":
+            return False
+        if access_level == "role_restricted":
+            allowed = payload.get("allowed_role_codes") if isinstance(payload.get("allowed_role_codes"), list) else []
+            return str(role_code or "").strip() in {str(item or "").strip() for item in allowed if str(item or "").strip()}
+        return False
+
+    def _policy_releaseable(self, payload: dict) -> bool:
+        state = str(payload.get("state") or "").strip() or "draft"
+        return state in self.RELEASEABLE_STATES
+
+    def _attach_edition_diagnostics(
+        self,
+        payload: dict,
+        *,
+        requested_product_key: str,
+        requested_base_product_key: str,
+        requested_edition_key: str,
+        role_code: str,
+        fallback_reason: str = "",
+        access_allowed: bool = True,
+    ) -> dict:
+        row = copy.deepcopy(payload if isinstance(payload, dict) else {})
+        row["edition_diagnostics"] = {
+            "requested_product_key": requested_product_key,
+            "requested_base_product_key": requested_base_product_key,
+            "requested_edition_key": requested_edition_key,
+            "resolved_product_key": str(row.get("product_key") or "").strip(),
+            "resolved_base_product_key": str(row.get("base_product_key") or "").strip(),
+            "resolved_edition_key": str(row.get("edition_key") or "").strip(),
+            "requested_role_code": str(role_code or "").strip(),
+            "policy_state": str(row.get("state") or "").strip(),
+            "access_level": str(row.get("access_level") or "").strip(),
+            "access_allowed": bool(access_allowed),
+            "fallback_reason": str(fallback_reason or "").strip(),
+            "fallback_applied": bool(fallback_reason),
+        }
+        return row
+
+    def _fallback_stable_policy(self, *, base_product_key: str) -> dict:
+        try:
+            rec = self.env["sc.product.policy"].sudo().search(
+                self._stable_policy_domain(base_product_key=base_product_key),
+                order="edition_key asc, id asc",
+                limit=1,
+            )
+        except Exception:
+            rec = None
+        if rec:
+            return rec.to_runtime_dict()
+        fallback = copy.deepcopy(DEFAULT_PRODUCT_POLICY)
+        fallback["product_key"] = f"{base_product_key}.standard"
+        fallback["base_product_key"] = base_product_key
+        fallback["edition_key"] = "standard"
+        fallback["state"] = "stable"
+        fallback["access_level"] = "public"
+        fallback["allowed_role_codes"] = []
+        return fallback
+
+    def _sanitize_scene_version_bindings(self, payload: dict) -> dict:
+        bindings = payload.get("scene_version_bindings") if isinstance(payload.get("scene_version_bindings"), dict) else {}
+        sanitized = {}
+        diagnostics = {}
+        for scene_key, binding in bindings.items():
+            key = str(scene_key or "").strip()
+            if not key:
+                continue
+            row = binding if isinstance(binding, dict) else {}
+            product_key = ""
+            for scene_row in payload.get("scenes") or []:
+                if isinstance(scene_row, dict) and str(scene_row.get("scene_key") or "").strip() == key:
+                    product_key = str(scene_row.get("product_key") or "").strip()
+                    break
+            if not product_key:
+                diagnostics[key] = {
+                    "binding_allowed": False,
+                    "reason": "SCENE_POLICY_MISSING",
+                }
+                continue
+            if self._snapshot_binding_is_releaseable(scene_key=key, product_key=product_key, binding=row):
+                sanitized[key] = {
+                    "version": str(row.get("version") or "").strip() or "v1",
+                    "channel": str(row.get("channel") or "").strip() or "stable",
+                }
+                diagnostics[key] = {
+                    "binding_allowed": True,
+                    "reason": "ACTIVE_STABLE_BOUND",
+                }
+            else:
+                diagnostics[key] = {
+                    "binding_allowed": False,
+                    "reason": "SNAPSHOT_NOT_ACTIVE_STABLE",
+                }
+        payload["scene_version_bindings"] = sanitized
+        payload["scene_binding_diagnostics"] = diagnostics
+        return payload
+
+    def get_policy(
+        self,
+        product_key: str | None = None,
+        *,
+        edition_key: str | None = None,
+        base_product_key: str | None = None,
+        role_code: str | None = None,
+        enforce_release: bool = False,
+        enforce_access: bool = False,
+    ) -> dict:
+        key, resolved_base_product_key, resolved_edition_key = self.resolve_policy_identity(
+            product_key=product_key,
+            edition_key=edition_key,
+            base_product_key=base_product_key,
+        )
+        resolved_role_code = str(role_code or "").strip()
+        try:
+            rec = self.env["sc.product.policy"].sudo().search([("product_key", "=", key), ("active", "=", True)], limit=1)
+        except Exception:
+            rec = None
+        if rec:
+            payload = rec.to_runtime_dict()
+            if isinstance(payload, dict) and payload.get("product_key"):
+                payload = self._sanitize_scene_version_bindings(payload)
+                access_allowed = self._access_allowed(payload, role_code=resolved_role_code) if enforce_access else True
+                release_allowed = self._policy_releaseable(payload) if enforce_release else True
+                if access_allowed and release_allowed:
+                    return self._attach_edition_diagnostics(
+                        payload,
+                        requested_product_key=key,
+                        requested_base_product_key=resolved_base_product_key,
+                        requested_edition_key=resolved_edition_key,
+                        role_code=resolved_role_code,
+                        access_allowed=access_allowed,
+                    )
+                fallback_reason = "EDITION_ACCESS_DENIED" if not access_allowed else "EDITION_STATE_NOT_RELEASEABLE"
+                fallback = self._sanitize_scene_version_bindings(
+                    self._fallback_stable_policy(base_product_key=resolved_base_product_key)
+                )
+                return self._attach_edition_diagnostics(
+                    fallback,
+                    requested_product_key=key,
+                    requested_base_product_key=resolved_base_product_key,
+                    requested_edition_key=resolved_edition_key,
+                    role_code=resolved_role_code,
+                    fallback_reason=fallback_reason,
+                    access_allowed=access_allowed,
+                )
+        fallback = copy.deepcopy(DEFAULT_PRODUCT_POLICY)
+        fallback["product_key"] = key
+        fallback["base_product_key"] = resolved_base_product_key
+        fallback["edition_key"] = resolved_edition_key
+        fallback["label"] = "Construction Preview" if resolved_edition_key == "preview" else fallback.get("label")
+        if enforce_release or enforce_access:
+            fallback = self._sanitize_scene_version_bindings(
+                self._fallback_stable_policy(base_product_key=resolved_base_product_key)
+            )
+        else:
+            fallback = self._sanitize_scene_version_bindings(fallback)
+        return self._attach_edition_diagnostics(
+            fallback,
+            requested_product_key=key,
+            requested_base_product_key=resolved_base_product_key,
+            requested_edition_key=resolved_edition_key,
+            role_code=resolved_role_code,
+            fallback_reason="POLICY_NOT_FOUND",
+            access_allowed=True,
+        )

--- a/addons/smart_core/delivery/release_operator_read_model_service.py
+++ b/addons/smart_core/delivery/release_operator_read_model_service.py
@@ -1,0 +1,236 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import Any
+
+from .release_approval_policy_service import ReleaseApprovalPolicyService
+from .release_audit_trail_service import ReleaseAuditTrailService
+from .release_operator_contract_versions import (
+    RELEASE_OPERATOR_READ_MODEL_CONTRACT_VERSION,
+    RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
+)
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+class ReleaseOperatorReadModelService:
+    DEFAULT_PRODUCTS = ("construction.standard", "construction.preview")
+
+    def __init__(self, env):
+        self.env = env
+        self.audit_service = ReleaseAuditTrailService(env)
+        self.approval_policy_service = ReleaseApprovalPolicyService(env)
+
+    def _resolve_product_key(self, product_key: str = "") -> str:
+        requested = _text(product_key)
+        if requested in self.DEFAULT_PRODUCTS:
+            return requested
+        return "construction.standard"
+
+    def _resolve_identity(self, product_key: str = "") -> dict[str, str]:
+        resolved = self._resolve_product_key(product_key=product_key)
+        return self.approval_policy_service._release_identity(product_key=resolved)
+
+    def _products(self, current_product_key: str) -> list[dict[str, Any]]:
+        rows = []
+        for item in self.DEFAULT_PRODUCTS:
+            identity = self.approval_policy_service._release_identity(product_key=item)
+            rows.append(
+                {
+                    "product_key": item,
+                    "base_product_key": identity["base_product_key"],
+                    "edition_key": identity["edition_key"],
+                    "label": "Standard" if identity["edition_key"] == "standard" else "Preview",
+                    "selected": item == current_product_key,
+                }
+            )
+        return rows
+
+    def _build_surface_copy(self, *, product_key: str) -> dict[str, Any]:
+        identity = self._resolve_identity(product_key=product_key)
+        edition_key = _text(identity.get("edition_key")) or "standard"
+        edition_label = "标准版" if edition_key == "standard" else "预览版"
+        return {
+            "eyebrow": "Release Operator Surface",
+            "title": "发布控制台",
+            "description": f"查看 {edition_label} 当前发布状态、候选快照、待审批动作与回滚目标。",
+            "error_title": "加载失败",
+            "action_retry": "重试",
+            "action_refresh": "刷新",
+            "section_release_state": "当前发布状态",
+            "section_candidate": "可 Promote 候选",
+            "section_pending": "待审批动作",
+            "section_rollback": "回滚",
+            "section_history": "发布历史",
+            "hint_candidate": "仅展示当前产品下 candidate / approved 状态的候选快照。",
+            "hint_pending_count_prefix": "当前数量：",
+            "hint_rollback": "仅当当前 active released snapshot 存在 rollback target 时可执行。",
+            "hint_history": "最近 action 与 snapshot。",
+            "empty_candidate": "当前没有可 Promote 的候选快照。",
+            "empty_pending": "当前没有待审批动作。",
+            "metric_current_product": "当前产品",
+            "metric_active_snapshot": "Active Released Snapshot",
+            "metric_latest_action": "Latest Action",
+            "metric_approval_state": "Approval State",
+            "rollback_target_label": "Rollback Target",
+            "rollback_action_label": "执行回滚",
+            "history_actions_title": "Actions",
+            "history_snapshots_title": "Snapshots",
+            "approve_action_label": "审批并执行",
+        }
+
+    def _serialize_snapshot(self, row: dict[str, Any]) -> dict[str, Any]:
+        freeze_surface = _dict(row.get("freeze_surface"))
+        identity = _dict(freeze_surface.get("identity"))
+        return {
+            "id": int(row.get("id") or 0),
+            "product_key": _text(row.get("product_key")),
+            "edition_key": _text(row.get("edition_key")),
+            "version": _text(row.get("version")) or "v1",
+            "state": _text(row.get("state")) or "candidate",
+            "is_active": bool(row.get("is_active")),
+            "released_at": _text(row.get("released_at")),
+            "approved_at": _text(row.get("approved_at")),
+            "frozen_at": _text(row.get("frozen_at")),
+            "rollback_target_snapshot_id": int(row.get("rollback_target_snapshot_id") or 0),
+            "label": _text(row.get("label")) or _text(identity.get("label")) or _text(row.get("product_key")),
+            "channel": _text(row.get("channel")) or "stable",
+            "state_reason": _text(row.get("state_reason")),
+        }
+
+    def _build_promote_actions(self, *, product_key: str, snapshots: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        policy = self.approval_policy_service.resolve_policy(action_type="promote_snapshot", product_key=product_key)
+        actor_roles = self.approval_policy_service.resolve_actor_role_codes(self.env.user)
+        allowed = self.approval_policy_service.roles_match(actor_roles, list(_list(policy.get("allowed_executor_role_codes"))))
+        actions: list[dict[str, Any]] = []
+        for row in snapshots:
+            state = _text(row.get("state"))
+            if state not in {"candidate", "approved"}:
+                continue
+            snapshot_id = int(row.get("id") or 0)
+            if snapshot_id <= 0:
+                continue
+            actions.append(
+                {
+                    "write_model_contract_version": RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
+                    "key": f"promote:{snapshot_id}",
+                    "label": f"Promote {row.get('version') or 'v1'}",
+                    "intent": "release.operator.promote",
+                    "enabled": bool(allowed),
+                    "reason_code": "OK" if allowed else "RELEASE_EXECUTOR_NOT_ALLOWED",
+                    "params": {
+                        "product_key": product_key,
+                        "snapshot_id": snapshot_id,
+                        "replace_active": True,
+                    },
+                }
+            )
+        return actions
+
+    def _build_pending_approval_queue(self, *, product_key: str) -> dict[str, Any]:
+        actions = self.env["sc.release.action"].sudo().search(
+            [
+                ("product_key", "=", product_key),
+                ("active", "=", True),
+                ("approval_required", "=", True),
+                ("approval_state", "=", "pending_approval"),
+                ("state", "=", "pending"),
+            ],
+            order="requested_at desc, id desc",
+            limit=20,
+        )
+        rows: list[dict[str, Any]] = []
+        for action in actions:
+            payload = action.to_runtime_dict()
+            allowed, reason_code, diagnostics = self.approval_policy_service.can_approve(action=action, user=self.env.user)
+            rows.append(
+                {
+                    **payload,
+                    "can_approve": bool(allowed),
+                    "approve_reason_code": reason_code,
+                    "approve_diagnostics": diagnostics,
+                    "approve_intent": "release.operator.approve",
+                }
+            )
+        return {
+            "count": len(rows),
+            "write_model_contract_version": RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
+            "actions": rows,
+        }
+
+    def _build_rollback_action(self, *, product_key: str, active_snapshot: dict[str, Any]) -> dict[str, Any]:
+        policy = self.approval_policy_service.resolve_policy(action_type="rollback_snapshot", product_key=product_key)
+        actor_roles = self.approval_policy_service.resolve_actor_role_codes(self.env.user)
+        allowed = self.approval_policy_service.roles_match(actor_roles, list(_list(policy.get("allowed_executor_role_codes"))))
+        rollback_target_snapshot_id = int(active_snapshot.get("rollback_target_snapshot_id") or 0)
+        enabled = bool(allowed and rollback_target_snapshot_id > 0)
+        reason_code = "OK" if enabled else ("ROLLBACK_TARGET_NOT_FOUND" if rollback_target_snapshot_id <= 0 else "RELEASE_EXECUTOR_NOT_ALLOWED")
+        return {
+            "write_model_contract_version": RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
+            "key": f"rollback:{product_key}",
+            "label": "执行回滚",
+            "intent": "release.operator.rollback",
+            "enabled": enabled,
+            "reason_code": reason_code,
+            "params": {
+                "product_key": product_key,
+                "target_snapshot_id": rollback_target_snapshot_id,
+            },
+        }
+
+    def build_read_model(self, *, product_key: str = "", action_limit: int = 20) -> dict[str, Any]:
+        from .release_operator_contract_registry import build_release_operator_contract_registry
+
+        identity = self._resolve_identity(product_key=product_key)
+        audit = self.audit_service.build_audit_trail(product_key=identity["product_key"], action_limit=action_limit)
+        active_snapshot = _dict(audit.get("active_released_snapshot"))
+        release_actions = [row for row in _list(audit.get("release_actions")) if isinstance(row, dict)]
+        release_snapshots = [row for row in _list(audit.get("release_snapshots")) if isinstance(row, dict)]
+        candidate_snapshots = [
+            self._serialize_snapshot(row)
+            for row in release_snapshots
+            if _text(_dict(row).get("state")) in {"candidate", "approved"}
+        ]
+        release_history_summary = {
+            "actions": release_actions[:10],
+            "snapshots": [self._serialize_snapshot(row) for row in release_snapshots[:10]],
+        }
+        pending_approval_queue = self._build_pending_approval_queue(product_key=identity["product_key"])
+        current_release_state = {
+            "active_snapshot": self._serialize_snapshot(active_snapshot),
+            "runtime_summary": deepcopy(_dict(_dict(audit.get("runtime")).get("release_audit_trail_summary"))),
+            "released_snapshot_lineage": deepcopy(_dict(_dict(audit.get("runtime")).get("released_snapshot_lineage"))),
+        }
+        available_operator_actions = {
+            "write_model_contract_version": RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
+            "promote": self._build_promote_actions(product_key=identity["product_key"], snapshots=candidate_snapshots),
+            "rollback": self._build_rollback_action(product_key=identity["product_key"], active_snapshot=active_snapshot),
+        }
+        surface_copy = self._build_surface_copy(product_key=identity["product_key"])
+        return {
+            "contract_version": RELEASE_OPERATOR_READ_MODEL_CONTRACT_VERSION,
+            "contract_registry": build_release_operator_contract_registry(),
+            "copy": surface_copy,
+            "identity": {
+                "product_key": identity["product_key"],
+                "base_product_key": identity["base_product_key"],
+                "edition_key": identity["edition_key"],
+            },
+            "products": self._products(identity["product_key"]),
+            "current_release_state": current_release_state,
+            "pending_approval_queue": pending_approval_queue,
+            "candidate_snapshots": candidate_snapshots,
+            "release_history_summary": release_history_summary,
+            "available_operator_actions": available_operator_actions,
+        }

--- a/addons/smart_core/delivery/release_operator_surface_service.py
+++ b/addons/smart_core/delivery/release_operator_surface_service.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any
+
+from .release_operator_read_model_service import ReleaseOperatorReadModelService
+from .release_operator_contract_versions import RELEASE_OPERATOR_SURFACE_CONTRACT_VERSION
+
+
+
+class ReleaseOperatorSurfaceService:
+    def __init__(self, env):
+        self.env = env
+        self.read_model_service = ReleaseOperatorReadModelService(env)
+
+    def build_surface(self, *, product_key: str = "", action_limit: int = 20) -> dict[str, Any]:
+        from .release_operator_contract_registry import build_release_operator_contract_registry
+
+        read_model = self.read_model_service.build_read_model(product_key=product_key, action_limit=action_limit)
+        return {
+            "contract_version": RELEASE_OPERATOR_SURFACE_CONTRACT_VERSION,
+            "contract_registry": build_release_operator_contract_registry(),
+            "read_model_v1": read_model,
+            "copy": dict(read_model.get("copy") or {}),
+            "identity": dict(read_model.get("identity") or {}),
+            "products": list(read_model.get("products") or []),
+            "release_state": dict(read_model.get("current_release_state") or {}),
+            "pending_approval": dict(read_model.get("pending_approval_queue") or {}),
+            "candidate_snapshots": list(read_model.get("candidate_snapshots") or []),
+            "release_history": dict(read_model.get("release_history_summary") or {}),
+            "available_actions": dict(read_model.get("available_operator_actions") or {}),
+        }

--- a/addons/smart_core/delivery/scene_service.py
+++ b/addons/smart_core/delivery/scene_service.py
@@ -1,0 +1,94 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_core.core.scene_contract_builder import (
+    build_release_surface_scene_contract_from_delivery_entry,
+)
+from odoo.addons.smart_core.delivery.scene_snapshot_service import SceneSnapshotService
+
+
+class SceneService:
+    def __init__(self, env):
+        self.env = env
+        self.snapshot_service = SceneSnapshotService(env)
+
+    def build_entries(self, *, policy: dict, scenes: list[dict]) -> list[dict]:
+        scene_index = {}
+        binding_map = (
+            policy.get("scene_version_bindings") if isinstance(policy.get("scene_version_bindings"), dict) else {}
+        )
+        binding_diagnostics = (
+            policy.get("scene_binding_diagnostics") if isinstance(policy.get("scene_binding_diagnostics"), dict) else {}
+        )
+        for item in scenes or []:
+            if not isinstance(item, dict):
+                continue
+            scene_key = str(item.get("code") or item.get("key") or "").strip()
+            if scene_key and scene_key not in scene_index:
+                scene_index[scene_key] = item
+
+        entries: list[dict] = []
+        for row in policy.get("scenes") or []:
+            if not isinstance(row, dict):
+                continue
+            scene_key = str(row.get("scene_key") or "").strip()
+            if not scene_key:
+                continue
+            source = scene_index.get(scene_key) or {}
+            target = source.get("target") if isinstance(source.get("target"), dict) else {}
+            route = str(target.get("route") or row.get("route") or f"/s/{scene_key}").strip()
+            label = str(
+                row.get("label")
+                or source.get("name")
+                or source.get("title")
+                or source.get("label")
+                or scene_key
+            ).strip()
+            standard_contract = build_release_surface_scene_contract_from_delivery_entry(
+                {
+                    "scene_key": scene_key,
+                    "label": label,
+                    "description": str(row.get("description") or source.get("description") or "").strip(),
+                    "scope": str(row.get("scope") or source.get("scope") or "").strip(),
+                    "route": route,
+                    "product_key": str(row.get("product_key") or "").strip(),
+                    "capability_key": str(row.get("capability_key") or "").strip(),
+                    "requires_project_context": bool(row.get("requires_project_context", False)),
+                    "state": "present" if source else "policy_only",
+                }
+            )
+            snapshot_binding = binding_map.get(scene_key) if isinstance(binding_map.get(scene_key), dict) else {}
+            snapshot, snapshot_diagnostics = self.snapshot_service.resolve_snapshot_with_diagnostics(
+                scene_key=scene_key,
+                product_key=str(row.get("product_key") or "").strip(),
+                binding=snapshot_binding,
+            )
+            snapshot_contract = snapshot.get("contract_json") if isinstance(snapshot.get("contract_json"), dict) else {}
+            entries.append(
+                {
+                    "scene_key": scene_key,
+                    "label": label,
+                    "route": route,
+                    "product_key": str(row.get("product_key") or "").strip(),
+                    "capability_key": str(row.get("capability_key") or "").strip(),
+                    "requires_project_context": bool(row.get("requires_project_context", False)),
+                    "state": "present" if source else "policy_only",
+                    "source": "delivery_engine_v1",
+                    "scene_contract_standard_v1": snapshot_contract or standard_contract,
+                    "scene_asset_binding": {
+                        "version": str(snapshot_binding.get("version") or "v1").strip() or "v1",
+                        "channel": str(snapshot_binding.get("channel") or "stable").strip() or "stable",
+                        "resolved": bool(snapshot),
+                        "snapshot_id": int(snapshot.get("id") or 0),
+                        "snapshot_state": str(snapshot.get("state") or snapshot_diagnostics.get("snapshot_state") or "").strip(),
+                        "snapshot_fallback_reason": str(snapshot_diagnostics.get("snapshot_fallback_reason") or "").strip(),
+                        "binding_allowed": bool(_binding_diag(binding_diagnostics, scene_key).get("binding_allowed", False)),
+                    },
+                }
+            )
+        return entries
+
+
+def _binding_diag(diags: dict, scene_key: str) -> dict:
+    row = diags.get(scene_key)
+    return row if isinstance(row, dict) else {}

--- a/addons/smart_core/handlers/execute_button.py
+++ b/addons/smart_core/handlers/execute_button.py
@@ -23,7 +23,7 @@ _logger = logging.getLogger(__name__)
 class ExecuteButtonHandler(BaseIntentHandler):
     INTENT_TYPE = "execute_button"
     DESCRIPTION = "执行模型按钮方法"
-    REQUIRED_GROUPS = ["smart_core.group_smart_core_data_operator"]
+    REQUIRED_GROUPS = []
     ACL_MODE = "explicit_check"
     NON_IDEMPOTENT_ALLOWED = "button methods can trigger business side effects beyond replay-safe scope"
 
@@ -45,7 +45,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                     model=model,
                     res_id=res_ids[0] if res_ids else None,
                     reason_code=REASON_MISSING_PARAMS,
-                    message="缺少参数 model/button.name/res_id",
+                    message="后端未收到完整按钮执行参数",
                     trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                     status_code=400,
                 )
@@ -55,7 +55,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                     model=model,
                     res_id=res_ids[0],
                     reason_code=REASON_UNSUPPORTED_BUTTON_TYPE,
-                    message=f"不支持的按钮类型: {button_type}",
+                    message=f"后端不支持按钮类型: {button_type}",
                     trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                     status_code=400,
                 )
@@ -68,7 +68,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                     model=model,
                     res_id=res_ids[0],
                     reason_code=REASON_NOT_FOUND,
-                    message="记录不存在",
+                    message="后端未找到目标记录",
                     trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                     status_code=404,
                 )
@@ -81,7 +81,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                     model=model,
                     res_id=res_ids[0],
                     reason_code=REASON_METHOD_NOT_CALLABLE,
-                    message=f"方法不可调用: {method_name}",
+                    message=f"后端不可调用按钮方法: {method_name}",
                     trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                     status_code=400,
                 )
@@ -92,7 +92,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                     "status": "success",
                     "success": True,
                     "reason_code": REASON_DRY_RUN,
-                    "message": "Dry run completed",
+                    "message": "后端已完成 dry run 校验",
                     "res_model": model,
                     "res_id": res_ids[0],
                     "method": method_name,
@@ -115,7 +115,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                 "status": "success",
                 "success": True,
                 "reason_code": REASON_OK,
-                "message": "Action executed successfully",
+                "message": "后端已执行动作",
                 "res_model": model,
                 "res_id": res_ids[0],
             }
@@ -171,7 +171,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                 model=model,
                 res_id=res_ids[0] if res_ids else None,
                 reason_code=REASON_PERMISSION_DENIED,
-                message=str(exc) or "Permission denied",
+                message=str(exc) or "后端拒绝本次按钮执行",
                 trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                 status_code=403,
             )
@@ -180,7 +180,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                 model=model,
                 res_id=res_ids[0] if res_ids else None,
                 reason_code=REASON_BUSINESS_RULE_FAILED,
-                message=str(exc) or "Business rule failed",
+                message=str(exc) or "后端业务规则拒绝本次按钮执行",
                 trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                 status_code=400,
             )
@@ -190,7 +190,7 @@ class ExecuteButtonHandler(BaseIntentHandler):
                 model=model,
                 res_id=res_ids[0] if res_ids else None,
                 reason_code=REASON_SYSTEM_ERROR,
-                message="Action execution failed",
+                message="后端执行按钮动作失败",
                 trace_id=self.context.get("trace_id") if isinstance(self.context, dict) else "",
                 status_code=500,
             )

--- a/addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py
+++ b/addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_core.core.industry_orchestration_service_adapter import (
+    build_cost_tracking_service,
+)
+from odoo.addons.smart_core.orchestration.base_scene_entry_orchestrator import BaseSceneEntryOrchestrator
+
+
+class CostTrackingContractOrchestrator(BaseSceneEntryOrchestrator):
+    scene_key = "cost.tracking"
+    scene_label = "成本记录"
+    state_fallback_text = "后端未提供成本记录状态摘要"
+    title_empty = "成本记录"
+    suggested_action_key = "load_cost_entry"
+    suggested_action_reason_code = "COST_SLICE_PREPARED_READY"
+    block_fetch_intent = "cost.tracking.block.fetch"
+    entry_summary_keys = (
+        "project_code",
+        "manager_name",
+        "stage_name",
+        "cost_record_count",
+        "cost_total_amount",
+    )
+    entry_blocks = (
+        ("cost_entry", "成本录入", "deferred"),
+        ("cost_list", "成本记录", "deferred"),
+        ("cost_summary", "成本汇总", "deferred"),
+        ("next_actions", "成本下一步", "deferred"),
+    )
+
+    def __init__(self, env):
+        super().__init__(env, build_cost_tracking_service(env))
+
+    def resolve_first_action(self, runtime_fetch_hints):
+        blocks = runtime_fetch_hints.get("blocks") if isinstance(runtime_fetch_hints.get("blocks"), dict) else {}
+        return blocks.get("cost_entry") or blocks.get("cost_list") or {}
+
+    def resolve_title(self, project_payload):
+        return "成本记录：%s" % str(project_payload.get("name") or "项目")

--- a/addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py
+++ b/addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_core.core.industry_orchestration_service_adapter import (
+    build_project_dashboard_service,
+)
+from odoo.addons.smart_core.orchestration.base_scene_entry_orchestrator import (
+    BaseSceneEntryOrchestrator,
+)
+
+
+class ProjectDashboardSceneOrchestrator(BaseSceneEntryOrchestrator):
+    scene_key = "project.management"
+    scene_label = "项目驾驶舱"
+    state_fallback_text = "后端未提供项目驾驶舱状态摘要"
+    title_empty = "项目驾驶舱"
+    suggested_action_key = "load_dashboard_progress"
+    suggested_action_reason_code = "PROJECT_DASHBOARD_READY"
+    block_fetch_intent = "project.dashboard.block.fetch"
+    block_alias_map = {"risk": "risks"}
+    entry_summary_keys = (
+        "project_code",
+        "manager_name",
+        "partner_name",
+        "stage_name",
+        "lifecycle_state",
+        "milestone",
+        "health_state",
+        "progress_percent",
+        "cost_total",
+        "payment_total",
+        "status",
+    )
+    entry_blocks = (
+        ("progress", "项目进度", "deferred"),
+        ("risks", "风险提醒", "deferred"),
+        ("next_actions", "下一步动作", "deferred"),
+    )
+
+    def __init__(self, env):
+        super().__init__(env, build_project_dashboard_service(env))
+
+    def resolve_first_action(self, runtime_fetch_hints):
+        blocks = runtime_fetch_hints.get("blocks") if isinstance(runtime_fetch_hints.get("blocks"), dict) else {}
+        return blocks.get("progress") or {}
+
+    def resolve_title(self, project_payload):
+        return "项目驾驶舱：%s" % str(project_payload.get("name") or "项目")

--- a/addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py
+++ b/addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from odoo.addons.smart_core.core.industry_orchestration_service_adapter import (
+    build_project_plan_bootstrap_service,
+)
+from odoo.addons.smart_core.orchestration.base_scene_entry_orchestrator import (
+    BaseSceneEntryOrchestrator,
+)
+
+
+class ProjectPlanBootstrapSceneOrchestrator(BaseSceneEntryOrchestrator):
+    scene_key = "project.plan_bootstrap"
+    scene_label = "计划准备"
+    state_fallback_text = "后端未提供计划准备状态摘要"
+    title_empty = "计划编排"
+    suggested_action_key = "load_plan_next_actions"
+    suggested_action_reason_code = "PROJECT_PLAN_BOOTSTRAP_READY"
+    block_fetch_intent = "project.plan_bootstrap.block.fetch"
+    entry_summary_keys = (
+        "project_code",
+        "manager_name",
+        "stage_name",
+        "date_start",
+        "date_end",
+    )
+    entry_blocks = (
+        ("plan_summary_detail", "计划摘要", "deferred"),
+        ("plan_tasks", "计划任务", "deferred"),
+        ("next_actions", "计划下一步", "deferred"),
+    )
+
+    def __init__(self, env):
+        super().__init__(env, build_project_plan_bootstrap_service(env))
+
+    def resolve_first_action(self, runtime_fetch_hints):
+        blocks = runtime_fetch_hints.get("blocks") if isinstance(runtime_fetch_hints.get("blocks"), dict) else {}
+        return blocks.get("next_actions") or blocks.get("plan_summary_detail") or {}
+
+    def resolve_title(self, project_payload):
+        return "计划准备：%s" % str(project_payload.get("name") or "项目")

--- a/addons/smart_core/tests/__init__.py
+++ b/addons/smart_core/tests/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-from . import test_action_dispatcher_server_mapping
-from . import test_scene_nav_contract_builder
-from . import test_scene_delivery_policy
-from . import test_scene_runtime_contract_chain
+"""
+smart_core tests package
+
+Keep package import side effects minimal so isolated pure-Python unittest
+modules can be executed without a live Odoo runtime. Odoo transaction-style
+tests remain discoverable by explicit module import in Odoo test execution.
+"""

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-DELIVERY-ORCHESTRATION-TAIL-PA90.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-DELIVERY-ORCHESTRATION-TAIL-PA90.yaml
@@ -1,0 +1,50 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-DELIVERY-ORCHESTRATION-TAIL-PA90
+title: Split residual smart_core delivery orchestration tail from 56b7eba
+objective: >
+  Isolate the remaining smart_core delivery/operator/orchestration tail from
+  commit 56b7eba into a bounded child batch for mainline review.
+context:
+  layer_target: Platform Layer
+  module: smart_core
+  module_ownership: Platform kernel
+  kernel_or_scenario: kernel
+  architecture_reason: >
+    This batch carries release-operator delivery helpers, scene-service policy
+    supply, and bounded scene orchestrator wiring that still belongs to
+    smart_core. It must remain separate from construction scene assets and
+    construction entry handlers.
+scope:
+  allowed_paths:
+    - addons/smart_core/__init__.py
+    - addons/smart_core/delivery/product_policy_service.py
+    - addons/smart_core/delivery/release_operator_read_model_service.py
+    - addons/smart_core/delivery/release_operator_surface_service.py
+    - addons/smart_core/delivery/scene_service.py
+    - addons/smart_core/handlers/execute_button.py
+    - addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py
+    - addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py
+    - addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py
+    - addons/smart_core/tests/__init__.py
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-SMART-CORE-DELIVERY-ORCHESTRATION-TAIL-PA90.yaml
+  forbidden_paths:
+    - addons/smart_core/**/payment*
+    - addons/smart_core/**/settlement*
+    - addons/smart_core/**/account*
+    - addons/smart_construction_scene/**
+    - addons/smart_construction_core/**
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_core/delivery/product_policy_service.py addons/smart_core/delivery/release_operator_read_model_service.py addons/smart_core/delivery/release_operator_surface_service.py addons/smart_core/delivery/scene_service.py addons/smart_core/handlers/execute_button.py addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Split the remaining smart_core delivery/orchestration tail from `56b7eba` out of residual umbrella PR #577.

This PR isolates release-operator delivery helpers, scene-service policy supply, execute-button wiring, and bounded smart_core orchestrators without carrying construction scene assets or construction entry handlers.

## Scope

- `addons/smart_core/__init__.py`
- `addons/smart_core/delivery/product_policy_service.py`
- `addons/smart_core/delivery/release_operator_read_model_service.py`
- `addons/smart_core/delivery/release_operator_surface_service.py`
- `addons/smart_core/delivery/scene_service.py`
- `addons/smart_core/handlers/execute_button.py`
- `addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py`
- `addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py`
- `addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py`
- `addons/smart_core/tests/__init__.py`

## Architecture Impact

- Layer Target: Platform Layer
- Affected Modules: `smart_core`
- Reason: recover the remaining platform delivery/operator/orchestrator tail into a bounded child slice after #587 and #588

## Verify

- `python3 -m py_compile addons/smart_core/delivery/product_policy_service.py addons/smart_core/delivery/release_operator_read_model_service.py addons/smart_core/delivery/release_operator_surface_service.py addons/smart_core/delivery/scene_service.py addons/smart_core/handlers/execute_button.py addons/smart_core/orchestration/cost_tracking_contract_orchestrator.py addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py addons/smart_core/orchestration/project_plan_bootstrap_scene_orchestrator.py`

## Relation

- parent residual umbrella: #577
- predecessor merged splits: #578 #579 #580 #581 #582 #583 #584 #585 #586
- predecessor residual slices: #587 #588 #589 #590
