### PR TITLE
Fix list search dropdown and supplier settings

### DIFF
--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -251,7 +251,7 @@
         <field name="view_id" ref="smart_construction_core.view_sc_supplier_partner_tree"/>
         <field name="search_view_id" ref="smart_construction_core.view_sc_supplier_partner_search"/>
         <field name="domain">[('supplier_rank', '&gt;', 0)]</field>
-        <field name="context">{'default_supplier_rank': 1, 'default_is_company': True, 'active_test': False}</field>
+        <field name="context">{'default_supplier_rank': 1, 'default_is_company': True}</field>
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_contact_manager'))]"/>
     </record>
     <record id="action_sc_supplier_partner_tree_view" model="ir.actions.act_window.view">

--- a/addons/smart_construction_core/views/support/account_extend_views.xml
+++ b/addons/smart_construction_core/views/support/account_extend_views.xml
@@ -33,6 +33,7 @@
         <field name="arch" type="xml">
             <tree string="供应商" default_order="name">
                 <field name="name" string="名称"/>
+                <field name="is_company" string="企业/组织"/>
                 <field name="sc_supplier_type"/>
                 <field name="phone" string="电话"/>
                 <field name="mobile" string="手机"/>
@@ -45,8 +46,6 @@
                 <field name="legacy_partner_id"/>
                 <field name="legacy_partner_source"/>
                 <field name="legacy_partner_name"/>
-                <field name="legacy_deleted_flag"/>
-                <field name="active" string="活动"/>
             </tree>
         </field>
     </record>
@@ -60,7 +59,7 @@
                     <group>
                         <group string="基本信息">
                             <field name="name" string="名称"/>
-                            <field name="is_company" string="公司"/>
+                            <field name="is_company" string="企业/组织"/>
                             <field name="sc_supplier_type"/>
                             <field name="vat" string="统一社会信用代码"/>
                             <field name="sc_region"/>
@@ -69,8 +68,6 @@
                             <field name="legacy_partner_name"/>
                             <field name="legacy_credit_code"/>
                             <field name="legacy_tax_no"/>
-                            <field name="legacy_deleted_flag"/>
-                            <field name="active" string="活动"/>
                         </group>
                         <group string="联系方式">
                             <field name="phone" string="电话"/>
@@ -117,10 +114,11 @@
                 <field name="legacy_partner_id"/>
                 <field name="legacy_partner_name"/>
                 <field name="legacy_partner_source"/>
-                <field name="legacy_deleted_flag"/>
-                <filter string="活动" name="active_supplier" domain="[('active', '=', True)]"/>
                 <filter string="含历史来源" name="legacy_supplier" domain="[('legacy_partner_id', '!=', False)]"/>
-                <filter string="历史删除标识" name="legacy_deleted" domain="[('legacy_deleted_flag', 'not in', [False, '', '0'])]"/>
+                <filter string="企业/组织" name="supplier_company" domain="[('is_company', '=', True)]"/>
+                <filter string="个人" name="supplier_person" domain="[('is_company', '=', False)]"/>
+                <separator/>
+                <filter string="按企业组织/个人" name="group_is_company" context="{'group_by': 'is_company'}"/>
                 <filter string="按供应商类型" name="group_supplier_type" context="{'group_by': 'sc_supplier_type'}"/>
                 <filter string="按地区" name="group_region" context="{'group_by': 'sc_region'}"/>
                 <filter string="按历史来源" name="group_legacy_source" context="{'group_by': 'legacy_partner_source'}"/>

--- a/frontend/apps/web/src/components/action/ActionSurfaceToolbar.vue
+++ b/frontend/apps/web/src/components/action/ActionSurfaceToolbar.vue
@@ -494,6 +494,8 @@ onBeforeUnmount(() => {
 
 <style scoped>
 .action-toolbar {
+  position: relative;
+  z-index: 40;
   display: grid;
   grid-template-columns: max-content minmax(320px, 560px) max-content;
   justify-content: center;
@@ -652,17 +654,20 @@ onBeforeUnmount(() => {
   top: calc(100% + 6px);
   left: 50%;
   transform: translateX(-50%);
-  z-index: 20;
+  z-index: 80;
   display: grid;
   grid-template-columns: repeat(3, minmax(180px, 1fr));
   width: min(680px, calc(100vw - 32px));
-  max-height: 420px;
-  overflow: auto;
+  max-height: min(640px, calc(100vh - 120px));
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-gutter: stable;
   border: 1px solid #cbd5e1;
   border-radius: 8px;
   background: #fff;
   box-shadow: 0 16px 36px rgba(15, 23, 42, 0.18);
-  padding: 8px 0;
+  padding: 8px 0 12px;
 }
 
 .search-dropdown-section {
@@ -905,6 +910,7 @@ onBeforeUnmount(() => {
     transform: none;
     grid-template-columns: 1fr;
     width: min(520px, 92vw);
+    max-height: min(560px, calc(100vh - 132px));
   }
 
   .search-dropdown-section + .search-dropdown-section {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1642,6 +1642,8 @@ onBeforeUnmount(() => {
 }
 
 .list-toolbar {
+  position: relative;
+  z-index: 35;
   display: grid;
   grid-template-columns: minmax(132px, 180px) minmax(0, 600px) max-content;
   align-items: center;


### PR DESCRIPTION
## Summary
- keep the list search dropdown above the table header with stable scroll bounds
- refine supplier partner action/view settings for enterprise/person filtering
- keep this split branch limited to dropdown layering and supplier settings

## Validation
- git diff --check main..HEAD
- XML parse check for smart_construction_core supplier/menu views
- attempted smart_construction_core upgrade locally; XML loaded without parse/id errors, but full local upgrade is blocked by missing base_tier_validation dependencies in the simulation environment