### PR TITLE
[hotfix] restore omitted scene bridge helpers

### DIFF
--- a/addons/smart_construction_scene/services/project_management_entry_target.py
+++ b/addons/smart_construction_scene/services/project_management_entry_target.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from odoo.addons.smart_construction_scene.scene_registry import load_scene_configs
+
+
+PROJECT_MANAGEMENT_SCENE_KEY = "project.management"
+PROJECT_MANAGEMENT_ROUTE_FALLBACK = "/s/project.management"
+
+
+def resolve_project_management_entry_target(env) -> Dict[str, Any]:
+    for scene in load_scene_configs(env) or []:
+        if not isinstance(scene, dict):
+            continue
+        if str(scene.get("code") or "").strip() != PROJECT_MANAGEMENT_SCENE_KEY:
+            continue
+        target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+        route = str(target.get("route") or "").strip()
+        if route:
+            return {
+                "scene_key": PROJECT_MANAGEMENT_SCENE_KEY,
+                "route": route,
+                "target": dict(target),
+            }
+    return {
+        "scene_key": PROJECT_MANAGEMENT_SCENE_KEY,
+        "route": PROJECT_MANAGEMENT_ROUTE_FALLBACK,
+        "target": {"route": PROJECT_MANAGEMENT_ROUTE_FALLBACK},
+    }

--- a/addons/smart_core/core/released_scene_semantic_surface_bridge.py
+++ b/addons/smart_core/core/released_scene_semantic_surface_bridge.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def apply_released_scene_semantic_surface_bridge(
+    payload: Dict[str, Any] | None,
+    scene_contract: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    out = dict(payload or {})
+    contract = dict(scene_contract or {})
+    if not contract:
+        return out
+
+    governance = _as_dict(contract.get("governance"))
+    parser_surface = _as_dict(governance.get("parser_semantic_surface"))
+    page_surface = _as_dict(_as_dict(contract.get("page")).get("surface"))
+    search_surface = _as_dict(contract.get("search_surface"))
+    permission_surface = _as_dict(contract.get("permission_surface"))
+    workflow_surface = _as_dict(contract.get("workflow_surface"))
+    validation_surface = _as_dict(contract.get("validation_surface"))
+    if not (parser_surface or page_surface or search_surface or permission_surface or workflow_surface or validation_surface):
+        return out
+
+    out["released_scene_semantic_surface"] = {
+        "scene_key": _text(_as_dict(contract.get("identity")).get("scene_key")),
+        "parser_semantic_surface": parser_surface,
+        "page_surface": page_surface,
+        "search_surface": search_surface,
+        "permission_surface": permission_surface,
+        "workflow_surface": workflow_surface,
+        "validation_surface": validation_surface,
+    }
+
+    semantic_runtime = _as_dict(out.get("semantic_runtime"))
+    if page_surface:
+        semantic_runtime["view_type"] = _text(page_surface.get("view_type"))
+        semantic_runtime["semantic_view"] = _as_dict(page_surface.get("semantic_view"))
+        semantic_runtime["semantic_page"] = _as_dict(page_surface.get("semantic_page"))
+    if parser_surface:
+        semantic_runtime["parser_semantic_surface"] = parser_surface
+    if search_surface:
+        semantic_runtime["search_surface"] = search_surface
+    if permission_surface:
+        semantic_runtime["permission_surface"] = permission_surface
+    if workflow_surface:
+        semantic_runtime["workflow_surface"] = workflow_surface
+    if validation_surface:
+        semantic_runtime["validation_surface"] = validation_surface
+    if semantic_runtime:
+        out["semantic_runtime"] = semantic_runtime
+
+    return out

--- a/addons/smart_core/core/scene_contract_parser_semantic_bridge.py
+++ b/addons/smart_core/core/scene_contract_parser_semantic_bridge.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def apply_scene_contract_parser_semantic_bridge(
+    payload: Dict[str, Any] | None,
+    source: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    out = dict(payload or {})
+    raw = dict(source or {})
+
+    parser_contract = _as_dict(raw.get("parser_contract"))
+    view_semantics = _as_dict(raw.get("view_semantics"))
+    native_view = _as_dict(raw.get("native_view"))
+    semantic_page = _as_dict(raw.get("semantic_page"))
+
+    if not (parser_contract or view_semantics or native_view or semantic_page):
+        return out
+
+    surface = {
+        "parser_contract": parser_contract,
+        "view_semantics": view_semantics,
+        "native_view": native_view,
+        "semantic_page": semantic_page,
+    }
+
+    page = _as_dict(out.get("page"))
+    page_surface = _as_dict(page.get("surface"))
+    if parser_contract:
+        page_surface["view_type"] = _text(parser_contract.get("view_type"))
+    if view_semantics:
+        page_surface["semantic_view"] = {
+            "source_view": _text(view_semantics.get("source_view")),
+            "capability_flags": _as_dict(view_semantics.get("capability_flags")),
+            "semantic_meta": _as_dict(view_semantics.get("semantic_meta")),
+        }
+    if semantic_page:
+        page_surface["semantic_page"] = semantic_page
+    if page_surface:
+        page["surface"] = page_surface
+        out["page"] = page
+
+    governance = _as_dict(out.get("governance"))
+    governance["parser_semantic_surface"] = surface
+    out["governance"] = governance
+    return out

--- a/addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py
+++ b/addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _resolve_semantic_layout(surface: Dict[str, Any]) -> str:
+    parser_contract = _as_dict(surface.get("parser_contract"))
+    view_semantics = _as_dict(surface.get("view_semantics"))
+    semantic_page = _as_dict(surface.get("semantic_page"))
+    view_type = _text(parser_contract.get("view_type") or view_semantics.get("source_view"))
+
+    if view_type == "form":
+        return "detail"
+    if view_type == "tree":
+        return "list"
+    if view_type == "kanban":
+        return "board"
+    if view_type == "search":
+        return "search"
+    if semantic_page.get("list_semantics"):
+        return "list"
+    if semantic_page.get("kanban_semantics"):
+        return "board"
+    if semantic_page.get("title_node"):
+        return "detail"
+    return ""
+
+
+def apply_scene_contract_semantic_orchestration_bridge(
+    payload: Dict[str, Any] | None,
+) -> Dict[str, Any]:
+    out = dict(payload or {})
+    governance = _as_dict(out.get("governance"))
+    parser_surface = _as_dict(governance.get("parser_semantic_surface"))
+    if not parser_surface:
+        return out
+
+    semantic_layout = _resolve_semantic_layout(parser_surface)
+    if not semantic_layout:
+        return out
+
+    page = _as_dict(out.get("page"))
+    page["layout"] = semantic_layout
+    zones = []
+    for zone in _as_list(page.get("zones")):
+        if not isinstance(zone, dict):
+            continue
+        zone_copy = dict(zone)
+        zone_copy["layout"] = semantic_layout
+        zones.append(zone_copy)
+    if zones:
+        page["zones"] = zones
+    out["page"] = page
+    return out

--- a/addons/smart_enterprise_base/core_extension.py
+++ b/addons/smart_enterprise_base/core_extension.py
@@ -1,0 +1,111 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import logging
+
+_logger = logging.getLogger(__name__)
+
+
+def get_intent_handler_contributions():
+    return []
+
+
+def _resolve_action_target(env, action_xmlid: str, menu_xmlid: str, scene_key: str = "", route: str = "") -> dict:
+    action = env.ref(action_xmlid, raise_if_not_found=False)
+    menu = env.ref(menu_xmlid, raise_if_not_found=False)
+    return {
+        "action_id": int(action.id) if action else 0,
+        "menu_id": int(menu.id) if menu else 0,
+        "action_xmlid": action_xmlid,
+        "menu_xmlid": menu_xmlid,
+        "scene_key": scene_key or "",
+        "route": route or (f"/a/{int(action.id)}" if action else ""),
+    }
+
+
+def smart_core_extend_system_init(data, env, user):
+    try:
+        ext_facts = data.get("ext_facts") if isinstance(data.get("ext_facts"), dict) else {}
+        enablement = ext_facts.get("enterprise_enablement") if isinstance(ext_facts.get("enterprise_enablement"), dict) else {}
+        company_id = int(user.company_id.id or env.company.id or 0) if (user.company_id or env.company) else 0
+        department_count = env["hr.department"].sudo().search_count([("company_id", "=", company_id)]) if company_id else 0
+        managed_user_count = env["res.users"].sudo().search_count(
+            [
+                ("share", "=", False),
+                ("id", "!=", user.id),
+                ("company_ids", "in", [company_id]),
+            ]
+        ) if company_id else 0
+        company_target = _resolve_action_target(
+            env,
+            "smart_enterprise_base.action_enterprise_company",
+            "smart_enterprise_base.menu_enterprise_company",
+            scene_key="enterprise.company",
+            route="/s/enterprise.company",
+        )
+        department_target = _resolve_action_target(
+            env,
+            "smart_enterprise_base.action_enterprise_department",
+            "smart_enterprise_base.menu_enterprise_department",
+            scene_key="enterprise.department",
+            route="/s/enterprise.department",
+        )
+        user_target = _resolve_action_target(
+            env,
+            "smart_enterprise_base.action_enterprise_user",
+            "smart_enterprise_base.menu_enterprise_user",
+            scene_key="enterprise.user",
+            route="/s/enterprise.user",
+        )
+        company_status = "done" if company_id else "active"
+        department_status = "done" if department_count > 0 else ("active" if company_status == "done" else "pending")
+        user_status = "active" if department_count > 0 else "pending"
+        if managed_user_count > 0:
+            user_status = "done"
+        primary_action = company_target
+        if company_status == "done" and department_status != "done":
+            primary_action = department_target
+        elif company_status == "done" and department_status == "done":
+            primary_action = user_target
+        enablement["mainline"] = {
+            "version": "v1",
+            "phase": "sprint1" if department_count > 0 else "sprint0",
+            "theme": "company_department_user_role_bootstrap" if department_count > 0 else "company_department_user_bootstrap",
+            "entry_root_xmlid": "smart_enterprise_base.menu_enterprise_base_root",
+            "steps": [
+                {
+                    "key": "company",
+                    "label": "公司信息",
+                    "status": company_status,
+                    "entry_xmlid": "smart_enterprise_base.menu_enterprise_company",
+                    "action_xmlid": "smart_enterprise_base.action_enterprise_company",
+                    "next_hint": "保存公司后进入组织架构",
+                    "target": company_target,
+                },
+                {
+                    "key": "department",
+                    "label": "组织架构",
+                    "status": department_status,
+                    "entry_xmlid": "smart_enterprise_base.menu_enterprise_department",
+                    "action_xmlid": "smart_enterprise_base.action_enterprise_department",
+                    "next_hint": "先创建一级部门，再补齐二级和三级部门",
+                    "target": department_target,
+                },
+                {
+                    "key": "user",
+                    "label": "用户设置",
+                    "status": user_status,
+                    "entry_xmlid": "smart_enterprise_base.menu_enterprise_user",
+                    "action_xmlid": "smart_enterprise_base.action_enterprise_user",
+                    "next_hint": "给用户挂公司、部门、产品角色和初始密码，再用该账号登录验证首页入口",
+                    "target": user_target,
+                },
+            ],
+            "current_company_id": company_id,
+            "current_company_name": user.company_id.display_name if user.company_id else (env.company.display_name if env.company else ""),
+            "primary_action": primary_action,
+        }
+        ext_facts["enterprise_enablement"] = enablement
+        data["ext_facts"] = ext_facts
+    except Exception as exc:
+        _logger.warning("[smart_enterprise_base] extend system.init failed: %s", exc)

--- a/agent_ops/tasks/ITER-2026-04-22-HOTFIX-MISSING-SCENE-BRIDGE-TAIL-PA92.yaml
+++ b/agent_ops/tasks/ITER-2026-04-22-HOTFIX-MISSING-SCENE-BRIDGE-TAIL-PA92.yaml
@@ -1,0 +1,48 @@
+task_id: ITER-2026-04-22-HOTFIX-MISSING-SCENE-BRIDGE-TAIL-PA92
+title: Recover omitted scene bridge tail files after residual split merge
+objective: >
+  Restore three omitted low-risk bridge/helper files from commit 56b7eba so the
+  merged mainline runtime and direct-python test entrypoints become internally
+  consistent again.
+context:
+  layer_target: Platform Layer and Scene Layer
+  module: smart_core and smart_construction_scene
+  module_ownership: Platform kernel plus industry scene helper surface
+  kernel_or_scenario: kernel
+  architecture_reason: >
+    The current mainline merged residual slices but omitted three helper files
+    that are already referenced by merged imports and tests. This batch only
+    restores those missing files; it does not alter business facts, manifests,
+    ACLs, or financial semantics.
+scope:
+  allowed_paths:
+    - addons/smart_construction_scene/services/project_management_entry_target.py
+    - addons/smart_core/core/scene_contract_parser_semantic_bridge.py
+    - addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py
+    - addons/smart_core/core/released_scene_semantic_surface_bridge.py
+    - addons/smart_enterprise_base/core_extension.py
+    - agent_ops/tasks/ITER-2026-04-22-HOTFIX-MISSING-SCENE-BRIDGE-TAIL-PA92.yaml
+  forbidden_paths:
+    - addons/**/payment*
+    - addons/**/settlement*
+    - addons/**/account*
+    - addons/**/security/**
+    - addons/**/__manifest__.py
+change_rules:
+  additive_only: true
+  no_contract_breaking_changes: true
+  no_acl_or_manifest_changes: true
+  no_financial_semantic_changes: true
+acceptance:
+  verification_commands:
+    - python3 -m py_compile addons/smart_construction_scene/services/project_management_entry_target.py addons/smart_core/core/scene_contract_parser_semantic_bridge.py addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py addons/smart_core/core/released_scene_semantic_surface_bridge.py addons/smart_enterprise_base/core_extension.py
+    - python3 addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py
+    - python3 addons/smart_core/tests/test_scene_contract_builder_semantics.py
+reporting:
+  iteration_report_required: true
+  include:
+    - changed_files
+    - verification_result
+    - risk_summary
+    - rollback_suggestion
+    - next_iteration_suggestion


### PR DESCRIPTION
## Summary

Restore omitted helper/bridge files after the residual split merge so `main` regains internal consistency for direct Python verification and scene-first enterprise enablement routing.

## Scope

- `addons/smart_construction_scene/services/project_management_entry_target.py`
- `addons/smart_core/core/scene_contract_parser_semantic_bridge.py`
- `addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py`
- `addons/smart_core/core/released_scene_semantic_surface_bridge.py`
- `addons/smart_enterprise_base/core_extension.py`

## Architecture Impact

- Layer Target: Platform Layer and Scene Layer helper recovery
- Affected Modules: `smart_core`, `smart_construction_scene`, `smart_enterprise_base`
- Reason: recover omitted helper files and align enterprise enablement targets to scene-first routes already expected by merged tests and scene mappings

## Verify

- `python3 -m py_compile addons/smart_enterprise_base/core_extension.py addons/smart_construction_scene/services/project_management_entry_target.py addons/smart_core/core/scene_contract_parser_semantic_bridge.py addons/smart_core/core/scene_contract_semantic_orchestration_bridge.py addons/smart_core/core/released_scene_semantic_surface_bridge.py`
- `python3 addons/smart_construction_scene/tests/test_action_only_scene_semantic_supply.py`
- `python3 addons/smart_core/tests/test_scene_contract_builder_semantics.py`
- `python3 addons/smart_core/tests/test_platform_menu_api_scene_map.py`
- `python3 addons/smart_core/tests/test_menu_target_interpreter_entry_target.py`
- `python3 addons/smart_core/tests/test_identity_resolver_entry_target.py`
