### PR TITLE
[split] construction scene asset entry tail

### DIFF
--- a/addons/smart_construction_core/handlers/cost_tracking_enter.py
+++ b/addons/smart_construction_core/handlers/cost_tracking_enter.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+from odoo.addons.smart_core.core.base_handler import BaseIntentHandler
+from odoo.addons.smart_core.core.scene_contract_builder import attach_release_surface_scene_contract
+from odoo.addons.smart_construction_core.services.project_context_contract import (
+    attach_project_context_to_scene_payload,
+)
+from odoo.addons.smart_core.orchestration.cost_tracking_contract_orchestrator import (
+    CostTrackingContractOrchestrator,
+)
+from odoo.addons.smart_construction_scene.services.project_management_entry_target import (
+    resolve_project_management_entry_target,
+)
+
+
+class CostTrackingEnterHandler(BaseIntentHandler):
+    INTENT_TYPE = "cost.tracking.enter"
+    DESCRIPTION = "返回成本跟踪最小 scene-ready contract"
+    VERSION = "1.0.0"
+    ETAG_ENABLED = False
+    REQUIRED_GROUPS = ["base.group_user"]
+
+    @staticmethod
+    def _coerce_project_id(raw: Any) -> int:
+        try:
+            value = int(raw or 0)
+        except Exception:
+            return 0
+        return value if value > 0 else 0
+
+    def _resolve_project_id(self, params: Dict[str, Any], ctx: Dict[str, Any]) -> int:
+        candidates = [
+            (params or {}).get("project_id"),
+            (params or {}).get("record_id"),
+            ((params or {}).get("project_context") or {}).get("project_id")
+            if isinstance((params or {}).get("project_context"), dict)
+            else None,
+            (ctx or {}).get("project_id"),
+            (ctx or {}).get("record_id"),
+        ]
+        for item in candidates:
+            project_id = self._coerce_project_id(item)
+            if project_id > 0:
+                return project_id
+        return 0
+
+    def handle(self, payload=None, ctx=None):
+        ts0 = time.time()
+        params = payload or self.params or {}
+        if isinstance(params, dict) and isinstance(params.get("params"), dict):
+            params = params.get("params") or {}
+        ctx = ctx or {}
+
+        project_id = self._resolve_project_id(params, ctx)
+        orchestrator = CostTrackingContractOrchestrator(self.env)
+        data = orchestrator.build_entry(project_id=project_id, context=ctx)
+        project, _diag = orchestrator._service.resolve_project_with_diagnostics(project_id)
+        data = attach_project_context_to_scene_payload(data, project)
+        data["summary_rows"] = orchestrator._service.build_summary_rows(project)
+        target = resolve_project_management_entry_target(self.env)
+        data = attach_release_surface_scene_contract(
+            data,
+            product_key="fr3",
+            capability="delivery.fr3.cost_tracking",
+            route=str(target.get("route") or ""),
+            diagnostics_ref=self.INTENT_TYPE,
+            trace_id=str((self.context or {}).get("trace_id") or ""),
+        )
+        if int(data.get("project_id") or 0) <= 0:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "PROJECT_NOT_FOUND",
+                    "message": "项目不存在或当前账号不可访问",
+                    "suggested_action": "fix_input",
+                },
+                "meta": {
+                    "intent": self.INTENT_TYPE,
+                    "elapsed_ms": int((time.time() - ts0) * 1000),
+                    "trace_id": str((self.context or {}).get("trace_id") or ""),
+                },
+            }
+
+        return {
+            "ok": True,
+            "data": data,
+            "meta": {
+                "intent": self.INTENT_TYPE,
+                "elapsed_ms": int((time.time() - ts0) * 1000),
+                "trace_id": str((self.context or {}).get("trace_id") or ""),
+            },
+        }

--- a/addons/smart_construction_core/handlers/project_dashboard_enter.py
+++ b/addons/smart_construction_core/handlers/project_dashboard_enter.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import time
+from typing import Any, Dict
+
+from odoo.addons.smart_core.core.base_handler import BaseIntentHandler
+from odoo.addons.smart_core.core.scene_contract_builder import attach_release_surface_scene_contract
+from odoo.addons.smart_construction_core.services.project_context_contract import (
+    attach_project_context_to_scene_payload,
+)
+from odoo.addons.smart_core.orchestration.project_dashboard_scene_orchestrator import (
+    ProjectDashboardSceneOrchestrator,
+)
+from odoo.addons.smart_construction_core.handlers.reason_codes import REASON_PROJECT_NOT_FOUND
+from odoo.addons.smart_construction_scene.services.project_management_entry_target import (
+    resolve_project_management_entry_target,
+)
+from odoo.exceptions import AccessError
+
+
+class ProjectDashboardEnterHandler(BaseIntentHandler):
+    INTENT_TYPE = "project.dashboard.enter"
+    DESCRIPTION = "返回项目驾驶舱最小 scene-ready contract"
+    VERSION = "1.0.0"
+    ETAG_ENABLED = False
+    REQUIRED_GROUPS = ["base.group_user"]
+
+    @staticmethod
+    def _coerce_project_id(raw: Any) -> int:
+        try:
+            value = int(raw or 0)
+        except Exception:
+            return 0
+        return value if value > 0 else 0
+
+    def _resolve_project_id(self, params: Dict[str, Any], ctx: Dict[str, Any]) -> int:
+        candidates = [
+            (params or {}).get("project_id"),
+            (params or {}).get("record_id"),
+            ((params or {}).get("project_context") or {}).get("project_id")
+            if isinstance((params or {}).get("project_context"), dict)
+            else None,
+            (ctx or {}).get("project_id"),
+            (ctx or {}).get("record_id"),
+        ]
+        for item in candidates:
+            project_id = self._coerce_project_id(item)
+            if project_id > 0:
+                return project_id
+        return 0
+
+    @staticmethod
+    def _fallback_lifecycle_hints() -> Dict[str, Any]:
+        return {
+            "stage": "project_not_found",
+            "first_action": "create_project",
+            "primary_action_label": "创建项目",
+            "suggested_action_intent": "project.initiation.enter",
+            "suggested_action_title": "创建项目",
+        }
+
+    def handle(self, payload=None, ctx=None):
+        ts0 = time.time()
+        params = payload or self.params or {}
+        if isinstance(params, dict) and isinstance(params.get("params"), dict):
+            params = params.get("params") or {}
+        ctx = ctx or {}
+
+        project_id = self._resolve_project_id(params, ctx)
+        try:
+            orchestrator = ProjectDashboardSceneOrchestrator(self.env)
+            data = orchestrator.build_entry(project_id=project_id, context=ctx)
+            project, _diag = orchestrator._service.resolve_project_with_diagnostics(project_id)
+            project_for_payload = project
+            if project:
+                try:
+                    project_for_payload = project.sudo()
+                except Exception:
+                    project_for_payload = project
+            project_payload = orchestrator._service.project_payload(project_for_payload)
+            data = attach_project_context_to_scene_payload(data, project_for_payload)
+            data["state_explain"] = orchestrator._service.build_state_explain(project_for_payload)
+            data["metrics_explain"] = orchestrator._service.build_metrics_explain(project_for_payload)
+            data["flow_map"] = orchestrator._service.build_flow_map(project_for_payload)
+            data["completion"] = orchestrator._service.build_completion(project_for_payload)
+            data["summary_rows"] = orchestrator._service.build_summary_rows(project_for_payload)
+            data["evidence_refs"] = list((project_payload.get("evidence_refs") or []))
+            data["facts"] = dict(project_payload.get("facts") or {})
+            data["fact_metrics"] = list((project_payload.get("fact_metrics") or []))
+            target = resolve_project_management_entry_target(self.env)
+            data = attach_release_surface_scene_contract(
+                data,
+                product_key="fr2",
+                capability="delivery.fr2.project_flow",
+                route=str(target.get("route") or ""),
+                diagnostics_ref=self.INTENT_TYPE,
+                trace_id=str((self.context or {}).get("trace_id") or ""),
+            )
+        except AccessError as exc:
+            message = str(exc or "")
+            if "project.project" not in message or "stage_id" not in message:
+                raise
+            orchestrator = ProjectDashboardSceneOrchestrator(self.env.sudo())
+            data = orchestrator.build_entry(project_id=project_id, context=ctx)
+            target = resolve_project_management_entry_target(self.env.sudo())
+            data = attach_release_surface_scene_contract(
+                data,
+                product_key="fr2",
+                capability="delivery.fr2.project_flow",
+                route=str(target.get("route") or ""),
+                diagnostics_ref=self.INTENT_TYPE,
+                trace_id=str((self.context or {}).get("trace_id") or ""),
+            )
+            data["degraded_reason"] = "project_stage_access_fallback"
+        if int(data.get("project_id") or 0) <= 0:
+            lifecycle_hints = dict((data or {}).get("lifecycle_hints") or {})
+            if not lifecycle_hints:
+                lifecycle_hints = self._fallback_lifecycle_hints()
+            return {
+                "ok": False,
+                "error": {
+                    "code": "PROJECT_NOT_FOUND",
+                    "message": "项目不存在或当前账号不可访问",
+                    "suggested_action": "fix_input",
+                },
+                "data": {
+                    "lifecycle_hints": lifecycle_hints,
+                    "suggested_action_payload": {
+                        "intent": "project.initiation.enter",
+                        "reason_code": REASON_PROJECT_NOT_FOUND,
+                        "params": {
+                            "reason_code": REASON_PROJECT_NOT_FOUND,
+                        },
+                    },
+                },
+                "meta": {
+                    "intent": self.INTENT_TYPE,
+                    "elapsed_ms": int((time.time() - ts0) * 1000),
+                    "trace_id": str((self.context or {}).get("trace_id") or ""),
+                },
+            }
+
+        return {
+            "ok": True,
+            "data": data,
+            "meta": {
+                "intent": self.INTENT_TYPE,
+                "elapsed_ms": int((time.time() - ts0) * 1000),
+                "trace_id": str((self.context or {}).get("trace_id") or ""),
+            },
+        }

--- a/addons/smart_construction_scene/__init__.py
+++ b/addons/smart_construction_scene/__init__.py
@@ -1,4 +1,25 @@
 # -*- coding: utf-8 -*-
 from . import scene_registry  # noqa: F401
 
-from . import models  # noqa: F401
+try:
+    from . import models  # noqa: F401
+    from . import core_extension  # noqa: F401
+except ModuleNotFoundError as exc:
+    # Pure-Python semantic-supply tests import the package without an Odoo
+    # runtime. In that mode the package must still be importable so the test
+    # module can load its own isolated fixtures.
+    if exc.name != "odoo":
+        raise
+else:
+    from .core_extension import (  # noqa: F401
+        get_intent_handler_contributions,
+        smart_core_extend_system_init,
+        smart_core_identity_profile,
+        smart_core_nav_scene_maps,
+        smart_core_surface_nav_allowlist,
+        smart_core_surface_deep_link_allowlist,
+        smart_core_surface_policy_default_name,
+        smart_core_surface_policy_file_default,
+        smart_core_critical_scene_target_overrides,
+        smart_core_critical_scene_target_route_overrides,
+    )

--- a/addons/smart_construction_scene/data/project_management_scene.xml
+++ b/addons/smart_construction_scene/data/project_management_scene.xml
@@ -19,7 +19,8 @@
                 'layout': {'kind': 'workspace', 'sidebar': 'fixed', 'header': 'full'},
                 'target': {
                     'route': '/s/project.management',
-                    'menu_xmlid': 'smart_construction_core.menu_sc_project_management_scene'
+                    'menu_xmlid': 'smart_construction_core.menu_sc_project_management_scene',
+                    'action_xmlid': 'smart_construction_core.action_project_dashboard'
                 },
                 'related_scenes': [
                     'projects.intake',
@@ -70,7 +71,7 @@
                             {
                                 'key': 'block.project.header',
                                 'block_type': 'record_summary',
-                                'capability_key': 'project.dashboard.open'
+                                'capability_key': 'project.dashboard.enter'
                             }
                         ]
                     },
@@ -84,7 +85,7 @@
                             {
                                 'key': 'block.project.metrics',
                                 'block_type': 'metric_row',
-                                'capability_key': 'project.dashboard.open'
+                                'capability_key': 'project.dashboard.enter'
                             }
                         ]
                     },

--- a/addons/smart_construction_scene/data/sc_scene_layout.xml
+++ b/addons/smart_construction_scene/data/sc_scene_layout.xml
@@ -117,6 +117,71 @@
             <field name="active_version_id" ref="sc_scene_version_projects_intake_v2"/>
         </record>
 
+        <!-- Project initiation product scene -->
+        <record id="sc_scene_version_project_initiation_v1" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_projects_intake"/>
+            <field name="version">v1</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'project.initiation',
+                'name': '项目立项（产品场景）',
+                'version': 'v1',
+                'page': {
+                    'key': 'project.initiation.form',
+                    'title': '项目立项',
+                    'page_type': 'record',
+                    'page_mode': 'form'
+                },
+                'layout': {'kind': 'record', 'sidebar': 'fixed', 'header': 'full'},
+                'zone_blocks': [
+                    {
+                        'key': 'hero',
+                        'title': '立项概览',
+                        'zone_type': 'hero',
+                        'display_mode': 'stack',
+                        'block_key': 'block.projects.intake.hero'
+                    },
+                    {
+                        'key': 'form_main',
+                        'title': '立项信息',
+                        'zone_type': 'primary',
+                        'display_mode': 'form',
+                        'block_key': 'block.projects.intake.form'
+                    }
+                ],
+                'form_profile': {
+                    'model': 'project.project',
+                    'view_type': 'form',
+                    'mode': 'create_first',
+                    'primary_fields': [
+                        'name',
+                        'manager_id',
+                        'date_start',
+                        'description'
+                    ],
+                    'required_fields': [
+                        'name'
+                    ],
+                    'submit_action': 'project.initiation.enter'
+                },
+                'action_specs': {
+                    'submit': {
+                        'label': '提交立项',
+                        'intent': 'project.initiation.enter'
+                    }
+                },
+                'target': {
+                    'route': '/s/project.initiation',
+                    'menu_xmlid': 'smart_construction_core.menu_sc_project_initiation',
+                    'action_xmlid': 'smart_construction_core.action_project_initiation'
+                }
+            }"/>
+        </record>
+
+        <record id="sc_scene_projects_intake" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_project_initiation_v1"/>
+        </record>
+
         <!-- Portal lifecycle scene -->
         <record id="sc_scene_version_portal_lifecycle_v2" model="sc.scene.version">
             <field name="scene_id" ref="sc_scene_portal_lifecycle"/>
@@ -282,7 +347,7 @@
                     'stage': 'wave3'
                 },
                 'target': {
-                    'route': '/s/project.management'
+                    'route': '/s/portal.capability_matrix'
                 }
             }"/>
         </record>
@@ -506,8 +571,7 @@
                 ],
                 'target': {
                     'route': '/s/contract.center',
-                    'menu_xmlid': 'smart_construction_core.menu_sc_contract_center',
-                    'action_xmlid': 'smart_construction_core.action_construction_contract_my'
+                    'menu_xmlid': 'smart_construction_core.menu_sc_contract_center'
                 },
                 'list_profile': {
                     'model': 'construction.contract',
@@ -1005,6 +1069,87 @@
 
         <record id="sc_scene_projects_dashboard" model="sc.scene">
             <field name="active_version_id" ref="sc_scene_version_projects_dashboard_v2"/>
+        </record>
+
+        <!-- Product project dashboard scene -->
+        <record id="sc_scene_version_project_dashboard_v1" model="sc.scene.version">
+            <field name="scene_id" ref="sc_scene_projects_dashboard"/>
+            <field name="version">v1</field>
+            <field name="source">system</field>
+            <field name="payload_json" eval="{
+                'code': 'project.dashboard',
+                'name': '项目驾驶舱（产品场景）',
+                'version': 'v1',
+                'page': {
+                    'key': 'project.dashboard.main',
+                    'title': '项目驾驶舱',
+                    'page_type': 'dashboard',
+                    'page_mode': 'dashboard'
+                },
+                'layout': {'kind': 'workspace', 'sidebar': 'fixed', 'header': 'full'},
+                'zone_blocks': [
+                    {
+                        'key': 'summary',
+                        'title': '项目概览',
+                        'zone_type': 'hero',
+                        'display_mode': 'stack',
+                        'block_key': 'block.projects.dashboard.summary'
+                    },
+                    {
+                        'key': 'progress',
+                        'title': '执行进展',
+                        'zone_type': 'primary',
+                        'display_mode': 'stack',
+                        'block_key': 'block.projects.dashboard.progress'
+                    },
+                    {
+                        'key': 'next_actions',
+                        'title': '下一步动作',
+                        'zone_type': 'supporting',
+                        'display_mode': 'list',
+                        'block_key': 'block.projects.dashboard.next_actions'
+                    }
+                ],
+                'related_scenes': ['project.initiation', 'projects.list', 'project.management'],
+                'action_specs': {
+                    'open_project_list': {
+                        'label': '查看项目列表',
+                        'intent': 'ui.contract'
+                    },
+                    'open_project_management': {
+                        'label': '进入项目管理',
+                        'intent': 'ui.contract'
+                    }
+                },
+                'data_sources': {
+                    'project_dashboard_summary': {
+                        'source_type': 'computed',
+                        'provider': 'project.dashboard.summary'
+                    },
+                    'project_dashboard_progress': {
+                        'source_type': 'computed',
+                        'provider': 'project.dashboard.progress'
+                    },
+                    'project_dashboard_next_actions': {
+                        'source_type': 'computed',
+                        'provider': 'project.dashboard.next_actions'
+                    }
+                },
+                'product_policy': {
+                    'role_based': True,
+                    'primary_action': 'open_project_management',
+                    'stage': 'phase12c'
+                },
+                'target': {
+                    'route': '/s/project.dashboard',
+                    'action_xmlid': 'smart_construction_core.action_project_dashboard',
+                    'menu_xmlid': 'smart_construction_core.menu_sc_project_dashboard'
+                }
+            }"/>
+        </record>
+
+        <record id="sc_scene_projects_dashboard" model="sc.scene">
+            <field name="active_version_id" ref="sc_scene_version_project_dashboard_v1"/>
         </record>
 
         <!-- Project dashboard showcase scene -->

--- a/addons/smart_construction_scene/data/sc_scene_list_profile.xml
+++ b/addons/smart_construction_scene/data/sc_scene_list_profile.xml
@@ -50,11 +50,12 @@
                     'view_type': 'list',
                     'columns': [
                         'name',
-                        'stage_id',
                         'user_id',
-                        'dashboard_invoice_amount',
                         'partner_id',
-                        'write_date'
+                        'stage_id',
+                        'lifecycle_state',
+                        'date_start',
+                        'date'
                     ],
                     'hidden_columns': [
                         'message_needaction',
@@ -64,12 +65,13 @@
                         '__last_update'
                     ],
                     'column_labels': {
-                        'name': '项目名称',
-                        'stage_id': '状态',
-                        'user_id': '负责人',
-                        'dashboard_invoice_amount': '合同额',
-                        'partner_id': '建设单位',
-                        'write_date': '更新时间'
+                        'name': '名称',
+                        'user_id': '项目管理员',
+                        'partner_id': '客户',
+                        'stage_id': '阶段',
+                        'lifecycle_state': '项目状态',
+                        'date_start': '开始日期',
+                        'date': '有效期'
                     },
                     'row_primary': 'name',
                     'row_secondary': 'partner_id'
@@ -125,7 +127,7 @@
             <field name="source">system</field>
             <field name="payload_json" eval="{
                 'code': 'projects.ledger',
-                'name': '项目台账（试点）',
+                'name': '项目台账',
                 'version': 'v2',
                 'page': {
                     'key': 'projects.ledger.main',

--- a/addons/smart_construction_scene/data/sc_scene_orchestration.xml
+++ b/addons/smart_construction_scene/data/sc_scene_orchestration.xml
@@ -1,6 +1,121 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <odoo>
     <data noupdate="0">
+        <!-- Capability groups and capabilities are owned by scene orchestration. -->
+        <record id="smart_construction_core.sc_cap_group_project_management" model="sc.capability.group">
+            <field name="sequence">10</field>
+            <field name="key">project_management</field>
+            <field name="label">项目管理</field>
+            <field name="icon">briefcase</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_contract_management" model="sc.capability.group">
+            <field name="sequence">20</field>
+            <field name="key">contract_management</field>
+            <field name="label">合同管理</field>
+            <field name="icon">file-text</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_cost_management" model="sc.capability.group">
+            <field name="sequence">30</field>
+            <field name="key">cost_management</field>
+            <field name="label">成本管理</field>
+            <field name="icon">calculator</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_finance_management" model="sc.capability.group">
+            <field name="sequence">40</field>
+            <field name="key">finance_management</field>
+            <field name="label">财务管理</field>
+            <field name="icon">wallet</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_material_management" model="sc.capability.group">
+            <field name="sequence">50</field>
+            <field name="key">material_management</field>
+            <field name="label">物资管理</field>
+            <field name="icon">boxes</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_governance" model="sc.capability.group">
+            <field name="sequence">60</field>
+            <field name="key">governance</field>
+            <field name="label">治理配置</field>
+            <field name="icon">shield</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_analytics" model="sc.capability.group">
+            <field name="sequence">70</field>
+            <field name="key">analytics</field>
+            <field name="label">经营分析</field>
+            <field name="icon">chart</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_group_others" model="sc.capability.group">
+            <field name="sequence">80</field>
+            <field name="key">others</field>
+            <field name="label">其他能力</field>
+            <field name="icon">grid</field>
+        </record>
+
+        <record id="smart_construction_core.sc_cap_project_work" model="sc.capability">
+            <field name="sequence">10</field>
+            <field name="key">project.board.open</field>
+            <field name="name">项目工作</field>
+            <field name="group_id" ref="smart_construction_core.sc_cap_group_project_management"/>
+            <field name="ui_label">项目工作</field>
+            <field name="ui_hint">项目看板与概览入口</field>
+            <field name="intent">ui.contract</field>
+            <field name="default_payload" eval="{'action_xmlid': 'smart_construction_core.action_sc_project_kanban_lifecycle', 'menu_xmlid': 'smart_construction_core.menu_sc_project_project'}"/>
+            <field name="required_group_ids" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_project_read')])]"/>
+            <field name="tags">project</field>
+            <field name="status">ga</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_capability_matrix" model="sc.capability">
+            <field name="sequence">20</field>
+            <field name="key">governance.capability.matrix</field>
+            <field name="name">能力矩阵</field>
+            <field name="group_id" ref="smart_construction_core.sc_cap_group_governance"/>
+            <field name="ui_label">能力矩阵</field>
+            <field name="ui_hint">查看角色可用能力</field>
+            <field name="intent">ui.contract</field>
+            <field name="default_payload" eval="{'action_xmlid': 'smart_construction_portal.action_sc_portal_capability_matrix', 'menu_xmlid': 'smart_construction_portal.menu_sc_portal_capability_matrix'}"/>
+            <field name="tags">portal,capability</field>
+            <field name="status">ga</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_contract_work" model="sc.capability">
+            <field name="sequence">30</field>
+            <field name="key">contract.center.open</field>
+            <field name="name">合同工作</field>
+            <field name="group_id" ref="smart_construction_core.sc_cap_group_contract_management"/>
+            <field name="ui_label">合同工作</field>
+            <field name="ui_hint">合同台账与合同清单</field>
+            <field name="intent">ui.contract</field>
+            <field name="default_payload" eval="{'scene_key': 'contract.center', 'route': '/s/contract.center', 'menu_xmlid': 'smart_construction_core.menu_sc_contract_center'}"/>
+            <field name="required_group_ids" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_read')])]"/>
+            <field name="tags">contract</field>
+            <field name="status">ga</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_cost_work" model="sc.capability">
+            <field name="sequence">40</field>
+            <field name="key">cost.ledger.open</field>
+            <field name="name">成本工作</field>
+            <field name="group_id" ref="smart_construction_core.sc_cap_group_cost_management"/>
+            <field name="ui_label">成本工作</field>
+            <field name="ui_hint">成本台账与预算入口</field>
+            <field name="intent">ui.contract</field>
+            <field name="default_payload" eval="{'action_xmlid': 'smart_construction_core.action_project_cost_ledger_my', 'menu_xmlid': 'smart_construction_core.menu_sc_project_cost_ledger'}"/>
+            <field name="required_group_ids" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_cost_read')])]"/>
+            <field name="tags">cost</field>
+            <field name="status">ga</field>
+        </record>
+        <record id="smart_construction_core.sc_cap_finance_work" model="sc.capability">
+            <field name="sequence">50</field>
+            <field name="key">finance.payment_request.list</field>
+            <field name="name">财务工作</field>
+            <field name="group_id" ref="smart_construction_core.sc_cap_group_finance_management"/>
+            <field name="ui_label">财务工作</field>
+            <field name="ui_hint">付款申请与财务台账</field>
+            <field name="intent">ui.contract</field>
+            <field name="default_payload" eval="{'action_xmlid': 'smart_construction_core.action_payment_request_my', 'menu_xmlid': 'smart_construction_core.menu_payment_request'}"/>
+            <field name="required_group_ids" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read')])]"/>
+            <field name="tags">finance</field>
+            <field name="status">ga</field>
+        </record>
+
         <!-- Default scene: update base record only (version payloads moved to dedicated files) -->
         <record id="smart_construction_core.sc_scene_default" model="sc.scene">
             <field name="state">published</field>
@@ -43,7 +158,7 @@
         <!-- Projects ledger scene -->
         <record id="sc_scene_projects_ledger" model="sc.scene">
             <field name="sequence">50</field>
-            <field name="name">项目台账（试点）</field>
+            <field name="name">项目台账</field>
             <field name="code">projects.ledger</field>
             <field name="layout">grid</field>
             <field name="state">published</field>

--- a/addons/smart_construction_scene/data/sc_scene_tiles.xml
+++ b/addons/smart_construction_scene/data/sc_scene_tiles.xml
@@ -44,7 +44,7 @@
                         'icon': 'C',
                         'payload': {
                             'action_xmlid': 'smart_construction_core.action_construction_contract_my',
-                            'menu_xmlid': 'smart_construction_core.menu_sc_contract_income'
+                            'menu_xmlid': 'smart_construction_core.menu_sc_contract_center'
                         },
                         'required_capabilities': ['contract.center.open']
                     },

--- a/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-ASSET-ENTRY-TAIL-PA91.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-ASSET-ENTRY-TAIL-PA91.yaml
@@ -1,0 +1,51 @@
+task_id: ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-ASSET-ENTRY-TAIL-PA91
+title: Split residual construction scene asset and entry tail from 56b7eba
+objective: >
+  Isolate the remaining construction scene asset registration and entry-handler
+  tail from commit 56b7eba into a bounded child batch for mainline review.
+context:
+  layer_target: Scene Layer
+  module: smart_construction_scene and smart_construction_core
+  module_ownership: Industry scene/domain boundary handoff
+  kernel_or_scenario: scenario
+  architecture_reason: >
+    This batch carries the remaining scene asset payload updates and the domain
+    entry handlers that consume those scene targets. It must remain separate
+    from platform smart_core orchestration and previously split provider/runtime
+    supply slices.
+scope:
+  allowed_paths:
+    - addons/smart_construction_core/handlers/cost_tracking_enter.py
+    - addons/smart_construction_core/handlers/project_dashboard_enter.py
+    - addons/smart_construction_scene/__init__.py
+    - addons/smart_construction_scene/data/project_management_scene.xml
+    - addons/smart_construction_scene/data/sc_scene_layout.xml
+    - addons/smart_construction_scene/data/sc_scene_list_profile.xml
+    - addons/smart_construction_scene/data/sc_scene_orchestration.xml
+    - addons/smart_construction_scene/data/sc_scene_tiles.xml
+    - agent_ops/tasks/ITER-2026-04-22-GOV-RESIDUAL-CONSTRUCTION-SCENE-ASSET-ENTRY-TAIL-PA91.yaml
+  forbidden_paths:
+    - addons/smart_core/**
+    - addons/smart_construction_scene/providers/**
+    - addons/smart_construction_scene/services/**
+    - addons/smart_construction_scene/profiles/**
+    - addons/smart_construction_scene/scenes/**
+    - addons/smart_construction_core/**/payment*
+    - addons/smart_construction_core/**/settlement*
+    - addons/smart_construction_core/**/account*
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_construction_core/handlers/cost_tracking_enter.py addons/smart_construction_core/handlers/project_dashboard_enter.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Split the final remaining tail from `56b7eba` out of residual umbrella PR #577.

This PR isolates construction scene asset payload updates and the paired construction entry handlers that consume those scene targets, without carrying smart_core platform runtime or previously split provider/runtime files.

## Scope

- `addons/smart_construction_core/handlers/cost_tracking_enter.py`
- `addons/smart_construction_core/handlers/project_dashboard_enter.py`
- `addons/smart_construction_scene/__init__.py`
- `addons/smart_construction_scene/data/project_management_scene.xml`
- `addons/smart_construction_scene/data/sc_scene_layout.xml`
- `addons/smart_construction_scene/data/sc_scene_list_profile.xml`
- `addons/smart_construction_scene/data/sc_scene_orchestration.xml`
- `addons/smart_construction_scene/data/sc_scene_tiles.xml`

## Architecture Impact

- Layer Target: Scene Layer / domain-entry handoff
- Affected Modules: `smart_construction_scene`, `smart_construction_core`
- Reason: recover the remaining asset registration and entry consumption tail after provider/runtime and semantic-carrier slices were split out

## Verify

- `python3 -m py_compile addons/smart_construction_core/handlers/cost_tracking_enter.py addons/smart_construction_core/handlers/project_dashboard_enter.py`

## Relation

- parent residual umbrella: #577
- predecessor merged splits: #578 #579 #580 #581 #582 #583 #584 #585 #586
- predecessor residual slices: #587 #588 #589 #590 #591
