### PR TITLE
feat(scene): restore scene-only stash tail first slice

### DIFF
--- a/addons/smart_construction_scene/profiles/workspace_home_scene_content.py
+++ b/addons/smart_construction_scene/profiles/workspace_home_scene_content.py
@@ -248,6 +248,14 @@ def build_urgent_keywords() -> List[str]:
 def resolve_scene_by_source(source_key: str) -> str:
     aliases = build_scene_aliases()
     text = _to_text(source_key).lower()
+    exact_map = {
+        "task_items": aliases["task_center"],
+        "payment_requests": "finance.payment_requests",
+        "risk_actions": aliases["risk_center"],
+        "project_actions": aliases["project_management"],
+    }
+    if text in exact_map:
+        return exact_map[text]
     if "risk" in text or "风险" in text:
         return aliases["risk_center"]
     if "task" in text or "任务" in text:

--- a/addons/smart_construction_scene/services/scene_governance_service.py
+++ b/addons/smart_construction_scene/services/scene_governance_service.py
@@ -63,14 +63,32 @@ class SceneGovernanceService:
         config = self.env["ir.config_parameter"].sudo()
         key = f"sc.scene.channel.company.{company_id}"
         before = config.get_param(key)
+        user_key = f"sc.scene.channel.user.{self.user.id}" if self.user and self.user.id else ""
+        user_before = config.get_param(user_key) if user_key else ""
+        rollback_before = str(config.get_param("sc.scene.rollback") or "")
+        pinned_before = str(config.get_param("sc.scene.use_pinned") or "")
         config.set_param(key, channel)
+        if user_key:
+            config.set_param(user_key, channel)
+        # set_channel is an explicit operator choice and should exit rollback forcing mode.
+        config.set_param("sc.scene.rollback", "0")
+        config.set_param("sc.scene.use_pinned", "0")
         self._log(
             "switch_channel",
             company_id=company_id,
             from_channel=before,
             to_channel=channel,
             reason=reason,
-            payload={"key": key},
+            payload={
+                "key": key,
+                "rollback_before": rollback_before,
+                "use_pinned_before": pinned_before,
+                "rollback_after": "0",
+                "use_pinned_after": "0",
+                "user_key": user_key,
+                "user_before": user_before or "",
+                "user_after": channel if user_key else "",
+            },
             trace_id=trace_id,
         )
         return {
@@ -78,6 +96,7 @@ class SceneGovernanceService:
             "company_id": company_id,
             "from_channel": before or "stable",
             "to_channel": channel,
+            "rollback_active": False,
             "trace_id": trace_id or "",
         }
 


### PR DESCRIPTION
Summary
- restore the first bounded smart_construction_scene stash-only slice onto its own branch
- map explicit workspace source keys in workspace_home_scene_content for scene resolution
- make scene_governance_service clear rollback and pinned flags when operators switch scene channel

Scope
- addons/smart_construction_scene/profiles/workspace_home_scene_content.py
- addons/smart_construction_scene/services/scene_governance_service.py

Verification
- git show --stat --oneline c064a40
- python3 -m py_compile addons/smart_construction_scene/profiles/workspace_home_scene_content.py addons/smart_construction_scene/services/scene_governance_service.py

Notes
- this PR intentionally contains only the first safe scene-only replay slice from stash@{0}
- additional smart_construction_scene residuals remain screened but are not included here yet