### PR TITLE
feat(demo): restore scenario enrichment slice

### DIFF
--- a/addons/smart_construction_demo/README.md
+++ b/addons/smart_construction_demo/README.md
@@ -25,6 +25,13 @@ make demo.rebuild DB_NAME=sc_demo
 make demo.list DB_NAME=sc_demo
 ```
 
+标准产品场景别名：
+```bash
+make demo.load SCENARIO=project_normal DB_NAME=sc_demo
+make demo.load SCENARIO=project_over_budget DB_NAME=sc_demo
+make demo.load SCENARIO=project_payment_delay DB_NAME=sc_demo
+```
+
 加载单个场景：
 ```bash
 make demo.load SCENARIO=s10_contract_payment DB_NAME=sc_demo
@@ -217,6 +224,17 @@ make demo.verify DB_NAME=sc_demo
 | S40 | 失败路径（结构/金额/关联） | sc.settlement.order / sc.settlement.order.line / payment.request | fail conditions locked |
 
 发布态默认种子集合：`S00 + S10 + S20 + S30 + S60 + S90`
+
+## Product Hardening 场景别名
+
+| 别名 | 说明 | 当前映射 |
+| --- | --- | --- |
+| `project_normal` | 正常执行项目 | `s60_project_cockpit` |
+| `project_over_budget` | 超预算风险项目 | `s60_project_cockpit` |
+| `project_payment_delay` | 付款延迟风险项目 | `s60_project_cockpit` |
+
+官方样板映射见：
+- `docs/product/demo_evidence_scenarios_v1.md`
 
 发布态默认不加载：`S40 + S50`（过程/失败演练数据）
 

--- a/addons/smart_construction_demo/data/base/cost_demo.xml
+++ b/addons/smart_construction_demo/data/base/cost_demo.xml
@@ -42,4 +42,129 @@
         <field name="type">tax</field>
         <field name="level">1</field>
     </record>
+
+    <!-- === 成本域业务事实 Demo === -->
+    <record id="sc_demo_owner_partner" model="res.partner">
+        <field name="name">城市建设投资集团</field>
+        <field name="company_type">company</field>
+    </record>
+    <record id="sc_demo_supplier_partner" model="res.partner">
+        <field name="name">建材供应有限公司</field>
+        <field name="company_type">company</field>
+    </record>
+    <record id="sc_demo_subcontract_partner" model="res.partner">
+        <field name="name">桥梁分包工程队</field>
+        <field name="company_type">company</field>
+    </record>
+
+    <record id="sc_demo_project" model="project.project">
+        <field name="name">演示项目 · 城市快速路提升工程</field>
+        <field name="partner_id" ref="sc_demo_owner_partner"/>
+        <field name="company_id" ref="base.main_company"/>
+    </record>
+
+    <record id="sc_demo_wbs_root" model="project.wbs">
+        <field name="name">路基工程</field>
+        <field name="code">WBS-001</field>
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="level">1</field>
+    </record>
+    <record id="sc_demo_wbs_sub" model="project.wbs">
+        <field name="name">桥梁结构</field>
+        <field name="code">WBS-002</field>
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="parent_id" ref="sc_demo_wbs_root"/>
+        <field name="level">2</field>
+    </record>
+
+    <record id="sc_demo_budget_control" model="project.budget">
+        <field name="name">控制版 V1</field>
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="version">CTRL-V1</field>
+        <field name="version_date">2025-01-15</field>
+        <field name="amount_revenue_target">2600000</field>
+        <field name="amount_cost_target">2100000</field>
+        <field name="is_active">True</field>
+        <field name="note">包含土建与桥梁两大专业的控制成本</field>
+    </record>
+
+    <record id="sc_demo_budget_line_roadbed" model="project.budget.boq.line">
+        <field name="budget_id" ref="sc_demo_budget_control"/>
+        <field name="sequence">10</field>
+        <field name="boq_code">BOQ-100</field>
+        <field name="name">路基填筑</field>
+        <field name="wbs_id" ref="sc_demo_wbs_root"/>
+        <field name="qty_bidded">1200</field>
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+        <field name="price_bidded">800</field>
+        <field name="measure_rule">qty</field>
+    </record>
+
+    <record id="sc_demo_budget_line_bridge" model="project.budget.boq.line">
+        <field name="budget_id" ref="sc_demo_budget_control"/>
+        <field name="sequence">20</field>
+        <field name="boq_code">BOQ-200</field>
+        <field name="name">桥梁下部结构</field>
+        <field name="wbs_id" ref="sc_demo_wbs_sub"/>
+        <field name="qty_bidded">600</field>
+        <field name="uom_id" ref="uom.product_uom_hour"/>
+        <field name="price_bidded">1500</field>
+        <field name="measure_rule">qty</field>
+    </record>
+
+    <record id="sc_demo_alloc_roadbed_labor" model="project.budget.cost.alloc">
+        <field name="budget_boq_line_id" ref="sc_demo_budget_line_roadbed"/>
+        <field name="cost_code_id" ref="sc_cost_code_root_labor"/>
+        <field name="ratio">0.35</field>
+        <field name="amount_budget">336000</field>
+    </record>
+    <record id="sc_demo_alloc_roadbed_material" model="project.budget.cost.alloc">
+        <field name="budget_boq_line_id" ref="sc_demo_budget_line_roadbed"/>
+        <field name="cost_code_id" ref="sc_cost_code_root_material"/>
+        <field name="ratio">0.45</field>
+        <field name="amount_budget">432000</field>
+    </record>
+    <record id="sc_demo_alloc_bridge_sub" model="project.budget.cost.alloc">
+        <field name="budget_boq_line_id" ref="sc_demo_budget_line_bridge"/>
+        <field name="cost_code_id" ref="sc_cost_code_root_subcontract"/>
+        <field name="ratio">0.60</field>
+        <field name="amount_budget">540000</field>
+    </record>
+
+    <record id="sc_demo_cost_ledger_1" model="project.cost.ledger">
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="wbs_id" ref="sc_demo_wbs_root"/>
+        <field name="cost_code_id" ref="sc_cost_code_root_material"/>
+        <field name="date">2025-02-10</field>
+        <field name="qty">200</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="amount">240000</field>
+        <field name="partner_id" ref="sc_demo_supplier_partner"/>
+        <field name="source_model">purchase.order</field>
+        <field name="source_id">1</field>
+        <field name="note">钢筋采购入库</field>
+    </record>
+    <record id="sc_demo_cost_ledger_2" model="project.cost.ledger">
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="wbs_id" ref="sc_demo_wbs_sub"/>
+        <field name="cost_code_id" ref="sc_cost_code_root_subcontract"/>
+        <field name="date">2025-03-05</field>
+        <field name="qty">1</field>
+        <field name="uom_id" ref="uom.product_uom_unit"/>
+        <field name="amount">420000</field>
+        <field name="partner_id" ref="sc_demo_subcontract_partner"/>
+        <field name="source_model">account.move</field>
+        <field name="source_id">1</field>
+        <field name="note">桥梁桩基分包结算</field>
+    </record>
+
+    <record id="sc_demo_progress_entry" model="project.progress.entry">
+        <field name="project_id" ref="sc_demo_project"/>
+        <field name="wbs_id" ref="sc_demo_wbs_sub"/>
+        <field name="date">2025-03-20</field>
+        <field name="qty_done">180</field>
+        <field name="qty_cum">300</field>
+        <field name="progress_rate">35</field>
+        <field name="note">桩基完成 35%，已提交监理确认</field>
+    </record>
 </odoo>

--- a/addons/smart_construction_demo/data/scenario/s60_project_cockpit/10_cockpit_business_facts.xml
+++ b/addons/smart_construction_demo/data/scenario/s60_project_cockpit/10_cockpit_business_facts.xml
@@ -1,4 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="0">
     <function model="project.project" name="sc_demo_seed_cockpit_round2"/>
+
+    <record id="sc_demo_tender_060_001" model="tender.bid">
+        <field name="tender_name">德阳智能制造产教融合项目一期投标包</field>
+        <field name="project_id" ref="smart_construction_demo.sc_demo_project_001"/>
+        <field name="owner_id" ref="smart_construction_demo.sc_demo_partner_owner_001"/>
+        <field name="tender_round">1</field>
+        <field name="bid_amount">1280000</field>
+        <field name="deadline">2026-04-20 10:00:00</field>
+        <field name="open_date">2026-04-20 14:00:00</field>
+        <field name="state">submitted</field>
+    </record>
+
+    <record id="sc_demo_wbs_060_unit_001" model="construction.work.breakdown">
+        <field name="name">1# 产教融合主楼</field>
+        <field name="code">U01</field>
+        <field name="project_id" ref="smart_construction_demo.sc_demo_project_001"/>
+        <field name="level_type">unit</field>
+        <field name="sequence">10</field>
+    </record>
+
+    <record id="sc_demo_wbs_060_sub_001" model="construction.work.breakdown">
+        <field name="name">基础及主体结构</field>
+        <field name="code">U01-01</field>
+        <field name="project_id" ref="smart_construction_demo.sc_demo_project_001"/>
+        <field name="parent_id" ref="smart_construction_demo.sc_demo_wbs_060_unit_001"/>
+        <field name="level_type">sub_section</field>
+        <field name="sequence">20</field>
+    </record>
+
+    <record id="sc_demo_document_060_001" model="sc.project.document">
+        <field name="name">施工图会审纪要</field>
+        <field name="project_id" ref="smart_construction_demo.sc_demo_project_001"/>
+        <field name="wbs_id" ref="smart_construction_demo.sc_demo_wbs_060_sub_001"/>
+        <field name="doc_type_id" ref="smart_construction_demo.sc_dict_doc_type_drawing"/>
+        <field name="date_doc">2026-03-15</field>
+        <field name="version">A1</field>
+        <field name="is_mandatory">True</field>
+        <field name="state">done</field>
+        <field name="note">用于演示工程资料中心与 WBS 关联查看。</field>
+    </record>
+
+    <record id="sc_demo_document_060_002" model="sc.project.document">
+        <field name="name">专项施工方案技术交底</field>
+        <field name="project_id" ref="smart_construction_demo.sc_demo_project_001"/>
+        <field name="wbs_id" ref="smart_construction_demo.sc_demo_wbs_060_sub_001"/>
+        <field name="doc_type_id" ref="smart_construction_demo.sc_dict_doc_type_tech"/>
+        <field name="date_doc">2026-03-18</field>
+        <field name="version">B2</field>
+        <field name="state">review</field>
+        <field name="note">用于演示工程资料列表中的状态差异与基础筛选。</field>
+    </record>
 </odoo>

--- a/addons/smart_construction_demo/models/project_demo_cockpit_seed.py
+++ b/addons/smart_construction_demo/models/project_demo_cockpit_seed.py
@@ -8,6 +8,37 @@ from odoo import api, models
 class ProjectDemoCockpitSeed(models.Model):
     _inherit = "project.project"
 
+    _DEMO_COCKPIT_MARKER = "DEMO_COCKPIT_R2"
+    _OFFICIAL_SAMPLE_PROFILES = {
+        "展厅-智慧园区运营中心": {
+            "profile": "execution",
+            "showcase_ready": True,
+            "seed_costs": False,
+            "seed_payments": False,
+            "health_state": "warn",
+            "execution_state": "in_progress",
+            "target_lifecycle_state": "in_progress",
+        },
+        "展厅-装配式住宅试点": {
+            "profile": "payment",
+            "showcase_ready": True,
+            "seed_costs": True,
+            "seed_payments": False,
+            "health_state": "warn",
+            "execution_state": "done",
+            "target_lifecycle_state": "in_progress",
+        },
+        "展厅-产线升级改造工程": {
+            "profile": "settlement_complete",
+            "showcase_ready": True,
+            "seed_costs": True,
+            "seed_payments": True,
+            "health_state": "good",
+            "execution_state": "done",
+            "target_lifecycle_state": "done",
+        },
+    }
+
     @api.model
     def sc_demo_seed_cockpit_round2(self):
         partner_model = self.env["res.partner"]
@@ -27,6 +58,7 @@ class ProjectDemoCockpitSeed(models.Model):
         todo_type = self.env.ref("mail.mail_activity_data_todo", raise_if_not_found=False)
 
         for project in projects:
+            profile = self._sc_demo_profile(project)
             partner = project.partner_id or partner_fallback
             if not partner:
                 continue
@@ -37,66 +69,57 @@ class ProjectDemoCockpitSeed(models.Model):
                 contract_model=contract_model,
                 contract_line_model=contract_line_model,
             )
-            self._sc_demo_seed_cost_ledger(
-                project=project,
-                partner=partner,
-                cost_code=cost_code,
-                cost_ledger_model=cost_ledger_model,
-            )
-            self._sc_demo_seed_payments(
-                project=project,
-                partner=partner,
-                payment_request_model=payment_request_model,
-            )
+            if profile.get("seed_costs", True):
+                self._sc_demo_seed_cost_ledger(
+                    project=project,
+                    partner=partner,
+                    cost_code=cost_code,
+                    cost_ledger_model=cost_ledger_model,
+                )
+            else:
+                self._sc_demo_cleanup_cost_ledger(project)
+            if profile.get("seed_payments", True):
+                self._sc_demo_seed_payments(
+                    project=project,
+                    partner=partner,
+                    payment_request_model=payment_request_model,
+                )
+            else:
+                self._sc_demo_cleanup_payments(project)
             self._sc_demo_seed_risk_signals(
                 project=project,
                 activity_model=activity_model,
                 todo_type=todo_type,
                 model_id=model_id,
+                profile=profile,
             )
+            self._sc_demo_apply_showcase_profile(project, profile)
 
         return True
 
     @api.model
     def _sc_demo_release_projects(self):
-        """Pick release-grade projects for cockpit/list demo seeding.
+        """Pick showroom-first projects for cockpit demo seeding."""
 
-        Priority:
-        1) Active projects assigned to known PM demo users
-        2) Active projects that look like business/showcase projects
-        3) Fallback to first active projects
-        """
-
-        users = self.env["res.users"].sudo().search(
-            [("login", "in", ["demo_role_pm", "demo_pm", "sc_fx_pm"])],
-            order="id asc",
-        )
-        user_ids = users.ids
         project_model = self.with_context(active_test=False)
-
         projects = project_model.browse()
-        if user_ids:
+
+        sample_names = list(self._OFFICIAL_SAMPLE_PROFILES.keys())
+        if sample_names:
             projects |= project_model.search(
-                [("active", "=", True), ("user_id", "in", user_ids)],
+                [("active", "=", True), ("name", "in", sample_names)],
                 order="id asc",
-                limit=24,
             )
+
+        projects |= project_model.search(
+            [("active", "=", True), ("name", "ilike", "展厅-%")],
+            order="id asc",
+            limit=24,
+        )
 
         if len(projects) < 12:
             projects |= project_model.search(
-                [
-                    ("active", "=", True),
-                    "|",
-                    ("project_code", "!=", False),
-                    ("name", "ilike", "DEMO-"),
-                ],
-                order="id asc",
-                limit=24,
-            )
-
-        if len(projects) < 12:
-            projects |= project_model.search(
-                [("active", "=", True)],
+                [("active", "=", True), ("project_code", "ilike", "DEMO-%")],
                 order="id asc",
                 limit=24,
             )
@@ -104,8 +127,36 @@ class ProjectDemoCockpitSeed(models.Model):
         return projects
 
     @api.model
+    def _sc_demo_profile(self, project):
+        profile = dict(
+            self._OFFICIAL_SAMPLE_PROFILES.get(
+                str(project.name or "").strip(),
+                {
+                    "profile": "showroom",
+                    "showcase_ready": False,
+                    "seed_costs": True,
+                    "seed_payments": True,
+                    "health_state": "warn",
+                    "execution_state": "done",
+                    "target_lifecycle_state": str(getattr(project, "lifecycle_state", "") or "").strip().lower() or "in_progress",
+                },
+            )
+        )
+        profile.setdefault("profile", "showroom")
+        profile.setdefault("showcase_ready", False)
+        profile.setdefault("seed_costs", True)
+        profile.setdefault("seed_payments", True)
+        profile.setdefault("health_state", "warn")
+        profile.setdefault("execution_state", "done")
+        profile.setdefault(
+            "target_lifecycle_state",
+            str(getattr(project, "lifecycle_state", "") or "").strip().lower() or "in_progress",
+        )
+        return profile
+
+    @api.model
     def _sc_demo_seed_contracts(self, project, partner, contract_model, contract_line_model):
-        marker = "DEMO_COCKPIT_R2"
+        marker = self._DEMO_COCKPIT_MARKER
         existing = contract_model.search_count(
             [("project_id", "=", project.id), ("subject", "ilike", marker)]
         )
@@ -146,7 +197,7 @@ class ProjectDemoCockpitSeed(models.Model):
         if not cost_code:
             return
 
-        marker = "DEMO_COCKPIT_R2"
+        marker = self._DEMO_COCKPIT_MARKER
         base = date.today()
         samples = [
             ("材料采购", 1_180_000.0, 5),
@@ -181,8 +232,19 @@ class ProjectDemoCockpitSeed(models.Model):
                 continue
 
     @api.model
+    def _sc_demo_cleanup_cost_ledger(self, project):
+        ledger_model = self.env["project.cost.ledger"]
+        marker = self._DEMO_COCKPIT_MARKER
+        try:
+            ledger_model.search(
+                [("project_id", "=", project.id), ("note", "ilike", f"{marker}-%")]
+            ).unlink()
+        except Exception:
+            return
+
+    @api.model
     def _sc_demo_seed_payments(self, project, partner, payment_request_model):
-        marker = "DEMO_COCKPIT_R2"
+        marker = self._DEMO_COCKPIT_MARKER
         samples = [
             ("receive", "approved", 2_800_000.0, "节点回款A"),
             ("receive", "done", 1_650_000.0, "节点回款B"),
@@ -215,14 +277,33 @@ class ProjectDemoCockpitSeed(models.Model):
                 continue
 
     @api.model
-    def _sc_demo_seed_risk_signals(self, project, activity_model, todo_type, model_id):
-        if "health_state" in project._fields and (project.health_state or "ok") == "ok":
-            project.write({"health_state": "warn"})
+    def _sc_demo_cleanup_payments(self, project):
+        payment_request_model = self.env["payment.request"]
+        marker = self._DEMO_COCKPIT_MARKER
+        try:
+            payment_request_model.search(
+                [
+                    ("project_id", "=", project.id),
+                    "|",
+                    ("note", "=", marker),
+                    ("name", "ilike", f"{marker}-%"),
+                ]
+            ).unlink()
+        except Exception:
+            return
+
+    @api.model
+    def _sc_demo_seed_risk_signals(self, project, activity_model, todo_type, model_id, profile=None):
+        marker = self._DEMO_COCKPIT_MARKER
+        profile = dict(profile or {})
+        target_health = str(profile.get("health_state") or "warn").strip().lower() or "warn"
+        if "health_state" in project._fields and (project.health_state or "") != target_health:
+            project.write({"health_state": target_health})
 
         if not todo_type or not model_id:
             return
 
-        marker_summary = "DEMO_COCKPIT_R2-成本偏差复核"
+        marker_summary = f"{marker}-成本偏差复核"
         existing = activity_model.search_count(
             [
                 ("res_model", "=", "project.project"),
@@ -238,8 +319,24 @@ class ProjectDemoCockpitSeed(models.Model):
                 "res_model_id": model_id,
                 "res_id": project.id,
                 "summary": marker_summary,
-                "note": "DEMO_COCKPIT_R2：请复核本周成本偏差。",
+                "note": f"{marker}：请复核本周成本偏差。",
                 "user_id": project.user_id.id or self.env.user.id,
                 "date_deadline": date.today() - timedelta(days=2),
             }
         )
+
+    @api.model
+    def _sc_demo_apply_showcase_profile(self, project, profile):
+        vals = {"sc_demo_showcase": True, "sc_demo_showcase_ready": bool(profile.get("showcase_ready"))}
+        if "health_state" in project._fields:
+            vals["health_state"] = str(profile.get("health_state") or "warn")
+        if "sc_execution_state" in project._fields:
+            vals["sc_execution_state"] = str(profile.get("execution_state") or "done")
+        project.write(vals)
+
+        target_lifecycle = str(profile.get("target_lifecycle_state") or "").strip().lower()
+        if target_lifecycle and getattr(project, "lifecycle_state", "") != target_lifecycle:
+            try:
+                project.action_set_lifecycle_state(target_lifecycle)
+            except Exception:
+                pass

--- a/addons/smart_construction_demo/tools/scenario_loader.py
+++ b/addons/smart_construction_demo/tools/scenario_loader.py
@@ -68,6 +68,33 @@ SCENARIOS: Dict[str, List[str]] = {
     },
 }
 
+SCENARIO_ALIASES = {
+    "project_normal": "s60_project_cockpit",
+    "project_over_budget": "s60_project_cockpit",
+    "project_payment_delay": "s60_project_cockpit",
+}
+
+SCENARIO_PROFILES: Dict[str, Dict[str, object]] = {
+    "project_normal": {
+        "label": "正常项目",
+        "release_ready": True,
+        "showcase_project": "展厅-智慧园区运营中心",
+        "expected_risk": "EXECUTION_COST_MISSING",
+    },
+    "project_over_budget": {
+        "label": "超预算项目",
+        "release_ready": True,
+        "showcase_project": "展厅-产线升级改造工程",
+        "expected_risk": "PAYMENT_EXCEEDS_COST",
+    },
+    "project_payment_delay": {
+        "label": "付款风险项目",
+        "release_ready": True,
+        "showcase_project": "展厅-装配式住宅试点",
+        "expected_risk": "PAYMENT_MISSING",
+    },
+}
+
 
 RELEASE_SCENARIOS: List[str] = [
     "s00_min_path",
@@ -134,6 +161,8 @@ def load_scenario(
     scenario = (scenario or "").strip()
     if not scenario:
         raise ValueError("scenario is required, e.g. 's10_contract_payment'")
+
+    scenario = SCENARIO_ALIASES.get(scenario, scenario)
 
     if scenario not in SCENARIOS:
         known = ", ".join(sorted(SCENARIOS.keys()))


### PR DESCRIPTION
## Summary

Restore the bounded `smart_construction_demo` scenario-enrichment slice from `stash@{0}` onto `main`.

- adds demo cost-domain seed facts for a bounded project sample
- enriches the `s60_project_cockpit` scenario with tender, WBS, and document facts
- updates cockpit demo seeding to support showroom profiles and scenario aliases

## Architecture Impact

- additive demo-data and scenario-orchestration recovery only
- no manifest, ACL, security, payment, settlement, or account rule changes
- keeps the batch isolated inside `smart_construction_demo`

## Layer Target

- Backend Demo Seed
- Scene orchestration

## Affected Modules

- `addons/smart_construction_demo`

## Verification

- `git diff --name-only -- addons/smart_construction_demo`
- `python3 -m py_compile addons/smart_construction_demo/models/project_demo_cockpit_seed.py addons/smart_construction_demo/tools/scenario_loader.py`
