### PR TITLE
feat(core): restore project entry routing cleanup

### DIFF
--- a/addons/smart_construction_core/actions/execution_structure_actions_base.xml
+++ b/addons/smart_construction_core/actions/execution_structure_actions_base.xml
@@ -6,26 +6,39 @@
         <field name="state">code</field>
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_project_read'))]"/>
         <field name="code"><![CDATA[
-next_action = {
-    'type': 'ir.actions.act_window',
-    'name': '项目列表',
-    'res_model': 'project.project',
-    'view_mode': 'kanban,tree,form',
-    'views': [(False, 'kanban'), (False, 'tree'), (False, 'form')],
-    'target': 'current',
-    'context': dict(env.context),
-}
-action = {
-    'type': 'ir.actions.client',
-    'tag': 'display_notification',
-    'params': {
-        'title': '执行结构',
-        'message': '请先选择项目，将跳转到项目列表。',
-        'type': 'warning',
-        'sticky': False,
-        'next': next_action,
+ctx = dict(env.context or {})
+Project = env['project.project']
+my_project_domain = ['|', ('manager_id', '=', env.uid), '|', ('owner_id', '=', env.uid), ('user_id', '=', env.uid)]
+my_projects = Project.search(my_project_domain, limit=2)
+
+if len(my_projects) == 1:
+    project = my_projects[0]
+    direct_action = project.action_open_exec_wbs()
+    action_ctx = Project._normalize_action_context(direct_action.get('context'))
+    action_ctx.update(ctx)
+    action_ctx['default_project_id'] = project.id
+    action_ctx['search_default_project_id'] = project.id
+    direct_action['context'] = action_ctx
+    direct_action['domain'] = [('project_id', '=', project.id)]
+    action = direct_action
+else:
+    next_action = env['ir.actions.act_window']._for_xml_id('smart_construction_core.action_sc_project_kanban_lifecycle')
+    next_ctx = Project._normalize_action_context(next_action.get('context'))
+    next_ctx.update(ctx)
+    next_ctx['search_default_filter_my_projects'] = 1
+    next_ctx['sc_exec_entry_mode'] = 'wbs'
+    next_action['context'] = next_ctx
+    action = {
+        'type': 'ir.actions.client',
+        'tag': 'display_notification',
+        'params': {
+            'title': '执行结构',
+            'message': '请先选择项目，再进入执行结构。',
+            'type': 'warning',
+            'sticky': False,
+            'next': next_action,
+        }
     }
-}
         ]]></field>
     </record>
 

--- a/addons/smart_construction_core/wizard/project_quick_create_wizard.py
+++ b/addons/smart_construction_core/wizard/project_quick_create_wizard.py
@@ -2,6 +2,9 @@
 from __future__ import annotations
 
 from odoo import api, fields, models
+from odoo.addons.smart_construction_scene.services.project_management_entry_target import (
+    resolve_project_management_entry_target,
+)
 
 
 class ProjectQuickCreateWizard(models.TransientModel):
@@ -28,9 +31,9 @@ class ProjectQuickCreateWizard(models.TransientModel):
         if self.owner_id:
             vals["owner_id"] = int(self.owner_id.id)
         project = self.env["project.project"].create(vals)
+        target = resolve_project_management_entry_target(self.env)
         return {
             "type": "ir.actions.act_url",
-            "url": "/s/project.management?project_id=%s" % int(project.id),
+            "url": str(target.get("route") or ""),
             "target": "self",
         }
-


### PR DESCRIPTION
## Summary

Restore the bounded 2-file project-entry routing cleanup slice from `stash@{1}`.

- quick-create now redirects through the canonical project-management entry target
- execution-structure entry jumps directly into WBS when the user owns exactly one project
- otherwise the entry falls back to the filtered project list with execution-mode context

## Architecture Impact

- additive scene-orchestration routing cleanup only
- no manifest, ACL, security, payment, settlement, or account rule changes
- keeps the batch isolated inside `smart_construction_core`

## Layer Target

- Backend scene entry routing
- Scene orchestration

## Affected Modules

- `addons/smart_construction_core`

## Verification

- `git diff --name-only -- addons/smart_construction_core/wizard/project_quick_create_wizard.py addons/smart_construction_core/actions/execution_structure_actions_base.xml`
- `python3 -m py_compile addons/smart_construction_core/wizard/project_quick_create_wizard.py`
