### PR TITLE
fix(web): align custom list page rendering

### DIFF
--- a/frontend/apps/web/src/api/client.ts
+++ b/frontend/apps/web/src/api/client.ts
@@ -129,6 +129,9 @@ export async function apiRequestRaw<T>(path: string, options: RequestInit = {}) 
       isAnonymousIntent = false;
     }
   }
+  if (isAnonymousIntent) {
+    headers.set('X-Anonymous-Intent', '1');
+  }
   if (session.token && !isAnonymousIntent) {
     headers.set('Authorization', `Bearer ${session.token}`);
   }

--- a/frontend/apps/web/src/app/action_runtime/useActionViewContractShapeRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewContractShapeRuntime.ts
@@ -34,6 +34,7 @@ type ListColumnOption = {
   label: string;
   optional: string;
   defaultVisible: boolean;
+  sortable?: boolean;
   type?: string;
   widget?: string;
   cellRole?: string;
@@ -151,6 +152,9 @@ export function useActionViewContractShapeRuntime(options: UseActionViewContract
         const status = v2FieldStatus[name];
         const optional = String(schema.optional || '').trim();
         const invisible = schema.invisible === true || schema.column_invisible === true || status?.visible === false;
+        const sortableRaw = Object.prototype.hasOwnProperty.call(schema, 'sortable')
+          ? schema.sortable
+          : field.sortable;
         const type = String(schema.type || field.type || '').trim();
         const widget = String(schema.widget || field.widget || field.type || '').trim();
         const rawSelection = Array.isArray(schema.selection) ? schema.selection : field.selection;
@@ -159,6 +163,7 @@ export function useActionViewContractShapeRuntime(options: UseActionViewContract
           label: String(labels[name] || schema.label || schema.string || field.string || name).trim() || name,
           optional,
           defaultVisible: !hidden.has(name) && optional !== 'hide' && !invisible,
+          sortable: sortableRaw === false ? false : undefined,
           type: type || undefined,
           widget: widget || undefined,
           cellRole: String(schema.cell_role || schema.cellRole || '').trim() || undefined,

--- a/frontend/apps/web/src/components/action/ActionSurfaceToolbar.vue
+++ b/frontend/apps/web/src/components/action/ActionSurfaceToolbar.vue
@@ -497,8 +497,8 @@ onBeforeUnmount(() => {
   position: relative;
   z-index: 40;
   display: grid;
-  grid-template-columns: max-content minmax(320px, 560px) max-content;
-  justify-content: center;
+  grid-template-columns: max-content minmax(320px, 560px) minmax(max-content, 1fr);
+  justify-content: stretch;
   align-items: center;
   gap: 8px;
   min-width: 0;
@@ -807,6 +807,8 @@ onBeforeUnmount(() => {
   flex-wrap: wrap;
   gap: 8px;
   min-width: 0;
+  justify-self: end;
+  width: 100%;
 }
 
 .contract-label {
@@ -842,7 +844,7 @@ onBeforeUnmount(() => {
 
 @media (max-width: 1360px) {
   .action-toolbar {
-    grid-template-columns: max-content minmax(300px, 500px) max-content;
+    grid-template-columns: max-content minmax(300px, 500px) minmax(max-content, 1fr);
   }
 
   .native-search {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -2358,7 +2358,7 @@ tfoot tr:nth-child(2) td {
 }
 
 .footer-number {
-  text-align: right;
+  text-align: left;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow-wrap: normal;

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1101,7 +1101,12 @@ const rangeEnd = computed(() => {
   return Math.min(total, listOffset.value + props.records.length);
 });
 const showPagination = computed(() => listTotal.value !== null && props.status === 'ok' && !showGroupedRows.value);
-const toolbarSubtitle = computed(() => showPagination.value ? '' : props.subtitle || '');
+const toolbarSubtitle = computed(() => {
+  if (listTotal.value !== null) {
+    return uiLabel('record_count', '{count} 条记录', { count: listTotal.value });
+  }
+  return props.subtitle || '';
+});
 const canPagePrev = computed(() => listOffset.value > 0);
 const canPageNext = computed(() => {
   const total = listTotal.value || 0;

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -509,12 +509,11 @@
               />
               <select
                 class="pagination-size-select"
-                :value="pageLimitOptions.includes(listLimit) ? String(listLimit) : ''"
+                :value="pageLimitOptions.includes(listLimit) ? String(listLimit) : undefined"
                 :disabled="loading"
                 :aria-label="uiLabel('pagination_page_size_select', '选择每页条数')"
                 @change="onPageLimitSelectChange"
               >
-                <option value="" disabled></option>
                 <option v-for="option in pageLimitOptions" :key="`page-limit-${option}`" :value="String(option)">
                   {{ option }}
                 </option>
@@ -2274,6 +2273,11 @@ onBeforeUnmount(() => {
 .pagination-size-select:disabled {
   opacity: 0.6;
   cursor: not-allowed;
+}
+
+.pagination-size-select option {
+  font-size: 12px;
+  color: #0f172a;
 }
 
 @media (max-width: 900px) {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -2351,15 +2351,17 @@ tfoot tr:nth-child(2) td {
   color: #0f172a;
   font-size: 12px;
   line-height: 1.2;
-  white-space: normal;
+  min-width: 88px;
+  width: 88px;
+  white-space: nowrap;
+  overflow-wrap: normal;
 }
 
 .footer-number {
-  min-width: 150px;
-  text-align: left;
+  text-align: right;
   font-variant-numeric: tabular-nums;
-  white-space: normal;
-  overflow-wrap: anywhere;
+  white-space: nowrap;
+  overflow-wrap: normal;
 }
 
 .cell-sortable {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -26,7 +26,7 @@
       <section class="list-toolbar">
         <div class="list-title">
           <h2>{{ title }}</h2>
-          <p>{{ subtitle }}</p>
+          <p v-if="toolbarSubtitle">{{ toolbarSubtitle }}</p>
         </div>
         <div class="list-header-toolbar">
           <slot name="toolbar"></slot>
@@ -46,7 +46,7 @@
             {{ uiLabel('search_submit', '搜索') }}
           </button>
         </div>
-        <span v-else class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
+        <span v-else-if="!showPagination" class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
       </section>
       <section class="list-empty-state">
         <div class="list-empty-copy">
@@ -74,7 +74,7 @@
       <section class="list-toolbar">
         <div class="list-title">
           <h2>{{ title }}</h2>
-          <p>{{ subtitle }}</p>
+          <p v-if="toolbarSubtitle">{{ toolbarSubtitle }}</p>
         </div>
         <div class="list-header-toolbar">
           <slot name="toolbar"></slot>
@@ -94,7 +94,7 @@
             {{ uiLabel('search_submit', '搜索') }}
           </button>
         </div>
-        <span v-else class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
+        <span v-else-if="!showPagination" class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
       </section>
 
       <section v-if="enableSummaryStrip && summaryItems.length" class="summary-strip">
@@ -1102,6 +1102,7 @@ const rangeEnd = computed(() => {
   return Math.min(total, listOffset.value + props.records.length);
 });
 const showPagination = computed(() => listTotal.value !== null && props.status === 'ok' && !showGroupedRows.value);
+const toolbarSubtitle = computed(() => showPagination.value ? '' : props.subtitle || '');
 const canPagePrev = computed(() => listOffset.value > 0);
 const canPageNext = computed(() => {
   const total = listTotal.value || 0;
@@ -2245,8 +2246,8 @@ onBeforeUnmount(() => {
 }
 
 .pagination-input--size {
-  width: 54px;
-  padding-right: 22px;
+  width: 64px;
+  padding-right: 28px;
 }
 
 .pagination-size-combo {
@@ -2260,11 +2261,12 @@ onBeforeUnmount(() => {
   top: 1px;
   right: 1px;
   bottom: 1px;
-  width: 22px;
+  width: 26px;
   border: 0;
   border-left: 1px solid #bfdbfe;
   border-radius: 0 5px 5px 0;
   background: #eff6ff;
+  font-size: 0;
   color: #1d4ed8;
   cursor: pointer;
 }

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1677,7 +1677,7 @@ onBeforeUnmount(() => {
   position: relative;
   z-index: 35;
   display: grid;
-  grid-template-columns: minmax(132px, 180px) minmax(0, 600px) max-content;
+  grid-template-columns: minmax(132px, 180px) minmax(0, 1fr) max-content;
   align-items: center;
   gap: 6px;
   border: 1px solid #e2e8f0;
@@ -1723,13 +1723,14 @@ onBeforeUnmount(() => {
   display: flex;
   justify-content: flex-start;
   min-width: 0;
+  width: 100%;
 }
 
 .list-header-toolbar :deep(.action-toolbar) {
-  grid-template-columns: max-content minmax(280px, 460px) max-content;
-  justify-content: start;
-  width: min(600px, 100%);
-  max-width: 600px;
+  grid-template-columns: max-content minmax(280px, 460px) minmax(max-content, 1fr);
+  justify-content: stretch;
+  width: 100%;
+  max-width: none;
   border: 0;
   box-shadow: none;
   padding: 0;

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -340,7 +340,8 @@
                   :style="columnWidthStyle(col)"
                   :class="[columnDensityClass(col), { 'footer-number': isNumericColumn(col) }]"
                 >
-                  {{ groupFooterCellText(col, group, 'page') }}
+                  <span v-if="isNumericColumn(col)" class="footer-number-value">{{ groupFooterCellText(col, group, 'page') }}</span>
+                  <template v-else>{{ groupFooterCellText(col, group, 'page') }}</template>
                 </td>
               </tr>
               <tr>
@@ -351,7 +352,8 @@
                   :style="columnWidthStyle(col)"
                   :class="[columnDensityClass(col), { 'footer-number': isNumericColumn(col) }]"
                 >
-                  {{ groupFooterCellText(col, group, 'total') }}
+                  <span v-if="isNumericColumn(col)" class="footer-number-value">{{ groupFooterCellText(col, group, 'total') }}</span>
+                  <template v-else>{{ groupFooterCellText(col, group, 'total') }}</template>
                 </td>
               </tr>
             </tfoot>
@@ -487,7 +489,8 @@
               :style="columnWidthStyle(col)"
               :class="[columnDensityClass(col), { 'footer-number': isNumericColumn(col) }]"
             >
-              {{ footerCellText(col, 'page', pageVisibleRows.length) }}
+              <span v-if="isNumericColumn(col)" class="footer-number-value">{{ footerCellText(col, 'page', pageVisibleRows.length) }}</span>
+              <template v-else>{{ footerCellText(col, 'page', pageVisibleRows.length) }}</template>
             </td>
             <td v-if="columnChoices.length" class="cell-column-picker"></td>
           </tr>
@@ -500,7 +503,8 @@
               :style="columnWidthStyle(col)"
               :class="[columnDensityClass(col), { 'footer-number': isNumericColumn(col) }]"
             >
-              {{ footerCellText(col, 'total', listTotal || pageVisibleRows.length) }}
+              <span v-if="isNumericColumn(col)" class="footer-number-value">{{ footerCellText(col, 'total', listTotal || pageVisibleRows.length) }}</span>
+              <template v-else>{{ footerCellText(col, 'total', listTotal || pageVisibleRows.length) }}</template>
             </td>
             <td v-if="columnChoices.length" class="cell-column-picker"></td>
           </tr>
@@ -2358,10 +2362,17 @@ tfoot tr:nth-child(2) td {
 }
 
 .footer-number {
-  text-align: left;
+  text-align: left !important;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow-wrap: normal;
+}
+
+.footer-number-value {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  text-align: left;
 }
 
 .cell-sortable {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -263,7 +263,7 @@
                   v-for="col in displayedColumns"
                   :key="`group-col-${group.key}-${col}`"
                   class="cell-sortable"
-                  :class="[columnDensityClass(col), { 'is-sorted': isSortedColumn(col), 'is-dragging': draggingColumn === col }]"
+                  :class="[columnDensityClass(col), { 'is-sorted': isSortedColumn(col), 'is-dragging': draggingColumn === col, 'is-sort-disabled': !isColumnSortable(col) }]"
                   :data-column="col"
                   :style="columnWidthStyle(col)"
                   draggable="true"
@@ -276,6 +276,7 @@
                     type="button"
                     class="column-sort-btn"
                     :title="columnSortTitle(col)"
+                    :aria-disabled="!isColumnSortable(col)"
                     draggable="false"
                     @click.stop="toggleColumnSort(col)"
                   >
@@ -380,7 +381,7 @@
               v-for="col in displayedColumns"
               :key="col"
               class="cell-sortable"
-              :class="[columnDensityClass(col), { 'is-sorted': isSortedColumn(col), 'is-dragging': draggingColumn === col }]"
+              :class="[columnDensityClass(col), { 'is-sorted': isSortedColumn(col), 'is-dragging': draggingColumn === col, 'is-sort-disabled': !isColumnSortable(col) }]"
               :data-column="col"
               :style="columnWidthStyle(col)"
               draggable="true"
@@ -393,6 +394,7 @@
                 type="button"
                 class="column-sort-btn"
                 :title="columnSortTitle(col)"
+                :aria-disabled="!isColumnSortable(col)"
                 draggable="false"
                 @click.stop="toggleColumnSort(col)"
               >
@@ -529,6 +531,7 @@ type ColumnOption = {
   label: string;
   optional?: string;
   defaultVisible?: boolean;
+  sortable?: boolean;
   type?: string;
   widget?: string;
   cellRole?: string;
@@ -1336,6 +1339,9 @@ function columnSortIndicator(col: string) {
 
 function columnSortTitle(col: string) {
   const label = columnLabel(col);
+  if (!isColumnSortable(col)) {
+    return uiLabel('sort_column_disabled', '{column} 不支持排序', { column: label });
+  }
   if (isSortedColumn(col) && sortDirection(props.sortValue || '') === 'asc') {
     return uiLabel('sort_column_desc', '按 {column} 降序', { column: label });
   }
@@ -1343,6 +1349,7 @@ function columnSortTitle(col: string) {
 }
 
 function toggleColumnSort(col: string) {
+  if (!isColumnSortable(col)) return;
   const currentDirection = isSortedColumn(col) ? sortDirection(props.sortValue || '') : '';
   const nextDirection = currentDirection === 'asc' ? 'desc' : 'asc';
   props.onSort(`${col} ${nextDirection}`);
@@ -1483,6 +1490,10 @@ function columnOption(field: string) {
   return columnChoices.value.find((column) => column.name === field) || null;
 }
 
+function isColumnSortable(field: string) {
+  return columnOption(field)?.sortable !== false;
+}
+
 function isColumnVisible(name: string) {
   const visibility = props.columnVisibility || {};
   if (Object.prototype.hasOwnProperty.call(visibility, name)) {
@@ -1572,13 +1583,13 @@ function totalAggregateValue(field: string) {
 }
 
 function footerCellText(field: string, scope: 'page' | 'total', rowCount: number) {
+  void rowCount;
   if (!isNumericColumn(field)) return '';
-  const label = columnLabel(field);
   if (scope === 'page') {
-    return `${label}：${pageFooterStatsMap.value[field]?.sumText || '--'}`;
+    return pageFooterStatsMap.value[field]?.sumText || '--';
   }
   const value = totalAggregateValue(field);
-  return `${label}：${value === null ? '--' : formatFooterNumber(value, field)}`;
+  return value === null ? '--' : formatFooterNumber(value, field);
 }
 
 function rowsNumericSum(rows: Array<Record<string, unknown>>, field: string) {
@@ -1601,13 +1612,12 @@ function groupFooterCellText(
   scope: 'page' | 'total',
 ) {
   if (!isNumericColumn(field)) return '';
-  const label = columnLabel(field);
   if (scope === 'page') {
     const value = rowsNumericSum(group.sampleRows || [], field);
-    return `${label}：${value === null ? '--' : formatFooterNumber(value, field)}`;
+    return value === null ? '--' : formatFooterNumber(value, field);
   }
   const value = groupAggregateValue(group, field);
-  return value === null ? '' : `${label}：${formatFooterNumber(value, field)}`;
+  return value === null ? '--' : formatFooterNumber(value, field);
 }
 
 function footerRowLabel(scope: 'page' | 'total', rowCount: number) {
@@ -2364,6 +2374,11 @@ tfoot tr:nth-child(2) td {
   opacity: 0.55;
 }
 
+.cell-sortable.is-sort-disabled .column-sort-btn {
+  color: #475569;
+  cursor: default;
+}
+
 .column-sort-btn {
   display: inline-flex;
   align-items: center;
@@ -2411,6 +2426,10 @@ tfoot tr:nth-child(2) td {
 
 .column-sort-btn:hover {
   color: #1d4ed8;
+}
+
+.cell-sortable.is-sort-disabled .column-sort-btn:hover {
+  color: #475569;
 }
 
 .sort-indicator {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -94,60 +94,6 @@
             {{ uiLabel('search_submit', '搜索') }}
           </button>
         </div>
-        <div v-if="showPagination" class="pagination-actions pagination-actions--top">
-          <button
-            type="button"
-            class="pagination-btn"
-            :disabled="loading || !canPagePrev"
-            @click="pagePrev"
-          >
-            {{ uiLabel('pagination_prev', '上一页') }}
-          </button>
-          <span>{{ paginationPageText }}</span>
-          <button
-            type="button"
-            class="pagination-btn"
-            :disabled="loading || !canPageNext"
-            @click="pageNext"
-          >
-            {{ uiLabel('pagination_next', '下一页') }}
-          </button>
-          <input
-            class="pagination-input"
-            :value="pageJumpInput"
-            :disabled="loading || totalPages <= 1"
-            inputmode="numeric"
-            pattern="[0-9]*"
-            @input="onPageJumpInput"
-            @keyup.enter="jumpPage"
-          />
-          <button
-            type="button"
-            class="pagination-btn"
-            :disabled="loading || totalPages <= 1"
-            @click="jumpPage"
-          >
-            {{ uiLabel('pagination_jump', '跳转') }}
-          </button>
-          <span class="pagination-size-label">{{ uiLabel('pagination_page_size', '每页') }}</span>
-          <input
-            class="pagination-input pagination-input--size"
-            :value="pageLimitInput"
-            :disabled="loading"
-            inputmode="numeric"
-            pattern="[0-9]*"
-            @input="onPageLimitInput"
-            @keyup.enter="applyPageLimit"
-          />
-          <button
-            type="button"
-            class="pagination-btn"
-            :disabled="loading"
-            @click="applyPageLimit"
-          >
-            {{ uiLabel('pagination_apply_size', '应用') }}
-          </button>
-        </div>
         <span v-else class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
       </section>
 
@@ -511,6 +457,72 @@
         </tfoot>
       </table>
     </section>
+
+      <section v-if="showPagination" class="pagination-footer">
+        <div class="pagination-actions pagination-actions--bottom">
+          <button
+            type="button"
+            class="pagination-btn"
+            :disabled="loading || !canPagePrev"
+            @click="pagePrev"
+          >
+            {{ uiLabel('pagination_prev', '上一页') }}
+          </button>
+          <span>{{ paginationPageText }}</span>
+          <button
+            type="button"
+            class="pagination-btn"
+            :disabled="loading || !canPageNext"
+            @click="pageNext"
+          >
+            {{ uiLabel('pagination_next', '下一页') }}
+          </button>
+          <input
+            class="pagination-input"
+            :value="pageJumpInput"
+            :disabled="loading || totalPages <= 1"
+            inputmode="numeric"
+            pattern="[0-9]*"
+            @input="onPageJumpInput"
+            @keyup.enter="jumpPage"
+          />
+          <button
+            type="button"
+            class="pagination-btn"
+            :disabled="loading || totalPages <= 1"
+            @click="jumpPage"
+          >
+            {{ uiLabel('pagination_jump', '跳转') }}
+          </button>
+          <label class="pagination-size-control">
+            <span class="pagination-size-label">{{ uiLabel('pagination_page_size', '每页') }}</span>
+            <span class="pagination-size-combo">
+              <input
+                class="pagination-input pagination-input--size"
+                :value="pageLimitInput"
+                :disabled="loading"
+                inputmode="numeric"
+                pattern="[0-9]*"
+                @input="onPageLimitInput"
+                @change="applyPageLimit"
+                @keyup.enter="applyPageLimit"
+              />
+              <select
+                class="pagination-size-select"
+                :value="pageLimitOptions.includes(listLimit) ? String(listLimit) : ''"
+                :disabled="loading"
+                :aria-label="uiLabel('pagination_page_size_select', '选择每页条数')"
+                @change="onPageLimitSelectChange"
+              >
+                <option value="" disabled></option>
+                <option v-for="option in pageLimitOptions" :key="`page-limit-${option}`" :value="String(option)">
+                  {{ option }}
+                </option>
+              </select>
+            </span>
+          </label>
+        </div>
+      </section>
 
     </template>
   </section>
@@ -1062,6 +1074,7 @@ const listLimit = computed(() => {
   const limit = Number(props.listLimit || 40);
   return Number.isFinite(limit) && limit > 0 ? Math.trunc(limit) : 40;
 });
+const pageLimitOptions = computed(() => [10, 20, 50]);
 const listTotal = computed(() => {
   if (props.listTotalCount === null || typeof props.listTotalCount === 'undefined') return null;
   const raw = Number(props.listTotalCount);
@@ -1164,18 +1177,25 @@ function jumpPage() {
   emitPageOffset((normalizedPage - 1) * listLimit.value);
 }
 
-function onPageLimitInput(event: Event) {
-  pageLimitInput.value = String((event.target as HTMLInputElement | null)?.value || '');
-}
-
-function applyPageLimit() {
-  const raw = Number(pageLimitInput.value || listLimit.value);
+function applyPageLimitValue(raw: number) {
   if (!Number.isFinite(raw)) return;
   const normalized = Math.min(Math.max(Math.trunc(raw), 1), 200);
   pageLimitInput.value = String(normalized);
   if (normalized === listLimit.value) return;
   observedListLimit.value = normalized;
   props.onPageLimitChange?.(normalized);
+}
+
+function onPageLimitInput(event: Event) {
+  pageLimitInput.value = String((event.target as HTMLInputElement | null)?.value || '');
+}
+
+function applyPageLimit() {
+  applyPageLimitValue(Number(pageLimitInput.value || listLimit.value));
+}
+
+function onPageLimitSelectChange(event: Event) {
+  applyPageLimitValue(Number((event.target as HTMLSelectElement | null)?.value || 0));
 }
 
 function onPlainSearchInput(event: Event) {
@@ -2073,19 +2093,29 @@ onBeforeUnmount(() => {
   gap: 5px;
 }
 
-.pagination-size-label {
-  color: #64748b;
-  font-size: 12px;
+.pagination-footer {
+  display: flex;
+  justify-content: flex-end;
+  padding-top: 8px;
 }
 
-.pagination-actions--top {
-  justify-self: end;
-  flex: 0 0 auto;
+.pagination-actions--bottom {
   justify-content: flex-end;
   flex-wrap: nowrap;
   color: #475569;
   font-size: 12px;
   white-space: nowrap;
+}
+
+.pagination-size-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+
+.pagination-size-label {
+  color: #64748b;
+  font-size: 12px;
 }
 
 .cell-column-picker {
@@ -2216,6 +2246,32 @@ onBeforeUnmount(() => {
 
 .pagination-input--size {
   width: 54px;
+  padding-right: 22px;
+}
+
+.pagination-size-combo {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.pagination-size-select {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  bottom: 1px;
+  width: 22px;
+  border: 0;
+  border-left: 1px solid #bfdbfe;
+  border-radius: 0 5px 5px 0;
+  background: #eff6ff;
+  color: #1d4ed8;
+  cursor: pointer;
+}
+
+.pagination-size-select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 @media (max-width: 900px) {
@@ -2236,6 +2292,11 @@ onBeforeUnmount(() => {
 
   .pagination-actions {
     flex-wrap: wrap;
+  }
+
+  .pagination-actions--bottom {
+    justify-content: flex-start;
+    white-space: normal;
   }
 
   .list-plain-search {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1619,10 +1619,10 @@ function groupFooterCellText(
 }
 
 function footerRowLabel(scope: 'page' | 'total', rowCount: number) {
-  const count = Math.max(0, Math.trunc(Number(rowCount || 0)));
+  void rowCount;
   return scope === 'page'
-    ? uiLabel('page_footer_current_count', '本页：{count} 条', { count })
-    : uiLabel('page_footer_total_count', '总计：{count} 条', { count });
+    ? uiLabel('page_footer_current_total', '当页总计')
+    : uiLabel('page_footer_total', '总计');
 }
 
 function handleColumnPickerPointerDown(event: PointerEvent) {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1417,9 +1417,7 @@ function effectiveColumnWidth(field: string) {
 function columnWidthStyle(field: string) {
   const width = effectiveColumnWidth(field);
   if (!width) return {};
-  const maxTextWidth = isNameLikeColumn(field) ? 220 : isLongTextColumn(field) ? 180 : 0;
-  const resolvedWidth = maxTextWidth ? Math.min(width, maxTextWidth) : width;
-  return { width: `${resolvedWidth}px`, minWidth: `${resolvedWidth}px`, maxWidth: `${resolvedWidth}px` };
+  return { width: `${width}px`, minWidth: `${width}px`, maxWidth: `${width}px` };
 }
 
 function isLongTextColumn(field: string) {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1813,7 +1813,7 @@ onBeforeUnmount(() => {
 .table {
   width: 100%;
   max-width: 100%;
-  max-height: max(500px, calc(100vh - 185px));
+  max-height: max(500px, calc(100vh - 145px));
   overflow-x: auto;
   overflow-y: auto;
   background: white;
@@ -2102,7 +2102,7 @@ onBeforeUnmount(() => {
 .pagination-footer {
   display: flex;
   justify-content: flex-end;
-  padding-top: 8px;
+  padding-top: 4px;
 }
 
 .pagination-actions--bottom {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -2362,7 +2362,7 @@ tfoot tr:nth-child(2) td {
 }
 
 .footer-number {
-  text-align: left !important;
+  text-align: right;
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
   overflow-wrap: normal;
@@ -2372,7 +2372,7 @@ tfoot tr:nth-child(2) td {
   display: block;
   width: 100%;
   min-width: 0;
-  text-align: left;
+  text-align: right;
 }
 
 .cell-sortable {

--- a/frontend/apps/web/src/views/ActionView.vue
+++ b/frontend/apps/web/src/views/ActionView.vue
@@ -2670,7 +2670,6 @@ function buildListColumnPreference(visibility: Record<string, boolean>, columnOr
 
 async function handleListColumnVisibilityChange(payload: { visibility: Record<string, boolean> }): Promise<void> {
   const saveSeq = ++listColumnSaveSeq;
-  const previous = { ...listColumnVisibility.value };
   const next = payload.visibility || {};
   listColumnVisibility.value = { ...next };
   setListColumnSaveStatus('saving');
@@ -2681,7 +2680,6 @@ async function handleListColumnVisibilityChange(payload: { visibility: Record<st
     }
   } catch (err) {
     if (saveSeq === listColumnSaveSeq) {
-      listColumnVisibility.value = previous;
       setListColumnSaveStatus('error');
     }
     console.warn('[list-columns] failed to save preference', err);
@@ -2690,7 +2688,6 @@ async function handleListColumnVisibilityChange(payload: { visibility: Record<st
 
 async function handleListColumnOrderChange(payload: { columnOrder: string[] }): Promise<void> {
   const saveSeq = ++listColumnSaveSeq;
-  const previous = [...listColumnOrder.value];
   const next = Array.isArray(payload.columnOrder) ? payload.columnOrder.map((item) => String(item || '').trim()).filter(Boolean) : [];
   listColumnOrder.value = next;
   setListColumnSaveStatus('saving');
@@ -2701,7 +2698,6 @@ async function handleListColumnOrderChange(payload: { columnOrder: string[] }): 
     }
   } catch (err) {
     if (saveSeq === listColumnSaveSeq) {
-      listColumnOrder.value = previous;
       setListColumnSaveStatus('error');
     }
     console.warn('[list-columns] failed to save column order preference', err);
@@ -2710,7 +2706,6 @@ async function handleListColumnOrderChange(payload: { columnOrder: string[] }): 
 
 async function handleListColumnWidthsChange(payload: { columnWidths: Record<string, number> }): Promise<void> {
   const saveSeq = ++listColumnSaveSeq;
-  const previous = { ...listColumnWidths.value };
   const next = Object.entries(payload.columnWidths || {}).reduce<Record<string, number>>((acc, [name, width]) => {
     const normalizedName = String(name || '').trim();
     const normalizedWidth = normalizeListColumnWidth(width);
@@ -2729,7 +2724,6 @@ async function handleListColumnWidthsChange(payload: { columnWidths: Record<stri
     }
   } catch (err) {
     if (saveSeq === listColumnSaveSeq) {
-      listColumnWidths.value = previous;
       setListColumnSaveStatus('error');
     }
     console.warn('[list-columns] failed to save column width preference', err);

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 LIST_PAGE = ROOT / "frontend" / "apps" / "web" / "src" / "pages" / "ListPage.vue"
+ACTION_VIEW = ROOT / "frontend" / "apps" / "web" / "src" / "views" / "ActionView.vue"
 SHAPE_RUNTIME = (
     ROOT
     / "frontend"
@@ -28,14 +29,20 @@ def _extract_function(source: str, name: str) -> str:
     start = source.find(marker)
     if start < 0:
         raise AssertionError(f"missing function {name}")
-    next_function = source.find("\nfunction ", start + len(marker))
-    if next_function < 0:
+    next_markers = [
+        index
+        for marker_text in ("\nfunction ", "\nasync function ")
+        for index in [source.find(marker_text, start + len(marker))]
+        if index >= 0
+    ]
+    if not next_markers:
         return source[start:]
-    return source[start:next_function]
+    return source[start:min(next_markers)]
 
 
 def main() -> int:
     list_page = _read(LIST_PAGE)
+    action_view = _read(ACTION_VIEW)
     shape_runtime = _read(SHAPE_RUNTIME)
     errors: list[str] = []
 
@@ -61,6 +68,14 @@ def main() -> int:
     column_width_style = _extract_function(list_page, "columnWidthStyle")
     if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
         errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")
+    for name in (
+        "handleListColumnVisibilityChange",
+        "handleListColumnOrderChange",
+        "handleListColumnWidthsChange",
+    ):
+        block = _extract_function(action_view, name)
+        if "previous =" in block or "= previous" in block:
+            errors.append(f"{name} must keep current-session list interactions applied when preference persistence fails")
 
     if errors:
         print("[frontend_list_contract_rendering_guard] FAIL")

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -85,19 +85,19 @@ def main() -> int:
     if "white-space: nowrap" not in footer_row_label_css:
         errors.append("footer row labels must stay on one line")
     footer_number_css = _extract_css_block(list_page, ".footer-number")
-    if "text-align: left" not in footer_number_css:
-        errors.append("footer numeric cells must left-align as the fallback cue for their source column")
+    if "text-align: right" not in footer_number_css:
+        errors.append("footer numeric cells must right-align with body numeric values in their source column")
     if "min-width:" in footer_number_css:
         errors.append("footer numeric cells must not add independent min-width that breaks column alignment")
     if "white-space: nowrap" not in footer_number_css:
         errors.append("footer numeric cells must stay on one line")
     footer_number_value_css = _extract_css_block(list_page, ".footer-number-value")
     if "display: block" not in footer_number_value_css or "width: 100%" not in footer_number_value_css:
-        errors.append("footer aggregate values must use a block wrapper so the visual value starts at the column left edge")
-    if "text-align: left" not in footer_number_value_css:
-        errors.append("footer aggregate value wrapper must left-align independently of numeric column defaults")
+        errors.append("footer aggregate values must use a full-width block wrapper so the visual anchor matches body numeric values")
+    if "text-align: right" not in footer_number_value_css:
+        errors.append("footer aggregate value wrapper must right-align to match body numeric values")
     if "footer-number-value" not in list_page:
-        errors.append("footer numeric aggregate text must be wrapped for stable visual left alignment")
+        errors.append("footer numeric aggregate text must be wrapped for stable visual numeric alignment")
     column_width_style = _extract_function(list_page, "columnWidthStyle")
     if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
         errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -91,6 +91,13 @@ def main() -> int:
         errors.append("footer numeric cells must not add independent min-width that breaks column alignment")
     if "white-space: nowrap" not in footer_number_css:
         errors.append("footer numeric cells must stay on one line")
+    footer_number_value_css = _extract_css_block(list_page, ".footer-number-value")
+    if "display: block" not in footer_number_value_css or "width: 100%" not in footer_number_value_css:
+        errors.append("footer aggregate values must use a block wrapper so the visual value starts at the column left edge")
+    if "text-align: left" not in footer_number_value_css:
+        errors.append("footer aggregate value wrapper must left-align independently of numeric column defaults")
+    if "footer-number-value" not in list_page:
+        errors.append("footer numeric aggregate text must be wrapped for stable visual left alignment")
     column_width_style = _extract_function(list_page, "columnWidthStyle")
     if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
         errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -65,6 +65,11 @@ def main() -> int:
         errors.append("ListPage must not emit sort requests for non-sortable columns")
     if "sort_column_disabled" not in list_page:
         errors.append("ListPage must expose disabled sort affordance text")
+    footer_row_label = _extract_function(list_page, "footerRowLabel")
+    if "当页总计" not in footer_row_label or "'总计'" not in footer_row_label:
+        errors.append("footer rows must label summable rows as current-page total and total")
+    if "本页：" in footer_row_label or "{count} 条" in footer_row_label:
+        errors.append("footer row labels must describe aggregate scope, not duplicate row-count pagination text")
     column_width_style = _extract_function(list_page, "columnWidthStyle")
     if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
         errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+LIST_PAGE = ROOT / "frontend" / "apps" / "web" / "src" / "pages" / "ListPage.vue"
+SHAPE_RUNTIME = (
+    ROOT
+    / "frontend"
+    / "apps"
+    / "web"
+    / "src"
+    / "app"
+    / "action_runtime"
+    / "useActionViewContractShapeRuntime.ts"
+)
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_function(source: str, name: str) -> str:
+    marker = f"function {name}("
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing function {name}")
+    next_function = source.find("\nfunction ", start + len(marker))
+    if next_function < 0:
+        return source[start:]
+    return source[start:next_function]
+
+
+def main() -> int:
+    list_page = _read(LIST_PAGE)
+    shape_runtime = _read(SHAPE_RUNTIME)
+    errors: list[str] = []
+
+    footer_cell = _extract_function(list_page, "footerCellText")
+    group_footer_cell = _extract_function(list_page, "groupFooterCellText")
+    for name, block in (
+        ("footerCellText", footer_cell),
+        ("groupFooterCellText", group_footer_cell),
+    ):
+        if "columnLabel(" in block or "`${label}" in block or "}：" in block:
+            errors.append(f"{name} must render numeric-only footer cells; row header owns the label")
+
+    if "sortable?: boolean" not in shape_runtime:
+        errors.append("contract column options must expose sortable?: boolean")
+    if "sortableRaw === false ? false : undefined" not in shape_runtime:
+        errors.append("columns_schema.sortable=false must be preserved from contract to column options")
+    if "function isColumnSortable" not in list_page:
+        errors.append("ListPage must centralize column sortable resolution")
+    if "if (!isColumnSortable(col)) return;" not in list_page:
+        errors.append("ListPage must not emit sort requests for non-sortable columns")
+    if "sort_column_disabled" not in list_page:
+        errors.append("ListPage must expose disabled sort affordance text")
+
+    if errors:
+        print("[frontend_list_contract_rendering_guard] FAIL")
+        for item in errors:
+            print(f" - {item}")
+        return 1
+    print("[frontend_list_contract_rendering_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -58,6 +58,9 @@ def main() -> int:
         errors.append("ListPage must not emit sort requests for non-sortable columns")
     if "sort_column_disabled" not in list_page:
         errors.append("ListPage must expose disabled sort affordance text")
+    column_width_style = _extract_function(list_page, "columnWidthStyle")
+    if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
+        errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")
 
     if errors:
         print("[frontend_list_contract_rendering_guard] FAIL")

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -85,8 +85,8 @@ def main() -> int:
     if "white-space: nowrap" not in footer_row_label_css:
         errors.append("footer row labels must stay on one line")
     footer_number_css = _extract_css_block(list_page, ".footer-number")
-    if "text-align: right" not in footer_number_css:
-        errors.append("footer numeric cells must right-align with their source column")
+    if "text-align: left" not in footer_number_css:
+        errors.append("footer numeric cells must left-align as the fallback cue for their source column")
     if "min-width:" in footer_number_css:
         errors.append("footer numeric cells must not add independent min-width that breaks column alignment")
     if "white-space: nowrap" not in footer_number_css:

--- a/scripts/verify/frontend_list_contract_rendering_guard.py
+++ b/scripts/verify/frontend_list_contract_rendering_guard.py
@@ -40,6 +40,17 @@ def _extract_function(source: str, name: str) -> str:
     return source[start:min(next_markers)]
 
 
+def _extract_css_block(source: str, selector: str) -> str:
+    marker = f"{selector} {{"
+    start = source.find(marker)
+    if start < 0:
+        raise AssertionError(f"missing CSS selector {selector}")
+    end = source.find("\n}", start)
+    if end < 0:
+        return source[start:]
+    return source[start : end + 2]
+
+
 def main() -> int:
     list_page = _read(LIST_PAGE)
     action_view = _read(ACTION_VIEW)
@@ -70,6 +81,16 @@ def main() -> int:
         errors.append("footer rows must label summable rows as current-page total and total")
     if "本页：" in footer_row_label or "{count} 条" in footer_row_label:
         errors.append("footer row labels must describe aggregate scope, not duplicate row-count pagination text")
+    footer_row_label_css = _extract_css_block(list_page, ".footer-row-label")
+    if "white-space: nowrap" not in footer_row_label_css:
+        errors.append("footer row labels must stay on one line")
+    footer_number_css = _extract_css_block(list_page, ".footer-number")
+    if "text-align: right" not in footer_number_css:
+        errors.append("footer numeric cells must right-align with their source column")
+    if "min-width:" in footer_number_css:
+        errors.append("footer numeric cells must not add independent min-width that breaks column alignment")
+    if "white-space: nowrap" not in footer_number_css:
+        errors.append("footer numeric cells must stay on one line")
     column_width_style = _extract_function(list_page, "columnWidthStyle")
     if "Math.min(width" in column_width_style or "maxTextWidth" in column_width_style:
         errors.append("explicit column widths must render as saved; do not clamp name/text columns after resize")


### PR DESCRIPTION
## Summary
- preserve list column contract behavior, saved widths, and local preference state on save failures
- align list footer totals with numeric columns and clarify page/overall aggregate labels
- move pagination controls to the lower-right footer with typed page-size input plus 10/20/50 quick select
- polish list toolbar spacing, create action alignment, total-count subtitle, and vertical density
- send anonymous intent header for login so prod-sim frontend/backend auth stays aligned

## Verification
- python3 scripts/verify/frontend_list_contract_rendering_guard.py
- pnpm -C frontend/apps/web typecheck
- pnpm -C frontend/apps/web build
- Playwright prod-sim browser checks for login, footer totals, pagination input/select, toolbar count, create alignment, and vertical spacing