### PR TITLE
fix(bootstrap): guard company currency compatibility

### DIFF
--- a/addons/smart_construction_bootstrap/hooks.py
+++ b/addons/smart_construction_bootstrap/hooks.py
@@ -2,39 +2,50 @@
 import logging
 
 from odoo import SUPERUSER_ID, api
+from odoo.exceptions import UserError
 
 _logger = logging.getLogger(__name__)
 
 
 def _as_env(env_or_cr, registry=None):
-    """Accept env (new API) or (cr, registry) signature and return Environment."""
     if isinstance(env_or_cr, api.Environment):
         return env_or_cr
     return api.Environment(env_or_cr, SUPERUSER_ID, {})
 
 
+def _find_currency(env, code):
+    currency = env.ref(f"base.{code}", raise_if_not_found=False)
+    if currency:
+        return currency
+    return env["res.currency"].sudo().with_context(active_test=False).search(
+        [("name", "=", code)],
+        limit=1,
+    )
+
+
+def _ensure_company_currency(env, code):
+    currency = _find_currency(env, code)
+    if not currency:
+        raise UserError(f"{code} currency not found. Install base currency data before bootstrap.")
+    if not currency.active:
+        currency.sudo().active = True
+
+    Company = env["res.company"].sudo()
+    companies = Company.search([])
+    if not companies or all(company.currency_id == currency for company in companies):
+        return
+    if "account.move.line" in env.registry and env["account.move.line"].sudo().search_count([]):
+        raise UserError(f"Cannot switch company currency to {code} after journal items exist.")
+    companies.write({"currency_id": currency.id})
+    env["ir.config_parameter"].sudo().set_param("sc.bootstrap.currency", code)
+
+
 def post_init_hook(env_or_cr, registry=None):
-    """Bootstrap baseline settings for a fresh DB (idempotent)."""
+    """Apply fresh-DB currency compatibility for legacy bootstrap flows."""
     env = _as_env(env_or_cr, registry)
 
-    ICP = env["ir.config_parameter"].sudo()
-    lang = ICP.get_param("sc.bootstrap.lang", "zh_CN")
-    tz = ICP.get_param("sc.bootstrap.tz", "Asia/Shanghai")
-    cur = ICP.get_param("sc.bootstrap.currency", "CNY")
+    icp = env["ir.config_parameter"].sudo()
+    cur = icp.get_param("sc.bootstrap.currency", "CNY")
+    _ensure_company_currency(env, cur)
 
-    # 1) Activate language (stable API)
-    env["res.lang"]._activate_lang(lang)
-
-    # 2) System defaults
-    ICP.set_param("lang", lang)
-    ICP.set_param("tz", tz)
-
-    # 3) Company currency
-    currency = env.ref(f"base.{cur}")
-    env.company.write({"currency_id": currency.id})
-
-    # 4) Admin user preferences
-    admin = env.ref("base.user_admin")
-    admin.write({"lang": lang, "tz": tz})
-
-    _logger.info("Bootstrap baseline applied: lang=%s tz=%s currency=%s", lang, tz, cur)
+    _logger.info("Construction bootstrap compatibility applied: currency=%s", cur)


### PR DESCRIPTION
## Summary
- narrow bootstrap post-init behavior to company currency compatibility only
- guard currency switching when journal items already exist
- resolve currency records safely even when the base XMLID is unavailable

## Verification
- python3 -m py_compile addons/smart_construction_bootstrap/hooks.py
