### PR TITLE
fix deploy gate contract and install guards

### DIFF
--- a/addons/smart_construction_core/views/core/project_quick_create_wizard_views.xml
+++ b/addons/smart_construction_core/views/core/project_quick_create_wizard_views.xml
@@ -23,7 +23,7 @@
         <field name="view_mode">form</field>
         <field name="view_id" ref="view_project_quick_create_wizard_form"/>
         <field name="target">new</field>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_project_manager'), ref('smart_construction_core.group_sc_super_admin')])]"/>
         <field name="context">{'default_manager_id': uid}</field>
     </record>
 </odoo>
-

--- a/addons/smart_core/core/system_init_payload_builder.py
+++ b/addons/smart_core/core/system_init_payload_builder.py
@@ -411,7 +411,7 @@ class SystemInitPayloadBuilder:
                 compact["workflow_surface"] = compact_workflow_surface
             meta = item.get("meta") if isinstance(item.get("meta"), dict) else {}
             compact_meta = {}
-            for key in ("target", "next_scene", "ui_base_contract_source", "parser_semantic_surface"):
+            for key in ("target", "next_scene", "ui_base_contract_source", "parser_semantic_surface", "compile_verdict"):
                 value = meta.get(key)
                 if value not in (None, {}, []):
                     compact_meta[key] = value
@@ -422,7 +422,13 @@ class SystemInitPayloadBuilder:
 
         meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
         compact_meta = {}
-        for key in ("generated_by", "scene_count", "mode"):
+        for key in (
+            "generated_by",
+            "scene_count",
+            "mode",
+            "base_contract_bound_scene_count",
+            "compile_issue_scene_count",
+        ):
             value = meta.get(key)
             if value not in (None, {}, []):
                 compact_meta[key] = value

--- a/addons/smart_core/core/ui_base_contract_asset_producer.py
+++ b/addons/smart_core/core/ui_base_contract_asset_producer.py
@@ -66,6 +66,10 @@ def _load_scene_rows(env) -> tuple[list[dict], str]:
         return [], "fallback"
 
 
+def _normalize_scene_rows(scene_rows: list[dict] | None) -> list[dict]:
+    return [row for row in (scene_rows or []) if isinstance(row, dict)]
+
+
 def _build_runtime_ui_base_contract(env, *, action_id: int) -> dict:
     if int(action_id or 0) <= 0:
         return {}
@@ -105,6 +109,7 @@ def refresh_ui_base_contract_assets(
     env,
     *,
     scene_keys: list[str] | None = None,
+    scene_rows: list[dict] | None = None,
     limit: int = 50,
     role_code: str | None = None,
     company_id: int | None = None,
@@ -113,6 +118,10 @@ def refresh_ui_base_contract_assets(
 ) -> dict:
     requested_keys = {_text(item) for item in (scene_keys or []) if _text(item)}
     rows, scene_source = _load_scene_rows(env)
+    if not rows:
+        rows = _normalize_scene_rows(scene_rows)
+        if rows:
+            scene_source = "runtime_rows"
     produced = 0
     skipped = 0
     failed = 0

--- a/addons/smart_core/core/ui_base_contract_asset_repository.py
+++ b/addons/smart_core/core/ui_base_contract_asset_repository.py
@@ -97,6 +97,7 @@ def _auto_refresh_missing_assets(
     env,
     *,
     scene_keys: list[str],
+    scene_rows: list[dict] | None = None,
     role_code: str | None,
     company_id: int | None,
 ) -> None:
@@ -108,6 +109,7 @@ def _auto_refresh_missing_assets(
         refresh_ui_base_contract_assets(
             env,
             scene_keys=scene_keys,
+            scene_rows=scene_rows,
             limit=max(len(scene_keys), 1),
             role_code=role_code,
             company_id=company_id,
@@ -443,6 +445,7 @@ def bind_scene_assets(
         _auto_refresh_missing_assets(
             env,
             scene_keys=missing_keys,
+            scene_rows=[row for row in rows if _text(row.get("code") or row.get("key")) in set(missing_keys)],
             role_code=role_code,
             company_id=company_id,
         )

--- a/addons/smart_core/handlers/system_init.py
+++ b/addons/smart_core/handlers/system_init.py
@@ -46,6 +46,7 @@ from odoo.addons.smart_core.core.system_init_scene_runtime_surface_context impor
 from odoo.addons.smart_core.core.system_init_scene_runtime_surface_builder import SystemInitSceneRuntimeSurfaceBuilder
 from odoo.addons.smart_core.core.system_init_dictionary_data_helper import apply_dictionary_startup_data
 from odoo.addons.smart_core.core.intent_execution_result import IntentExecutionResult
+from odoo.addons.smart_core.core.page_contracts_builder import build_page_contracts
 from odoo.addons.smart_core.core.workspace_home_contract_builder import build_workspace_home_contract
 from odoo.addons.smart_core.core.runtime_page_contract_builder import mirror_workspace_home_role_context
 from odoo.addons.smart_core.core.scene_governance_payload_builder import build_scene_governance_payload_v1
@@ -679,6 +680,7 @@ class SystemInitHandler(BaseIntentHandler):
             data["workspace_home"] = build_workspace_home_contract(data)
         else:
             data.pop("workspace_home", None)
+        data["page_contracts"] = build_page_contracts(data)
         mirror_workspace_home_role_context(data)
         stage_ts = _mark("build_workspace_home", stage_ts)
         role_surface = data.get("role_surface") if isinstance(data, dict) else {}

--- a/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
+++ b/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
@@ -275,6 +275,40 @@ class TestSystemInitPayloadBuilderSemantics(unittest.TestCase):
         self.assertEqual(((scene.get("runtime_handoff_surface") or {}).get("family")), "contracts")
         self.assertEqual(((scene.get("product_delivery_surface") or {}).get("delivery_mode")), "direct_delivery")
 
+    def test_minimal_scene_ready_contract_preserves_gate_meta(self):
+        payload = target.SystemInitPayloadBuilder._build_minimal_scene_ready_contract(
+            {
+                "scenes": [
+                    {
+                        "scene": {"key": "projects.list", "title": "项目列表"},
+                        "page": {"route": "/s/projects.list"},
+                        "meta": {
+                            "target": {"route": "/s/projects.list"},
+                            "ui_base_contract_source": {"kind": "asset", "asset_id": 12},
+                            "compile_verdict": {
+                                "ok": True,
+                                "grammar_ok": True,
+                                "semantic_ok": True,
+                                "base_contract_bound": True,
+                            },
+                        },
+                    }
+                ],
+                "meta": {
+                    "generated_by": "test",
+                    "scene_count": 1,
+                    "mode": "dual_track",
+                    "base_contract_bound_scene_count": 1,
+                    "compile_issue_scene_count": 0,
+                },
+            }
+        )
+
+        scene = ((payload.get("scenes") or [])[0] or {})
+        self.assertTrue(((scene.get("meta") or {}).get("compile_verdict") or {}).get("base_contract_bound"))
+        self.assertEqual(((payload.get("meta") or {}).get("base_contract_bound_scene_count")), 1)
+        self.assertEqual(((payload.get("meta") or {}).get("compile_issue_scene_count")), 0)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/addons/smart_core/tests/test_ui_base_contract_asset_producer.py
+++ b/addons/smart_core/tests/test_ui_base_contract_asset_producer.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+CORE_DIR = Path(__file__).resolve().parents[1] / "core"
+
+
+def _load_module(module_name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+sys.modules.setdefault("odoo", types.ModuleType("odoo"))
+odoo_mod = sys.modules["odoo"]
+odoo_mod.api = types.SimpleNamespace(Environment=lambda *args, **kwargs: None)
+
+sys.modules.setdefault("odoo.addons", types.ModuleType("odoo.addons"))
+smart_core_pkg = sys.modules.setdefault("odoo.addons.smart_core", types.ModuleType("odoo.addons.smart_core"))
+smart_core_pkg.__path__ = [str(CORE_DIR.parent)]
+core_pkg = sys.modules.setdefault("odoo.addons.smart_core.core", types.ModuleType("odoo.addons.smart_core.core"))
+core_pkg.__path__ = [str(CORE_DIR)]
+smart_core_pkg.core = core_pkg
+
+canonicalizer = types.ModuleType("odoo.addons.smart_core.core.ui_base_contract_canonicalizer")
+canonicalizer.canonicalize_ui_base_contract = lambda payload: payload if isinstance(payload, dict) else {}
+sys.modules["odoo.addons.smart_core.core.ui_base_contract_canonicalizer"] = canonicalizer
+core_pkg.ui_base_contract_canonicalizer = canonicalizer
+
+contract_service = types.ModuleType("odoo.addons.smart_core.app_config_engine.services.contract_service")
+contract_service.ContractService = object
+sys.modules["odoo.addons.smart_core.app_config_engine.services.contract_service"] = contract_service
+
+action_dispatcher = types.ModuleType(
+    "odoo.addons.smart_core.app_config_engine.services.dispatchers.action_dispatcher"
+)
+action_dispatcher.ActionDispatcher = object
+sys.modules[
+    "odoo.addons.smart_core.app_config_engine.services.dispatchers.action_dispatcher"
+] = action_dispatcher
+
+scene_registry_provider = types.ModuleType("odoo.addons.smart_core.core.scene_registry_provider")
+scene_registry_provider.has_db_scenes = lambda env: False
+scene_registry_provider.load_scene_configs = lambda env, drift=None: []
+sys.modules["odoo.addons.smart_core.core.scene_registry_provider"] = scene_registry_provider
+core_pkg.scene_registry_provider = scene_registry_provider
+
+captured_upserts = []
+
+
+def _upsert_asset(_env, **vals):
+    captured_upserts.append(vals)
+    return {"id": len(captured_upserts), **vals}
+
+
+repo_module = types.ModuleType("odoo.addons.smart_core.core.ui_base_contract_asset_repository")
+repo_module.upsert_asset = _upsert_asset
+sys.modules["odoo.addons.smart_core.core.ui_base_contract_asset_repository"] = repo_module
+core_pkg.ui_base_contract_asset_repository = repo_module
+
+target = _load_module(
+    "odoo.addons.smart_core.core.ui_base_contract_asset_producer",
+    CORE_DIR / "ui_base_contract_asset_producer.py",
+)
+
+
+class TestUiBaseContractAssetProducer(unittest.TestCase):
+    def setUp(self):
+        captured_upserts.clear()
+
+    def test_refresh_uses_runtime_rows_when_registry_empty(self):
+        result = target.refresh_ui_base_contract_assets(
+            env=object(),
+            scene_keys=["projects.list"],
+            scene_rows=[
+                {
+                    "code": "projects.list",
+                    "target": {
+                        "route": "/s/projects.list",
+                        "model": "project.project",
+                    },
+                }
+            ],
+            role_code="owner",
+            company_id=1,
+            source_type="runtime_intent",
+            code_version="unit-test",
+        )
+
+        self.assertEqual(result["scene_source"], "runtime_rows")
+        self.assertEqual(result["produced_count"], 1)
+        self.assertEqual(result["failed_count"], 0)
+        self.assertEqual(len(captured_upserts), 1)
+        self.assertEqual(captured_upserts[0]["scene_key"], "projects.list")
+        self.assertEqual(captured_upserts[0]["role_code"], "owner")
+        self.assertEqual(captured_upserts[0]["company_id"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/docs/ops/boundary_audit_smart_core_20260130.md
+++ b/docs/ops/boundary_audit_smart_core_20260130.md
@@ -1,15 +1,40 @@
 # smart_core boundary audit
 
 - Scan root: addons/smart_core
-- Generated at (UTC): 2026-02-15T13:32:42.201399Z
-- Files scanned: 135
+- Generated at (UTC): 2026-04-23T16:34:55.920377Z
+- Files scanned: 261
 
 ## Keyword Hits
-- addons/smart_core/app_config_engine/services/resolvers/action_resolver.py
-- addons/smart_core/handlers/scene_governance.py
-- addons/smart_core/handlers/scene_package.py
-- addons/smart_core/handlers/scene_packages_installed.py
+- addons/smart_core/core/industry_orchestration_service_adapter.py
+- addons/smart_core/core/page_contracts_builder.py
+- addons/smart_core/core/release_navigation_contract_builder.py
+- addons/smart_core/core/scene_delivery_policy.py
+- addons/smart_core/core/scene_dsl_compiler.py
+- addons/smart_core/core/scene_ready_semantic_orchestration_bridge.py
+- addons/smart_core/core/system_init_extension_fact_merger.py
+- addons/smart_core/core/workspace_home_contract_builder.py
+- addons/smart_core/delivery/edition_release_snapshot_service.py
+- addons/smart_core/delivery/product_policy_service.py
+- addons/smart_core/delivery/release_approval_policy_service.py
+- addons/smart_core/delivery/release_audit_trail_service.py
+- addons/smart_core/delivery/release_operator_read_model_service.py
 - addons/smart_core/handlers/system_init.py
+- addons/smart_core/orchestration/project_dashboard_scene_orchestrator.py
+- addons/smart_core/tests/test_action_dispatcher_server_mapping.py
+- addons/smart_core/tests/test_backend_semantic_copy_supply.py
+- addons/smart_core/tests/test_contract_governance_project_form.py
+- addons/smart_core/tests/test_identity_resolver_entry_target.py
+- addons/smart_core/tests/test_intent_dispatcher_permission_error_contract.py
+- addons/smart_core/tests/test_release_operator_surface_copy_backend.py
+- addons/smart_core/tests/test_scene_delivery_policy.py
+- addons/smart_core/tests/test_scene_nav_contract_builder.py
+- addons/smart_core/tests/test_scene_normalizer_entry_target.py
+- addons/smart_core/tests/test_scene_normalizer_target_resolution.py
+- addons/smart_core/tests/test_scene_ready_contract_builder_semantic_consumption.py
+- addons/smart_core/tests/test_scene_ready_semantic_orchestration_bridge.py
+- addons/smart_core/tests/test_scene_runtime_contract_chain.py
+- addons/smart_core/tests/test_ui_base_contract_asset_repository.py
+- addons/smart_core/utils/contract_governance.py
 
 ## Reverse Dependency Hits
 - None

--- a/frontend/apps/web/src/views/HomeView.vue
+++ b/frontend/apps/web/src/views/HomeView.vue
@@ -725,6 +725,19 @@ const blockHeroData = computed<Record<string, unknown>>(() => workspaceBlocksByT
 const blockMetricData = computed<Record<string, unknown>>(() => workspaceBlocksByType.value.get('metric') || {});
 const blockRiskData = computed<Record<string, unknown>>(() => workspaceBlocksByType.value.get('risk') || {});
 const blockOpsData = computed<Record<string, unknown>>(() => workspaceBlocksByType.value.get('ops') || {});
+const workspaceHomeMetrics = computed<unknown[]>(() => {
+  return Array.isArray(workspaceHome.value.metrics) ? workspaceHome.value.metrics : [];
+});
+const workspaceHomeRisk = computed<Record<string, unknown>>(() => {
+  return (workspaceHome.value.risk && typeof workspaceHome.value.risk === 'object')
+    ? workspaceHome.value.risk as Record<string, unknown>
+    : {};
+});
+const workspaceHomeOps = computed<Record<string, unknown>>(() => {
+  return (workspaceHome.value.ops && typeof workspaceHome.value.ops === 'object')
+    ? workspaceHome.value.ops as Record<string, unknown>
+    : {};
+});
 const workspaceHeroEffective = computed<Record<string, unknown>>(() => {
   return (blockHeroData.value.hero && typeof blockHeroData.value.hero === 'object')
     ? blockHeroData.value.hero as Record<string, unknown>
@@ -1089,7 +1102,9 @@ function keywordList(key: string, fallbackCsv: string) {
 }
 
 const coreMetrics = computed<CoreMetric[]>(() => {
-  const source = Array.isArray(blockMetricData.value.metrics) ? blockMetricData.value.metrics : [];
+  const source = workspaceHomeMetrics.value.length
+    ? workspaceHomeMetrics.value
+    : (Array.isArray(blockMetricData.value.metrics) ? blockMetricData.value.metrics : []);
   return source
     .map((item, idx) => {
       const row = (item && typeof item === 'object') ? item as Record<string, unknown> : {};
@@ -1135,9 +1150,11 @@ const primaryTodos = computed<SuggestionItem[]>(() => concreteTodos.value.slice(
 const hasMoreTodos = computed(() => concreteTodos.value.length > 3);
 
 const workspaceRisk = computed<Record<string, unknown>>(() => {
-  return (blockRiskData.value.risk && typeof blockRiskData.value.risk === 'object')
-    ? blockRiskData.value.risk as Record<string, unknown>
-    : {};
+  return Object.keys(workspaceHomeRisk.value).length
+    ? workspaceHomeRisk.value
+    : ((blockRiskData.value.risk && typeof blockRiskData.value.risk === 'object')
+      ? blockRiskData.value.risk as Record<string, unknown>
+      : {});
 });
 
 const riskBuckets = computed(() => {
@@ -1216,9 +1233,11 @@ const riskSources = computed(() => {
 });
 
 const workspaceOps = computed<Record<string, unknown>>(() => {
-  return (blockOpsData.value.ops && typeof blockOpsData.value.ops === 'object')
-    ? blockOpsData.value.ops as Record<string, unknown>
-    : {};
+  return Object.keys(workspaceHomeOps.value).length
+    ? workspaceHomeOps.value
+    : ((blockOpsData.value.ops && typeof blockOpsData.value.ops === 'object')
+      ? blockOpsData.value.ops as Record<string, unknown>
+      : {});
 });
 
 const opsBars = computed(() => {

--- a/scripts/verify/contract_api_mode_smoke.py
+++ b/scripts/verify/contract_api_mode_smoke.py
@@ -8,6 +8,8 @@ import urllib.request
 from http.cookiejar import CookieJar
 from urllib.error import HTTPError
 
+from python_http_smoke_utils import get_base_url
+
 
 def _post_json(url: str, payload: dict, *, cookie_jar: CookieJar, headers: dict | None = None):
     req = urllib.request.Request(url, data=json.dumps(payload).encode("utf-8"), method="POST")
@@ -120,7 +122,9 @@ def _run_one(base_url: str, db: str, login: str, password: str) -> bool:
 
 
 def main() -> None:
-    raw_base_url = os.environ.get("FRONTEND_API_BASE_URL", "http://localhost:8070").rstrip("/")
+    raw_base_url = os.environ.get("FRONTEND_API_BASE_URL", "").rstrip("/")
+    if not raw_base_url:
+        raw_base_url = get_base_url()
     lang = os.environ.get("FRONTEND_API_LANG", "").strip("/")
     db = os.environ.get("DB_NAME", "sc_demo")
     login = os.environ.get("FRONTEND_API_LOGIN", "admin")

--- a/scripts/verify/scene_engine_migration_matrix_guard.py
+++ b/scripts/verify/scene_engine_migration_matrix_guard.py
@@ -9,6 +9,7 @@ from typing import Any
 
 ROOT = Path(__file__).resolve().parents[2]
 BASELINE_PATH = ROOT / "scripts" / "verify" / "baselines" / "scene_engine_migration_matrix_guard.json"
+DEFAULT_FIELD_SCHEMA_STATE_PATH = ROOT / "artifacts" / "backend" / "scene_contract_v1_field_schema_state.json"
 
 
 def _text(value: Any) -> str:
@@ -58,6 +59,74 @@ def _write(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
 
 
+def _derive_runtime_state_from_scene_ready(payload: dict) -> dict:
+    ready = _as_dict(payload.get("scene_ready_contract_v1")) if isinstance(payload.get("scene_ready_contract_v1"), dict) else payload
+    if not ready:
+        return {}
+    scene_meta = _as_dict(ready.get("meta"))
+    scenes = _as_list(ready.get("scenes"))
+    if not scenes:
+        return {}
+
+    per_scene: dict[str, dict[str, Any]] = {}
+    source_kind_counts = {
+        "asset": 0,
+        "runtime_fallback": 0,
+        "runtime_minimal": 0,
+        "inline": 0,
+        "none": 0,
+        "other": 0,
+    }
+    scene_keys: list[str] = []
+    for row in scenes:
+        item = _as_dict(row)
+        scene_key = _text(_as_dict(item.get("scene")).get("key"))
+        if not scene_key:
+            continue
+        scene_keys.append(scene_key)
+        meta = _as_dict(item.get("meta"))
+        verdict = _as_dict(meta.get("compile_verdict"))
+        source_meta = _as_dict(meta.get("ui_base_contract_source"))
+        source_kind = _text(source_meta.get("kind")) or "none"
+        if source_kind not in source_kind_counts:
+            source_kind = "other"
+        source_kind_counts[source_kind] = _safe_int(source_kind_counts.get(source_kind), 0) + 1
+        action_total = _safe_int(_as_dict(_as_dict(item.get("action_surface")).get("counts")).get("total"), 0)
+        per_scene[scene_key] = {
+            "base_contract_bound": bool(verdict.get("base_contract_bound")),
+            "compile_ok": bool(verdict.get("ok")),
+            "source_kind": source_kind,
+            "action_total": action_total,
+        }
+
+    total_scene_count = _safe_int(scene_meta.get("scene_count"), len(scene_keys))
+    denom = float(total_scene_count) if total_scene_count > 0 else 1.0
+    source_kind_ratios = {
+        key: float(_safe_int(value, 0)) / denom
+        for key, value in source_kind_counts.items()
+    }
+    return {
+        "scene_count": total_scene_count,
+        "base_contract_bound_scene_count": _safe_int(scene_meta.get("base_contract_bound_scene_count"), 0),
+        "compile_issue_scene_count": _safe_int(scene_meta.get("compile_issue_scene_count"), 0),
+        "scene_keys": sorted(set(scene_keys)),
+        "source_kind_counts": source_kind_counts,
+        "source_kind_ratios": source_kind_ratios,
+        "per_scene": per_scene,
+    }
+
+
+def _load_runtime_state(state_path: Path) -> tuple[dict, str]:
+    field_schema_state = _load_json(DEFAULT_FIELD_SCHEMA_STATE_PATH)
+    derived_state = _derive_runtime_state_from_scene_ready(field_schema_state)
+    if derived_state:
+        return derived_state, DEFAULT_FIELD_SCHEMA_STATE_PATH.relative_to(ROOT).as_posix()
+    fallback_state = _load_json(state_path)
+    if fallback_state:
+        return fallback_state, state_path.relative_to(ROOT).as_posix()
+    return {}, state_path.relative_to(ROOT).as_posix()
+
+
 def main() -> int:
     baseline = _load_json(BASELINE_PATH)
     if not baseline:
@@ -89,7 +158,7 @@ def main() -> int:
     }
 
     module_map = _load_json(module_map_path)
-    state = _load_json(state_path)
+    state, effective_state_source = _load_runtime_state(state_path)
     if not module_map:
         print("[scene_engine_migration_matrix_guard] FAIL")
         print(f" - missing module map: {module_map_path.relative_to(ROOT).as_posix()}")
@@ -172,7 +241,7 @@ def main() -> int:
         "sources": {
             "baseline": BASELINE_PATH.relative_to(ROOT).as_posix(),
             "module_map_file": module_map_path.relative_to(ROOT).as_posix(),
-            "state_file": state_path.relative_to(ROOT).as_posix(),
+            "state_file": effective_state_source,
         },
     }
 


### PR DESCRIPTION
## Summary
- closes the remaining deploy gate blockers on `codex/main-deploy-gate-20260423`
- restores `system.init -> workspace_home/page_contracts` boundary compliance for Home
- fixes scene asset/runtime fallback and migration-matrix state sourcing so restricted/live contract guards pass
- tightens `smart_construction_core.action_project_quick_create_wizard` with explicit `groups_id` so install/security gates pass

## Architecture Impact
- keeps the startup chain stable: `login -> system.init -> ui.contract`
- preserves contract-first consumption for Home by wiring page/workspace payloads from backend instead of frontend inference
- keeps scene governance verification in `addons/smart_core` and security gating in `addons/smart_construction_core`

## Layer Target
- Platform Layer: `addons/smart_core`
- Domain / Odoo Action Security: `addons/smart_construction_core`
- Verification / Governance: `scripts/verify`, `docs/ops`

## Affected Modules
- `addons/smart_core`
- `addons/smart_construction_core`
- `frontend/apps/web`
- `scripts/verify`
- `docs/ops`

## Key Changes
- `addons/smart_core/core/ui_base_contract_asset_producer.py`
  adds runtime-row fallback support when registry scene config is unavailable
- `addons/smart_core/core/ui_base_contract_asset_repository.py`
  passes missing runtime rows into auto-refresh asset generation
- `addons/smart_core/core/system_init_payload_builder.py`
  preserves gate-critical `scene_ready_contract_v1` metadata in minimal payloads
- `addons/smart_core/handlers/system_init.py`
  injects `page_contracts` alongside `workspace_home`
- `frontend/apps/web/src/views/HomeView.vue`
  consumes `metrics/risk/ops` directly from `workspace_home` before block fallbacks
- `scripts/verify/scene_engine_migration_matrix_guard.py`
  derives runtime state from fresh field-schema artifacts before falling back to stale snapshots
- `scripts/verify/contract_api_mode_smoke.py`
  resolves the test/dev API base URL dynamically instead of hardcoding `8070`
- `addons/smart_construction_core/views/core/project_quick_create_wizard_views.xml`
  adds `groups_id` to the quick-create wizard action to block URL/action bypass

## Validation
- `python3 -m unittest addons.smart_core.tests.test_ui_base_contract_asset_producer addons.smart_core.tests.test_ui_base_contract_asset_repository addons.smart_core.tests.test_system_init_payload_builder_semantics`
- `python3 scripts/verify/frontend_home_suggestion_semantics_guard.py`
- `ENV=test ENV_FILE=.env.test DB_NAME=sc_test make env.matrix.check`
- `ENV=test ENV_FILE=.env.test DB_NAME=sc_test make demo.reset`
- `ENV=test ENV_FILE=.env.test DB_NAME=sc_test DB_CI=sc_ci_test_fix_quick_create make ci.gate`

## Result
- deploy gate status: PASS
- install/security gate status: PASS
- fresh CI db install status: PASS
