### PR TITLE
feat(ext): migrate small modules to contribution hooks

### DIFF
--- a/addons/smart_construction_bundle/__init__.py
+++ b/addons/smart_construction_bundle/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import smart_core_extend_system_init, smart_core_register  # noqa: F401
+from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401

--- a/addons/smart_construction_bundle/core_extension.py
+++ b/addons/smart_construction_bundle/core_extension.py
@@ -13,9 +13,8 @@ from .services.bundle_registry import (
 _logger = logging.getLogger(__name__)
 
 
-def smart_core_register(registry):
-    # Bundle module does not register new handler endpoints in v1.
-    return registry
+def get_intent_handler_contributions():
+    return []
 
 
 def smart_core_extend_system_init(data, env, user):

--- a/addons/smart_license_core/__init__.py
+++ b/addons/smart_license_core/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import smart_core_extend_system_init, smart_core_register  # noqa: F401
+from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401

--- a/addons/smart_license_core/core_extension.py
+++ b/addons/smart_license_core/core_extension.py
@@ -14,8 +14,8 @@ PREFIX_MIN_TIER = {
 }
 
 
-def smart_core_register(registry):
-    return registry
+def get_intent_handler_contributions():
+    return []
 
 
 def _min_tier_for_key(cap_key: str) -> str:

--- a/addons/smart_owner_bundle/__init__.py
+++ b/addons/smart_owner_bundle/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import smart_core_extend_system_init, smart_core_register  # noqa: F401
+from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401

--- a/addons/smart_owner_bundle/core_extension.py
+++ b/addons/smart_owner_bundle/core_extension.py
@@ -13,9 +13,8 @@ from .services.bundle_registry import (
 _logger = logging.getLogger(__name__)
 
 
-def smart_core_register(registry):
-    # Owner bundle does not add extra handlers (owner intents live in smart_owner_core).
-    return registry
+def get_intent_handler_contributions():
+    return []
 
 
 def smart_core_extend_system_init(data, env, user):

--- a/addons/smart_owner_core/__init__.py
+++ b/addons/smart_owner_core/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import smart_core_extend_system_init, smart_core_register  # noqa: F401
-
+from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401

--- a/addons/smart_owner_core/core_extension.py
+++ b/addons/smart_owner_core/core_extension.py
@@ -9,8 +9,7 @@ from .services.scene_registry_owner import list_owner_scenes
 _logger = logging.getLogger(__name__)
 
 
-def smart_core_register(registry):
-    """Register owner-domain intents into Smart Core registry."""
+def get_intent_handler_contributions():
     try:
         from odoo.addons.smart_owner_core.handlers.owner_payment_request import (
             OwnerApprovalCenterHandler,
@@ -24,16 +23,66 @@ def smart_core_register(registry):
         )
     except Exception as exc:
         _logger.warning("[smart_owner_core] intent import failed: %s", exc)
-        return
+        return []
 
-    registry["owner.payment.request.submit"] = OwnerPaymentRequestSubmitHandler
-    registry["owner.payment.request.approve"] = OwnerPaymentRequestApproveHandler
-    registry["owner.dashboard.open"] = OwnerDashboardOpenHandler
-    registry["owner.projects.list"] = OwnerProjectsListHandler
-    registry["owner.projects.detail"] = OwnerProjectsDetailHandler
-    registry["owner.risk.list"] = OwnerRiskListHandler
-    registry["owner.report.overview"] = OwnerReportOverviewHandler
-    registry["owner.approval.center"] = OwnerApprovalCenterHandler
+    return [
+        {
+            "intent": "owner.payment.request.submit",
+            "handler": OwnerPaymentRequestSubmitHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.payment.request.approve",
+            "handler": OwnerPaymentRequestApproveHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.dashboard.open",
+            "handler": OwnerDashboardOpenHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.projects.list",
+            "handler": OwnerProjectsListHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.projects.detail",
+            "handler": OwnerProjectsDetailHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.risk.list",
+            "handler": OwnerRiskListHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.report.overview",
+            "handler": OwnerReportOverviewHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+        {
+            "intent": "owner.approval.center",
+            "handler": OwnerApprovalCenterHandler,
+            "source_module": "smart_owner_core",
+            "domain": "owner",
+            "status": "active",
+        },
+    ]
 
 
 def smart_core_extend_system_init(data, env, user):


### PR DESCRIPTION
Summary
- migrate four small extension modules from smart_core_register to get_intent_handler_contributions
- keep smart_core_extend_system_init compatibility in place while aligning these modules with contribution-based runtime loading
- convert smart_owner_core intent registration into explicit contribution rows

Scope
- addons/smart_construction_bundle/{__init__.py,core_extension.py}
- addons/smart_license_core/{__init__.py,core_extension.py}
- addons/smart_owner_bundle/{__init__.py,core_extension.py}
- addons/smart_owner_core/{__init__.py,core_extension.py}

Verification
- git show --stat --oneline e341055
- python3 -m py_compile addons/smart_construction_bundle/__init__.py addons/smart_construction_bundle/core_extension.py addons/smart_license_core/__init__.py addons/smart_license_core/core_extension.py addons/smart_owner_bundle/__init__.py addons/smart_owner_bundle/core_extension.py addons/smart_owner_core/__init__.py addons/smart_owner_core/core_extension.py

Notes
- this PR is limited to the 8-file stash slice only
- no manifest, ACL, security, smart_core, frontend, or finance-adjacent paths are included