### PR TITLE
feat(core): replay project next-action rule updates

### DIFF
--- a/addons/smart_construction_core/data/project_next_action_rules.xml
+++ b/addons/smart_construction_core/data/project_next_action_rules.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
+<odoo>
+    <data noupdate="1">
     <!-- Draft stage rules -->
     <record id="sc_next_action_submit_project" model="sc.project.next_action.rule">
         <field name="name">提交立项</field>
@@ -55,7 +56,7 @@
     <record id="sc_next_action_update_cost" model="sc.project.next_action.rule">
         <field name="name">维护成本台账</field>
         <field name="lifecycle_state">in_progress</field>
-        <field name="sequence">20</field>
+        <field name="sequence">30</field>
         <field name="action_type">act_window_xmlid</field>
         <field name="action_ref">smart_construction_core.action_project_cost_ledger_my</field>
         <field name="condition_expr">s.get('cost', {}).get('count', 0) == 0</field>
@@ -74,9 +75,27 @@
     <record id="sc_next_action_create_task" model="sc.project.next_action.rule">
         <field name="name">创建任务</field>
         <field name="lifecycle_state">in_progress</field>
-        <field name="sequence">40</field>
+        <field name="sequence">20</field>
         <field name="action_type">object_method</field>
         <field name="action_ref">action_view_my_tasks</field>
-        <field name="condition_expr">s.get('task', {}).get('count', 0) == 0 and s.get('task', {}).get('in_progress', 0) == 0</field>
+        <field name="condition_expr">s.get('task', {}).get('count', 0) &lt;= 1 and s.get('task', {}).get('in_progress', 0) == 0</field>
     </record>
+    </data>
+
+    <!-- Canonical replay path for existing databases created under noupdate=1 -->
+    <data>
+        <function model="sc.project.next_action.rule" name="write">
+            <function model="sc.project.next_action.rule" name="search">
+                <value eval="[('id', '=', ref('smart_construction_core.sc_next_action_update_cost'))]"/>
+            </function>
+            <value eval="{'sequence': 30, 'condition_expr': &quot;s.get('cost', {}).get('count', 0) == 0&quot;}"/>
+        </function>
+
+        <function model="sc.project.next_action.rule" name="write">
+            <function model="sc.project.next_action.rule" name="search">
+                <value eval="[('id', '=', ref('smart_construction_core.sc_next_action_create_task'))]"/>
+            </function>
+            <value eval="{'sequence': 20, 'condition_expr': &quot;s.get('task', {}).get('count', 0) &lt;= 1 and s.get('task', {}).get('in_progress', 0) == 0&quot;}"/>
+        </function>
+    </data>
 </odoo>


### PR DESCRIPTION
## Summary

Restore the bounded single-file `project_next_action_rules.xml` replay slice from `stash@{4}`.

- reorder in-progress next-action priorities so task creation is evaluated earlier when task count is low
- keep the canonical XML records intact for fresh installs
- add replay writes so existing databases created under `noupdate=1` receive the same updates

## Architecture Impact

- additive scene-orchestration guidance update only
- no manifest, ACL, security, payment, settlement, or account file changes
- keeps the batch isolated to `smart_construction_core/data/project_next_action_rules.xml`

## Layer Target

- Backend scene-orchestration guidance

## Affected Modules

- `addons/smart_construction_core`

## Verification

- `git diff --name-only -- addons/smart_construction_core/data/project_next_action_rules.xml`
- `python3 - <<'PY' ... ET.parse(...) ... PY`
