### PR TITLE
Preserve provider scene target identity

### DIFF
--- a/addons/smart_core/core/scene_provider.py
+++ b/addons/smart_core/core/scene_provider.py
@@ -265,6 +265,16 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
 
         return target
 
+    def _refresh_target_ids_from_xmlid_identity(target_payload: dict) -> dict:
+        target = dict(target_payload) if isinstance(target_payload, dict) else {}
+        if not target:
+            return target
+        if str(target.get("action_xmlid") or "").strip():
+            target.pop("action_id", None)
+        if str(target.get("menu_xmlid") or "").strip():
+            target.pop("menu_id", None)
+        return _hydrate_target(target)
+
     def _ensure_minimal_route_target(scene_payload: dict, scene_code: str) -> None:
         if not isinstance(scene_payload, dict):
             return
@@ -350,6 +360,10 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
         if not has_xmlid_identity:
             return dict(registry_target)
         next_target = dict(current_target)
+        if str(next_target.get("action_xmlid") or "").strip():
+            next_target.pop("action_id", None)
+        if str(next_target.get("menu_xmlid") or "").strip():
+            next_target.pop("menu_id", None)
         for key, value in registry_target.items():
             if key in ("action_id", "menu_id"):
                 continue
@@ -403,6 +417,7 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
 
         if isinstance(scene.get("target"), dict):
             scene["target"] = _hydrate_target(scene.get("target"))
+            scene["target"] = _refresh_target_ids_from_xmlid_identity(scene.get("target"))
         _ensure_minimal_route_target(scene, code)
 
         if code not in critical_target_overrides:
@@ -422,7 +437,7 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
             current_target = scene.get("target")
             merged_target = _merge_registry_target_without_overwriting_identity(current_target, registry_target)
             if current_target != merged_target:
-                scene["target"] = merged_target
+                scene["target"] = _hydrate_target(merged_target)
                 reconciled.append(code)
 
         capability_target = capability_map.get(code)

--- a/addons/smart_core/core/scene_provider.py
+++ b/addons/smart_core/core/scene_provider.py
@@ -338,6 +338,25 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
         scene_payload["target"] = next_target
         return True
 
+    def _merge_registry_target_without_overwriting_identity(current_target: dict, registry_target: dict) -> dict:
+        if not isinstance(current_target, dict):
+            current_target = {}
+        if not isinstance(registry_target, dict):
+            return dict(current_target)
+        has_xmlid_identity = bool(
+            str(current_target.get("action_xmlid") or "").strip()
+            or str(current_target.get("menu_xmlid") or "").strip()
+        )
+        if not has_xmlid_identity:
+            return dict(registry_target)
+        next_target = dict(current_target)
+        for key, value in registry_target.items():
+            if key in ("action_id", "menu_id"):
+                continue
+            if next_target.get(key) in (None, "", [], {}) and value not in (None, "", [], {}):
+                next_target[key] = value
+        return next_target
+
     current = [scene for scene in (scenes or []) if isinstance(scene, dict)]
     dropped_pkg_variants = []
     filtered = []
@@ -401,8 +420,9 @@ def merge_missing_scenes_from_registry(env, scenes, warnings):
         registry_target = registry_scene.get("target")
         if isinstance(registry_target, dict) and registry_target:
             current_target = scene.get("target")
-            if current_target != registry_target:
-                scene["target"] = dict(registry_target)
+            merged_target = _merge_registry_target_without_overwriting_identity(current_target, registry_target)
+            if current_target != merged_target:
+                scene["target"] = merged_target
                 reconciled.append(code)
 
         capability_target = capability_map.get(code)

--- a/addons/smart_core/tests/test_scene_provider_target_identity_merge.py
+++ b/addons/smart_core/tests/test_scene_provider_target_identity_merge.py
@@ -161,6 +161,44 @@ class TestSceneProviderTargetIdentityMerge(unittest.TestCase):
         self.assertEqual(scene_target.get("action_id"), 452)
         self.assertEqual(scene_target.get("menu_id"), 265)
 
+    def test_existing_xmlid_identity_refreshes_stale_numeric_ids_without_provider_rewrite(self):
+        original_registry_load = target.registry_load_scene_configs
+        original_provider_payload = target._resolve_scene_provider_payload
+        original_extension_hook = target.call_extension_hook_first
+        try:
+            target.registry_load_scene_configs = lambda env: []
+            target._resolve_scene_provider_payload = lambda scene_key, runtime_context=None: {}
+            target.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: {"projects.list"} if hook_name == "smart_core_critical_scene_target_overrides" else {}
+
+            rows = target.merge_missing_scenes_from_registry(
+                _FakeEnv(),
+                [
+                    {
+                        "code": "projects.list",
+                        "name": "项目列表",
+                        "target": {
+                            "route": "/s/projects.list",
+                            "action_xmlid": "smart_construction_core.action_sc_project_list",
+                            "menu_xmlid": "smart_construction_core.menu_sc_root",
+                            "action_id": 519,
+                            "menu_id": 329,
+                        },
+                    }
+                ],
+                [],
+            )
+        finally:
+            target.registry_load_scene_configs = original_registry_load
+            target._resolve_scene_provider_payload = original_provider_payload
+            target.call_extension_hook_first = original_extension_hook
+
+        scene_target = rows[0].get("target") or {}
+        self.assertEqual(scene_target.get("route"), "/s/projects.list")
+        self.assertEqual(scene_target.get("action_xmlid"), "smart_construction_core.action_sc_project_list")
+        self.assertEqual(scene_target.get("menu_xmlid"), "smart_construction_core.menu_sc_root")
+        self.assertEqual(scene_target.get("action_id"), 452)
+        self.assertEqual(scene_target.get("menu_id"), 265)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/addons/smart_core/tests/test_scene_provider_target_identity_merge.py
+++ b/addons/smart_core/tests/test_scene_provider_target_identity_merge.py
@@ -65,21 +65,26 @@ class _FakeEnv:
 
 
 class TestSceneProviderTargetIdentityMerge(unittest.TestCase):
+    def _provider_payload(self, scene_key, runtime_context=None):
+        if scene_key != "projects.list":
+            return {}
+        return {
+            "primary_action": {
+                "action_xmlid": "smart_construction_core.action_sc_project_list",
+            },
+            "fallback_strategy": {
+                "menu_xmlid": "smart_construction_core.menu_sc_root",
+                "action_xmlid": "smart_construction_core.action_sc_project_list",
+            },
+        }
+
     def test_merge_missing_scenes_prefers_provider_identity_for_critical_scene(self):
         original_registry_load = target.registry_load_scene_configs
         original_provider_payload = target._resolve_scene_provider_payload
         original_extension_hook = target.call_extension_hook_first
         try:
             target.registry_load_scene_configs = lambda env: []
-            target._resolve_scene_provider_payload = lambda scene_key, runtime_context=None: {
-                "primary_action": {
-                    "action_xmlid": "smart_construction_core.action_sc_project_list",
-                },
-                "fallback_strategy": {
-                    "menu_xmlid": "smart_construction_core.menu_sc_root",
-                    "action_xmlid": "smart_construction_core.action_sc_project_list",
-                },
-            } if scene_key == "projects.list" else {}
+            target._resolve_scene_provider_payload = self._provider_payload
             target.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: {"projects.list"} if hook_name == "smart_core_critical_scene_target_overrides" else {}
 
             rows = target.merge_missing_scenes_from_registry(
@@ -104,6 +109,52 @@ class TestSceneProviderTargetIdentityMerge(unittest.TestCase):
 
         projects_list = rows[0]
         scene_target = projects_list.get("target") or {}
+        self.assertEqual(scene_target.get("route"), "/s/projects.list")
+        self.assertEqual(scene_target.get("action_xmlid"), "smart_construction_core.action_sc_project_list")
+        self.assertEqual(scene_target.get("menu_xmlid"), "smart_construction_core.menu_sc_root")
+        self.assertEqual(scene_target.get("action_id"), 452)
+        self.assertEqual(scene_target.get("menu_id"), 265)
+
+    def test_provider_identity_survives_stale_registry_numeric_target(self):
+        original_registry_load = target.registry_load_scene_configs
+        original_provider_payload = target._resolve_scene_provider_payload
+        original_extension_hook = target.call_extension_hook_first
+        try:
+            target.registry_load_scene_configs = lambda env: [
+                {
+                    "code": "projects.list",
+                    "name": "项目列表",
+                    "target": {
+                        "route": "/s/projects.list",
+                        "action_id": 519,
+                        "menu_id": 329,
+                    },
+                }
+            ]
+            target._resolve_scene_provider_payload = self._provider_payload
+            target.call_extension_hook_first = lambda env, hook_name, *args, **kwargs: {"projects.list"} if hook_name == "smart_core_critical_scene_target_overrides" else {}
+
+            rows = target.merge_missing_scenes_from_registry(
+                _FakeEnv(),
+                [
+                    {
+                        "code": "projects.list",
+                        "name": "项目列表",
+                        "target": {
+                            "route": "/s/projects.list",
+                            "action_id": 519,
+                            "menu_id": 329,
+                        },
+                    }
+                ],
+                [],
+            )
+        finally:
+            target.registry_load_scene_configs = original_registry_load
+            target._resolve_scene_provider_payload = original_provider_payload
+            target.call_extension_hook_first = original_extension_hook
+
+        scene_target = rows[0].get("target") or {}
         self.assertEqual(scene_target.get("route"), "/s/projects.list")
         self.assertEqual(scene_target.get("action_xmlid"), "smart_construction_core.action_sc_project_list")
         self.assertEqual(scene_target.get("menu_xmlid"), "smart_construction_core.menu_sc_root")

--- a/artifacts/pr_body.md
+++ b/artifacts/pr_body.md
@@ -32,7 +32,7 @@ python3 addons/smart_core/tests/test_scene_provider_target_identity_merge.py
 Result:
 
 ```text
-Ran 2 tests in 0.001s
+Ran 3 tests in 0.001s
 OK
 ```
 

--- a/artifacts/pr_body.md
+++ b/artifacts/pr_body.md
@@ -1,47 +1,41 @@
 ## Summary
 
-- Exposes history-continuity finance ledger surfaces in `smart_construction_core`.
-- Adds replay-chain steps for payment request outflow state activation, approved/done recovery, and project lifecycle continuity.
-- Records migration alignment decisions and attaches generated replay adapter payload/result artifacts.
+- Preserves provider-supplied `action_xmlid` / `menu_xmlid` when reconciling scene targets with registry rows.
+- Prevents stale registry `action_id` / `menu_id` values from overwriting recovered XMLID identity.
+- Adds a regression test covering stale registry numeric target drift.
 
 ## Architecture Impact
 
-- Keeps changes inside the construction domain module and migration/ops evidence lanes.
-- Does not change `login -> system.init -> ui.contract`.
-- Does not modify platform core intent/router/contract-engine modules.
-- Adds Odoo native list/form/search/menu surfaces for finance-center usability after historical replay.
+- Platform Layer change scoped to scene provider target reconciliation.
+- No changes to public intent names, startup chain, route semantics, or frontend consumers.
+- Keeps XMLID as the stable cross-database identity source when provider recovery has supplied it.
 
 ## Layer Target
 
-- Domain Layer: `addons/smart_construction_core`
-- Operations/Migration Layer: `scripts/migration`, `artifacts/migration`, `docs/migration_alignment`, `docs/ops`
+- Platform Layer: `addons/smart_core`
 
 ## Affected Modules
 
-- `addons/smart_construction_core`
-- `scripts/migration`
-- `artifacts/migration`
-- `docs/migration_alignment`
-- `docs/ops`
-- `Makefile`
+- `addons/smart_core/core/scene_provider.py`
+- `addons/smart_core/tests/test_scene_provider_target_identity_merge.py`
 
 ## Reason
 
-Prepare the history continuity promotion work for merge into `main` with separated implementation, documentation, and evidence artifacts.
+Fix review finding P1: provider target identity was recovered and hydrated, then immediately discarded by a later registry target overwrite when registry rows still carried stale numeric IDs.
 
 ## Verification
 
-- Local branch preflight passed:
-  - `pwd`
-  - `git rev-parse --show-toplevel`
-  - `git branch --show-current`
-  - `git status --short`
-- Worktree was clean before PR preparation.
-- No additional runtime validation was run in this PR-prep step.
+```bash
+python3 addons/smart_core/tests/test_scene_provider_target_identity_merge.py
+```
 
-## Commits
+Result:
 
-- `58791e11 feat(finance): expose history continuity ledger views`
-- `b3d4cf9b feat(migration): add history continuity promotion replay chain`
-- `6e4be64a docs(migration): record history continuity promotion decisions`
-- `8f4888ef chore(migration): add history continuity promotion artifacts`
+```text
+Ran 2 tests in 0.001s
+OK
+```
+
+## Commit
+
+- `adf01925 fix(scene): preserve provider target identity`


### PR DESCRIPTION
## Summary

- Preserves provider-supplied `action_xmlid` / `menu_xmlid` when reconciling scene targets with registry rows.
- Prevents stale registry `action_id` / `menu_id` values from overwriting recovered XMLID identity.
- Adds a regression test covering stale registry numeric target drift.

## Architecture Impact

- Platform Layer change scoped to scene provider target reconciliation.
- No changes to public intent names, startup chain, route semantics, or frontend consumers.
- Keeps XMLID as the stable cross-database identity source when provider recovery has supplied it.

## Layer Target

- Platform Layer: `addons/smart_core`

## Affected Modules

- `addons/smart_core/core/scene_provider.py`
- `addons/smart_core/tests/test_scene_provider_target_identity_merge.py`

## Reason

Fix review finding P1: provider target identity was recovered and hydrated, then immediately discarded by a later registry target overwrite when registry rows still carried stale numeric IDs.

## Verification

```bash
python3 addons/smart_core/tests/test_scene_provider_target_identity_merge.py
```

Result:

```text
Ran 2 tests in 0.001s
OK
```

## Commit

- `adf01925 fix(scene): preserve provider target identity`
