### PR TITLE
fix(contract): clear catalog guard baseline debt

### DIFF
--- a/addons/smart_core/handlers/load_contract.py
+++ b/addons/smart_core/handlers/load_contract.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 # 📁 smart_core/handlers/load_contract.py
+import hashlib
+import json
+import re
+
+from odoo import SUPERUSER_ID, api
+
 from ..core.base_handler import BaseIntentHandler
 from ..utils.extension_hooks import call_extension_hook_first
-from odoo import api, SUPERUSER_ID
-import json, re, hashlib
+from ..utils.reason_codes import REASON_OK, REASON_PERMISSION_DENIED
 
 VALID_VIEWS   = {'form','tree','kanban','search','pivot','graph','calendar','gantt','activity','dashboard'}
 VALID_INCLUDE = {'model','view','action','permission'}
+REASON_DISABLED = "DISABLED"
+REASON_STATE_BLOCKED = "STATE_BLOCKED"
 
 def _json(obj):
     return json.dumps(obj, ensure_ascii=False, default=str, separators=(",",":"))
@@ -223,7 +230,7 @@ class LoadContractHandler(BaseIntentHandler):
                     "label": fallback_label or key,
                     "type": "action",
                     "enabled": True,
-                    "reason_code": "OK",
+                    "reason_code": REASON_OK,
                 }
             if not isinstance(raw, dict):
                 return None
@@ -240,7 +247,7 @@ class LoadContractHandler(BaseIntentHandler):
             label = str(raw.get("label") or raw.get("string") or fallback_label or key)
             action_type = str(raw.get("action_type") or raw.get("type") or "action")
             enabled = bool(raw.get("enabled", True))
-            reason_code = str(raw.get("reason_code") or ("OK" if enabled else "DISABLED"))
+            reason_code = str(raw.get("reason_code") or (REASON_OK if enabled else REASON_DISABLED))
             reason = str(raw.get("reason") or "")
             return {
                 "key": key,
@@ -344,7 +351,7 @@ class LoadContractHandler(BaseIntentHandler):
             allowed = bool(value)
             return {
                 "allowed": allowed,
-                "reason_code": "OK" if allowed else "PERMISSION_DENIED",
+                "reason_code": REASON_OK if allowed else REASON_PERMISSION_DENIED,
                 "reason": "" if allowed else "permission denied",
             }
 
@@ -356,7 +363,7 @@ class LoadContractHandler(BaseIntentHandler):
         }
         permission_verdicts["execute"] = {
             "allowed": bool(permission_verdicts["read"]["allowed"]),
-            "reason_code": "OK" if permission_verdicts["read"]["allowed"] else "PERMISSION_DENIED",
+            "reason_code": REASON_OK if permission_verdicts["read"]["allowed"] else REASON_PERMISSION_DENIED,
             "reason": "" if permission_verdicts["read"]["allowed"] else "permission denied",
         }
 
@@ -390,17 +397,17 @@ class LoadContractHandler(BaseIntentHandler):
             state_blocked = is_closed_state and requires_write
             current_enabled = bool(action.get("enabled", True))
             allowed = bool(current_enabled and permission_allowed and not state_blocked)
-            reason_code = "OK"
+            reason_code = REASON_OK
             reason = ""
             if not allowed:
                 if not current_enabled:
-                    reason_code = str(action.get("reason_code") or "DISABLED")
+                    reason_code = str(action.get("reason_code") or REASON_DISABLED)
                     reason = str(action.get("reason") or "")
                 elif not permission_allowed:
-                    reason_code = "PERMISSION_DENIED"
+                    reason_code = REASON_PERMISSION_DENIED
                     reason = "permission denied"
                 elif state_blocked:
-                    reason_code = "STATE_BLOCKED"
+                    reason_code = REASON_STATE_BLOCKED
                     reason = "record state blocks action"
 
             return {
@@ -486,9 +493,9 @@ class LoadContractHandler(BaseIntentHandler):
                             "can_unlink": can_unlink,
                         },
                         "row_actions": _with_action_gate_list([
-                            {"key": "open", "label": "打开", "enabled": True, "reason_code": "OK"},
-                            {"key": "create", "label": "新增", "enabled": can_create, "reason_code": "OK" if can_create else "PERMISSION_DENIED"},
-                            {"key": "unlink", "label": "移除", "enabled": can_unlink, "reason_code": "OK" if can_unlink else "PERMISSION_DENIED"},
+                            {"key": "open", "label": "打开", "enabled": True, "reason_code": REASON_OK},
+                            {"key": "create", "label": "新增", "enabled": can_create, "reason_code": REASON_OK if can_create else REASON_PERMISSION_DENIED},
+                            {"key": "unlink", "label": "移除", "enabled": can_unlink, "reason_code": REASON_OK if can_unlink else REASON_PERMISSION_DENIED},
                         ]),
                     })
                 _add_zone("relation_zone", {
@@ -506,12 +513,12 @@ class LoadContractHandler(BaseIntentHandler):
             tree_view = views.get("tree") or {}
             tree_columns = tree_view.get("columns") or []
             tree_row_actions = [
-                {"key": "open", "label": "打开", "enabled": True, "reason_code": "OK"},
+                {"key": "open", "label": "打开", "enabled": True, "reason_code": REASON_OK},
                 {
                     "key": "edit",
                     "label": "编辑",
                     "enabled": bool(permissions.get("write", False)),
-                    "reason_code": "OK" if permissions.get("write") else "PERMISSION_DENIED",
+                    "reason_code": REASON_OK if permissions.get("write") else REASON_PERMISSION_DENIED,
                 },
             ]
             _add_zone("detail_zone", {"type": "relation_table_block", "data": {"columns": tree_columns, "row_actions": _with_action_gate_list(tree_row_actions)}})
@@ -521,12 +528,12 @@ class LoadContractHandler(BaseIntentHandler):
             kanban_view = views.get("kanban") or {}
             kanban_semantics = _extract_kanban_semantics(kanban_view)
             kanban_card_actions = [
-                {"key": "open", "label": "查看详情", "enabled": True, "reason_code": "OK"},
+                {"key": "open", "label": "查看详情", "enabled": True, "reason_code": REASON_OK},
                 {
                     "key": "edit",
                     "label": "编辑",
                     "enabled": bool(permissions.get("write", False)),
-                    "reason_code": "OK" if permissions.get("write") else "PERMISSION_DENIED",
+                    "reason_code": REASON_OK if permissions.get("write") else REASON_PERMISSION_DENIED,
                 },
             ]
             _add_zone(
@@ -565,7 +572,7 @@ class LoadContractHandler(BaseIntentHandler):
             },
             "verdict": {
                 "is_closed_state": is_closed_state,
-                "reason_code": "STATE_BLOCKED" if is_closed_state else "OK",
+                "reason_code": REASON_STATE_BLOCKED if is_closed_state else REASON_OK,
             },
         }
 

--- a/docs/contract/cases.yml
+++ b/docs/contract/cases.yml
@@ -258,6 +258,140 @@
     }
   },
   {
+    "case": "api_onchange_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "api.onchange",
+    "intent_params": {
+      "model": "project.project",
+      "values": {
+        "name": "Snapshot Project"
+      },
+      "changed_fields": [
+        "name"
+      ],
+      "changed": [
+        "name"
+      ],
+      "context": {}
+    }
+  },
+  {
+    "case": "meta_intent_catalog_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "meta.intent_catalog",
+    "intent_params": {}
+  },
+  {
+    "case": "telemetry_track_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "telemetry.track",
+    "intent_params": {
+      "event_type": "scene_open"
+    }
+  },
+  {
+    "case": "cost_tracking_enter_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "cost.tracking.enter",
+    "intent_params": {
+      "project_id": 1
+    }
+  },
+  {
+    "case": "project_dashboard_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "project.dashboard",
+    "intent_params": {
+      "project_id": 1
+    }
+  },
+  {
+    "case": "project_dashboard_enter_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "project.dashboard.enter",
+    "intent_params": {
+      "project_id": 1
+    }
+  },
+  {
+    "case": "risk_action_execute_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "risk.action.execute",
+    "intent_params": {
+      "action": "claim",
+      "project_id": 1,
+      "name": "Snapshot Risk Action"
+    }
+  },
+  {
+    "case": "payment_request_available_actions_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.available_actions",
+    "intent_params": {
+      "id": 1
+    }
+  },
+  {
+    "case": "payment_request_execute_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.execute",
+    "intent_params": {
+      "id": 1,
+      "action": "submit",
+      "request_id": "snapshot_payment_request_execute_1"
+    }
+  },
+  {
+    "case": "payment_request_submit_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.submit",
+    "intent_params": {
+      "id": 1,
+      "request_id": "snapshot_payment_request_submit_1"
+    }
+  },
+  {
+    "case": "payment_request_approve_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.approve",
+    "intent_params": {
+      "id": 1,
+      "request_id": "snapshot_payment_request_approve_1"
+    }
+  },
+  {
+    "case": "payment_request_reject_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.reject",
+    "intent_params": {
+      "id": 1,
+      "reason": "snapshot reject reason",
+      "request_id": "snapshot_payment_request_reject_1"
+    }
+  },
+  {
+    "case": "payment_request_done_intent_admin",
+    "user": "admin",
+    "op": "intent.invoke",
+    "intent": "payment.request.done",
+    "intent_params": {
+      "id": 1,
+      "request_id": "snapshot_payment_request_done_1"
+    }
+  },
+  {
     "case": "capability_visibility_report_intent_admin",
     "user": "admin",
     "op": "intent.invoke",
@@ -691,7 +825,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "project.project",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_sc_project_list",
     "include_meta": true
   },
@@ -700,7 +834,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "construction.contract",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_construction_contract",
     "include_meta": true
   },
@@ -709,7 +843,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "construction.contract",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_construction_contract_income",
     "include_meta": true
   },
@@ -718,7 +852,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "construction.contract",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_construction_contract_expense",
     "include_meta": true
   },
@@ -727,7 +861,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "project.cost.ledger",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_project_cost_ledger",
     "include_meta": true
   },
@@ -736,7 +870,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "project.cost.ledger",
-    "view_type": "pivot",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_project_cost_compare",
     "include_meta": true
   },
@@ -745,7 +879,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "payment.request",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_payment_request",
     "include_meta": true
   },
@@ -754,7 +888,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "payment.request",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "smart_construction_core.action_sc_operating_drill_overpay_risk_pr",
     "include_meta": true
   },
@@ -763,7 +897,7 @@
     "user": "pm",
     "op": "action_open",
     "model": "project.task",
-    "view_type": "tree",
+    "view_type": "list",
     "action_xmlid": "project.action_view_all_task",
     "include_meta": true
   },

--- a/docs/contract/snapshots/api_onchange_intent_admin.json
+++ b/docs/contract/snapshots/api_onchange_intent_admin.json
@@ -1,0 +1,12 @@
+{
+  "case": "api_onchange_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "changes": {
+      "name": "Snapshot Project"
+    }
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/cost_tracking_enter_intent_admin.json
+++ b/docs/contract/snapshots/cost_tracking_enter_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "cost_tracking_enter_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "project_id": 1,
+    "scene_key": "cost.tracking"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/load_view_intent_pm.json
+++ b/docs/contract/snapshots/load_view_intent_pm.json
@@ -1,0 +1,13 @@
+{
+  "case": "load_view_intent_pm",
+  "op": "intent.invoke",
+  "user": "pm",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "head": {
+      "model": "project.project",
+      "view_type": "form"
+    }
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/meta_intent_catalog_intent_admin.json
+++ b/docs/contract/snapshots/meta_intent_catalog_intent_admin.json
@@ -1,0 +1,12 @@
+{
+  "case": "meta_intent_catalog_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "intents": [
+      "system.init"
+    ]
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_approve_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_approve_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_approve_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "approve"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_available_actions_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_available_actions_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_available_actions_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "actions": []
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_done_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_done_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_done_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "done"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_execute_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_execute_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_execute_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "submit"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_reject_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_reject_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_reject_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "reject"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/payment_request_submit_intent_admin.json
+++ b/docs/contract/snapshots/payment_request_submit_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "payment_request_submit_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "submit"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/project_dashboard_enter_intent_admin.json
+++ b/docs/contract/snapshots/project_dashboard_enter_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "project_dashboard_enter_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "project_id": 1,
+    "scene_key": "project.dashboard"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/project_dashboard_intent_admin.json
+++ b/docs/contract/snapshots/project_dashboard_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "project_dashboard_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "project_id": 1,
+    "scene_key": "project.dashboard"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/risk_action_execute_intent_admin.json
+++ b/docs/contract/snapshots/risk_action_execute_intent_admin.json
@@ -1,0 +1,11 @@
+{
+  "case": "risk_action_execute_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "success": true,
+    "intent_action": "claim"
+  },
+  "error": null
+}

--- a/docs/contract/snapshots/telemetry_track_intent_admin.json
+++ b/docs/contract/snapshots/telemetry_track_intent_admin.json
@@ -1,0 +1,10 @@
+{
+  "case": "telemetry_track_intent_admin",
+  "op": "intent.invoke",
+  "user": "admin",
+  "contract_version": "v1",
+  "ui_contract_raw": {
+    "event_type": "scene_open"
+  },
+  "error": null
+}


### PR DESCRIPTION
## Summary
- replace handler-local load contract reason-code literals with stable constant references
- normalize outdated contract case view-type aliases and repair the broken `load_view` snapshot artifact
- add explicit contract cases and snapshot coverage for the previously inferred intent examples

## Verification
- bash scripts/verify/contract_drift_guard.sh
- make verify.contract.preflight
- make verify.contract.catalog
