### PR TITLE
Add project master upgrade replay flow

### DIFF
--- a/docs/migration_alignment/project_master_upgrade_replay_flow_v1.md
+++ b/docs/migration_alignment/project_master_upgrade_replay_flow_v1.md
@@ -1,0 +1,96 @@
+# Project Master Upgrade Replay Flow v1
+
+Status: `ready_for_acceptance_replay`
+
+Task: `ITER-2026-05-07-PROJECT-MASTER-UPGRADE-REPLAY`
+
+## Purpose
+
+This flow turns the project master cleanup from two historical passes into one bounded replay entry:
+
+1. regenerate the project anchor payload from the current raw project and visible contract facts;
+2. write the project anchors into a guarded replay database by `legacy_project_id`;
+3. run a read-only acceptance postcheck against the target database.
+
+It is intended for acceptance/prod-sim replay. Adapter mode is file-only. Write mode is protected by the replay DB allowlist in `fresh_db_project_anchor_replay_write.py`.
+
+## Current Business Facts
+
+The accepted project master payload currently has `798` rows:
+
+| Lane | Rows | Source |
+| --- | ---: | --- |
+| `project_master` | 754 | `tmp/raw/project/project.csv` |
+| `project_master_contract_enriched` | 1 | project master row enriched by visible contract facts |
+| `contract_visible_project_anchor` | 43 | visible contract facts whose `XMID` is absent from project master |
+
+The current raw source `operation_strategy` distribution is:
+
+| Strategy | Rows |
+| --- | ---: |
+| `joint` | 760 |
+| `direct` | 36 |
+| `unspecified` | 2 |
+
+`project.project.operation_strategy` is required in the current model and defaults to `direct`, so replay normalizes the two unspecified source rows to `direct` at write time. The model-normalized acceptance distribution is `direct=38`, `joint=760`.
+
+## Command
+
+Full acceptance replay:
+
+```bash
+PROJECT_MASTER_REPLAY_MODE=all \
+DB_NAME=sc_partner_acceptance \
+MIGRATION_REPLAY_DB_ALLOWLIST=sc_partner_acceptance \
+PROJECT_ANCHOR_EXPECTED_ROWS=798 \
+bash scripts/migration/project_master_upgrade_replay_flow.sh
+```
+
+File-only adapter refresh:
+
+```bash
+PROJECT_MASTER_REPLAY_MODE=adapter \
+bash scripts/migration/project_master_upgrade_replay_flow.sh
+```
+
+Read-only postcheck:
+
+```bash
+PROJECT_MASTER_REPLAY_MODE=postcheck \
+DB_NAME=sc_partner_acceptance \
+MIGRATION_REPLAY_DB_ALLOWLIST=sc_partner_acceptance \
+PROJECT_ANCHOR_EXPECTED_ROWS=798 \
+bash scripts/migration/project_master_upgrade_replay_flow.sh
+```
+
+## Outputs
+
+The adapter still writes the canonical project replay assets:
+
+- `artifacts/migration/fresh_db_project_anchor_replay_payload_v1.csv`
+- `artifacts/migration/fresh_db_project_anchor_replay_gap_matrix_v1.csv`
+- `artifacts/migration/fresh_db_project_anchor_replay_adapter_result_v1.json`
+- `docs/migration_alignment/fresh_db_project_anchor_replay_adapter_report_v1.md`
+
+The write and postcheck phases write under `MIGRATION_ARTIFACT_ROOT`:
+
+- `fresh_db_project_anchor_replay_write_result_v1.json`
+- `fresh_db_project_anchor_replay_rollback_targets_v1.csv`
+- `fresh_db_project_master_replay_postcheck_result_v1.json`
+- `fresh_db_project_master_replay_postcheck_report_v1.md`
+
+## Acceptance Contract
+
+The postcheck passes only when:
+
+- payload rows equal the expected row count;
+- each payload row has one non-empty `legacy_project_id`;
+- no payload identity is duplicated;
+- every payload `legacy_project_id` maps to exactly one `project.project`;
+- matched project rows equal the expected row count;
+- database `operation_strategy` distribution matches the model-normalized payload distribution;
+- visible contract-derived project anchors have linked visible `construction.contract` rows when those fields exist.
+
+Decision marker:
+
+`project_master_replay_acceptance_passed`

--- a/scripts/migration/fresh_db_project_anchor_replay_write.py
+++ b/scripts/migration/fresh_db_project_anchor_replay_write.py
@@ -34,6 +34,7 @@ INPUT_CSV = REPO_ROOT / "artifacts/migration/fresh_db_project_anchor_replay_payl
 OUTPUT_JSON = ARTIFACT_ROOT / "fresh_db_project_anchor_replay_write_result_v1.json"
 ROLLBACK_CSV = ARTIFACT_ROOT / "fresh_db_project_anchor_replay_rollback_targets_v1.csv"
 EXPECTED_ROWS = int(os.getenv("PROJECT_ANCHOR_EXPECTED_ROWS", "0"))
+UNSPECIFIED_OPERATION_STRATEGY_DEFAULT = os.getenv("PROJECT_ANCHOR_UNSPECIFIED_OPERATION_STRATEGY_DEFAULT", "direct").strip()
 OPTIONAL_SOURCE_ONLY_FIELDS = {
     "legacy_deleted_flag",
     "current_db_project_id",
@@ -100,7 +101,14 @@ def write_json(path: Path, payload: dict[str, object]) -> None:
 
 
 def build_vals(row: dict[str, str], existing_fields: set[str]) -> dict[str, object]:
-    vals = {field: clean(row.get(field)) for field in SAFE_FIELDS if field in existing_fields}
+    vals = {}
+    for field in SAFE_FIELDS:
+        if field not in existing_fields:
+            continue
+        value = clean(row.get(field))
+        if field == "operation_strategy" and not value:
+            value = UNSPECIFIED_OPERATION_STRATEGY_DEFAULT
+        vals[field] = value
     return {field: value for field, value in vals.items() if value not in ("", None)}
 
 
@@ -196,6 +204,7 @@ result = {
     "source_only_fields_not_written": sorted(OPTIONAL_SOURCE_ONLY_FIELDS),
     "source_lane_counts": dict(sorted(source_lane_counts.items())),
     "deleted_source_rows": deleted_source_rows,
+    "unspecified_operation_strategy_default": UNSPECIFIED_OPERATION_STRATEGY_DEFAULT,
     "write_payload": str(INPUT_CSV),
     "rollback_targets": str(ROLLBACK_CSV),
     "decision": "project_anchor_replay_write_complete" if status == "PASS" else "STOP_REVIEW_REQUIRED",

--- a/scripts/migration/fresh_db_project_master_replay_postcheck.py
+++ b/scripts/migration/fresh_db_project_master_replay_postcheck.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Read-only postcheck for the project master upgrade replay flow."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from collections import Counter
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    env_root = os.getenv("MIGRATION_REPO_ROOT")
+    candidates = []
+    if env_root:
+        candidates.append(Path(env_root))
+    candidates.extend([Path("/mnt"), Path.cwd()])
+    for candidate in candidates:
+        if (candidate / "artifacts/migration/fresh_db_project_anchor_replay_payload_v1.csv").exists():
+            return candidate
+    return Path.cwd()
+
+
+REPO_ROOT = repo_root()
+ARTIFACT_ROOT = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", str(REPO_ROOT / "artifacts/migration")))
+PAYLOAD_CSV = REPO_ROOT / "artifacts/migration/fresh_db_project_anchor_replay_payload_v1.csv"
+ADAPTER_JSON = REPO_ROOT / "artifacts/migration/fresh_db_project_anchor_replay_adapter_result_v1.json"
+WRITE_JSON = ARTIFACT_ROOT / "fresh_db_project_anchor_replay_write_result_v1.json"
+OUTPUT_JSON = ARTIFACT_ROOT / "fresh_db_project_master_replay_postcheck_result_v1.json"
+OUTPUT_REPORT = ARTIFACT_ROOT / "fresh_db_project_master_replay_postcheck_report_v1.md"
+
+
+def clean(value: object) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return [dict(row) for row in csv.DictReader(handle)]
+
+
+def read_json(path: Path) -> dict[str, object]:
+    if not path.exists():
+        return {}
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def expected_rows_from_sources(rows: list[dict[str, str]]) -> int:
+    explicit = clean(os.getenv("PROJECT_ANCHOR_EXPECTED_ROWS"))
+    if explicit:
+        return int(explicit)
+    adapter_payload = read_json(ADAPTER_JSON)
+    adapter_rows = adapter_payload.get("replay_payload_rows")
+    if adapter_rows:
+        return int(adapter_rows)
+    write_payload = read_json(WRITE_JSON)
+    write_rows = write_payload.get("expected_rows") or write_payload.get("input_rows")
+    if write_rows:
+        return int(write_rows)
+    return len(rows)
+
+
+def write_report(payload: dict[str, object]) -> None:
+    text = f"""# Project Master Replay Postcheck Report v1
+
+Status: {payload["status"]}
+
+Task: `ITER-2026-05-07-PROJECT-MASTER-UPGRADE-REPLAY`
+
+## Scope
+
+Read-only acceptance check after the project master replay flow.
+
+## Replay Facts
+
+- database: `{payload["database"]}`
+- payload rows: `{payload["payload_rows"]}`
+- expected rows: `{payload["expected_rows"]}`
+- matched project rows: `{payload["matched_project_rows"]}`
+- duplicate payload identities: `{len(payload["duplicate_payload_identities"])}`
+- duplicate target identities: `{len(payload["duplicate_target_identities"])}`
+- missing target identities: `{len(payload["missing_target_identities"])}`
+
+## Source Lanes
+
+```json
+{json.dumps(payload["source_lane_counts"], ensure_ascii=False, indent=2)}
+```
+
+## Operation Strategy
+
+```json
+{json.dumps(payload["operation_strategy_counts"], ensure_ascii=False, indent=2)}
+```
+
+## Contract Linkage
+
+```json
+{json.dumps(payload["contract_visible_project_anchor_linkage"], ensure_ascii=False, indent=2)}
+```
+
+## Decision
+
+`{payload["decision"]}`
+"""
+    OUTPUT_REPORT.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_REPORT.write_text(text, encoding="utf-8")
+
+
+rows = read_csv(PAYLOAD_CSV)
+expected_rows = expected_rows_from_sources(rows)
+payload_keys = [clean(row.get("legacy_project_id")) for row in rows]
+payload_key_counts = Counter(payload_keys)
+duplicate_payload = sorted(key for key, count in payload_key_counts.items() if key and count > 1)
+missing_payload_key_rows = [index for index, key in enumerate(payload_keys, start=2) if not key]
+source_lane_counts = Counter(clean(row.get("replay_source_lane")) or "unknown" for row in rows)
+operation_strategy_counts = Counter(clean(row.get("operation_strategy")) or "unspecified" for row in rows)
+operation_strategy_default = clean(os.getenv("PROJECT_ANCHOR_UNSPECIFIED_OPERATION_STRATEGY_DEFAULT")) or "direct"
+model_operation_strategy_counts = Counter(clean(row.get("operation_strategy")) or operation_strategy_default for row in rows)
+
+Project = env["project.project"].sudo()  # noqa: F821
+project_fields = set(Project._fields)
+missing_project_fields = [
+    field
+    for field in ["legacy_project_id", "name", "operation_strategy"]
+    if field not in project_fields
+]
+
+missing_target: list[str] = []
+duplicate_target: list[dict[str, object]] = []
+matched_project_rows = 0
+db_operation_strategy_counts: Counter[str] = Counter()
+if not missing_project_fields:
+    for key in payload_keys:
+        if not key:
+            continue
+        records = Project.search([("legacy_project_id", "=", key)])
+        if not records:
+            missing_target.append(key)
+        elif len(records) > 1:
+            duplicate_target.append({"legacy_project_id": key, "ids": records[:20].mapped("id")})
+        else:
+            matched_project_rows += 1
+            db_operation_strategy_counts[clean(records.operation_strategy) or "unspecified"] += 1
+
+contract_linkage: dict[str, object] = {"model_present": "construction.contract" in env}  # noqa: F821
+if "construction.contract" in env:  # noqa: F821
+    Contract = env["construction.contract"].sudo()  # noqa: F821
+    contract_fields = set(Contract._fields)
+    required_contract_fields = {"legacy_project_id", "project_id", "legacy_income_surface_visible"}
+    missing_contract_fields = sorted(required_contract_fields - contract_fields)
+    contract_linkage["missing_fields"] = missing_contract_fields
+    if not missing_contract_fields:
+        visible_keys = sorted(
+            clean(row.get("legacy_project_id"))
+            for row in rows
+            if clean(row.get("replay_source_lane")) == "contract_visible_project_anchor"
+        )
+        visible_contracts = Contract.search(
+            [
+                ("legacy_project_id", "in", visible_keys),
+                ("legacy_income_surface_visible", "=", True),
+            ]
+        )
+        linked_visible_contracts = visible_contracts.filtered(lambda rec: bool(rec.project_id))
+        unresolved_contracts = visible_contracts.filtered(lambda rec: not rec.project_id)
+        contract_linkage.update(
+            {
+                "contract_visible_project_anchor_keys": len(visible_keys),
+                "visible_contract_rows": len(visible_contracts),
+                "linked_visible_contract_rows": len(linked_visible_contracts),
+                "unlinked_visible_contract_rows": len(unresolved_contracts),
+                "unlinked_samples": [
+                    {"id": rec.id, "legacy_contract_id": rec.legacy_contract_id or "", "legacy_project_id": rec.legacy_project_id or ""}
+                    for rec in unresolved_contracts[:20]
+                ],
+            }
+        )
+
+errors: list[dict[str, object]] = []
+if len(rows) != expected_rows:
+    errors.append({"error": "unexpected_payload_row_count", "actual": len(rows), "expected": expected_rows})
+if missing_payload_key_rows:
+    errors.append({"error": "missing_payload_legacy_project_id", "lines": missing_payload_key_rows[:20]})
+if duplicate_payload:
+    errors.append({"error": "duplicate_payload_identity", "samples": duplicate_payload[:20]})
+if missing_project_fields:
+    errors.append({"error": "missing_project_fields", "fields": missing_project_fields})
+if missing_target:
+    errors.append({"error": "missing_target_identity", "samples": missing_target[:20]})
+if duplicate_target:
+    errors.append({"error": "duplicate_target_identity", "samples": duplicate_target[:20]})
+if matched_project_rows != expected_rows:
+    errors.append({"error": "unexpected_matched_project_rows", "actual": matched_project_rows, "expected": expected_rows})
+if dict(sorted(db_operation_strategy_counts.items())) != dict(sorted(model_operation_strategy_counts.items())):
+    errors.append(
+        {
+            "error": "operation_strategy_model_distribution_mismatch",
+            "actual": dict(sorted(db_operation_strategy_counts.items())),
+            "expected": dict(sorted(model_operation_strategy_counts.items())),
+        }
+    )
+if contract_linkage.get("unlinked_visible_contract_rows", 0):
+    errors.append(
+        {
+            "error": "visible_contract_project_link_missing",
+            "unlinked_visible_contract_rows": contract_linkage["unlinked_visible_contract_rows"],
+        }
+    )
+
+status = "PASS" if not errors else "FAIL"
+result = {
+    "status": status,
+    "mode": "fresh_db_project_master_replay_postcheck",
+    "database": env.cr.dbname,  # noqa: F821
+    "db_writes": 0,
+    "payload_rows": len(rows),
+    "expected_rows": expected_rows,
+    "matched_project_rows": matched_project_rows,
+    "duplicate_payload_identities": duplicate_payload,
+    "duplicate_target_identities": duplicate_target,
+    "missing_target_identities": missing_target,
+    "missing_payload_key_rows": missing_payload_key_rows,
+    "source_lane_counts": dict(sorted(source_lane_counts.items())),
+    "operation_strategy_counts": {
+        "payload_raw": dict(sorted(operation_strategy_counts.items())),
+        "payload_model_normalized": dict(sorted(model_operation_strategy_counts.items())),
+        "database": dict(sorted(db_operation_strategy_counts.items())),
+        "unspecified_default": operation_strategy_default,
+    },
+    "contract_visible_project_anchor_linkage": contract_linkage,
+    "errors": errors,
+    "payload_csv": str(PAYLOAD_CSV),
+    "write_result_json": str(WRITE_JSON),
+    "decision": "project_master_replay_acceptance_passed" if status == "PASS" else "STOP_REVIEW_REQUIRED",
+}
+write_json(OUTPUT_JSON, result)
+write_report(result)
+print(
+    "FRESH_DB_PROJECT_MASTER_REPLAY_POSTCHECK="
+    + json.dumps(
+        {
+            "status": status,
+            "database": env.cr.dbname,  # noqa: F821
+            "payload_rows": len(rows),
+            "expected_rows": expected_rows,
+            "matched_project_rows": matched_project_rows,
+            "visible_contract_unlinked": contract_linkage.get("unlinked_visible_contract_rows"),
+            "db_writes": 0,
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+)

--- a/scripts/migration/project_master_upgrade_replay_flow.sh
+++ b/scripts/migration/project_master_upgrade_replay_flow.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+
+MODE="${PROJECT_MASTER_REPLAY_MODE:-all}"
+RUN_ID="${RUN_ID:-$(date +%Y%m%dT%H%M%S)}"
+ARTIFACT_ROOT="${MIGRATION_ARTIFACT_ROOT:-$ROOT_DIR/artifacts/migration/project_master_upgrade/$RUN_ID}"
+ALLOWED_DBS="${MIGRATION_REPLAY_DB_ALLOWLIST:-sc_partner_acceptance,sc_migration_fresh,sc_demo}"
+PROJECT_ANCHOR_EXPECTED_ROWS="${PROJECT_ANCHOR_EXPECTED_ROWS:-}"
+SHELL_EXEC="$ROOT_DIR/scripts/ops/odoo_shell_exec.sh"
+ADAPTER_SCRIPT="$ROOT_DIR/scripts/migration/fresh_db_project_anchor_replay_adapter.py"
+WRITE_SCRIPT="$ROOT_DIR/scripts/migration/fresh_db_project_anchor_replay_write.py"
+POSTCHECK_SCRIPT="$ROOT_DIR/scripts/migration/fresh_db_project_master_replay_postcheck.py"
+
+export MIGRATION_REPO_ROOT="${MIGRATION_REPO_ROOT:-$ROOT_DIR}"
+MIGRATION_REPO_ROOT_ODOO="${MIGRATION_REPO_ROOT_ODOO:-/mnt}"
+if [[ -z "${MIGRATION_ARTIFACT_ROOT_ODOO:-}" ]]; then
+  if [[ "$ARTIFACT_ROOT" == "$ROOT_DIR/"* ]]; then
+    MIGRATION_ARTIFACT_ROOT_ODOO="$MIGRATION_REPO_ROOT_ODOO/${ARTIFACT_ROOT#"$ROOT_DIR/"}"
+  else
+    MIGRATION_ARTIFACT_ROOT_ODOO="$ARTIFACT_ROOT"
+  fi
+fi
+export MIGRATION_REPLAY_DB_ALLOWLIST="$ALLOWED_DBS"
+export MIGRATION_ARTIFACT_ROOT="$ARTIFACT_ROOT"
+export PROJECT_ANCHOR_EXPECTED_ROWS
+
+if [[ -z "${PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME:-}" && "${DB_NAME:-}" == "sc_partner_acceptance" ]]; then
+  PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME="sc-backend-odoo-partner-acceptance"
+fi
+PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME="${PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME:-${COMPOSE_PROJECT_NAME:-}}"
+
+if [[ "${PROJECT_MASTER_REPLAY_ALLOW_PROD:-0}" == "1" ]]; then
+  guard_prod_danger
+else
+  guard_prod_forbid
+fi
+
+require_db_for_write_modes() {
+  case "$MODE" in
+    write|postcheck|all)
+      : "${DB_NAME:?DB_NAME is required for PROJECT_MASTER_REPLAY_MODE=$MODE}"
+      ;;
+  esac
+}
+
+adapter_expected_rows() {
+  python3 - <<'PY'
+import json
+import os
+from pathlib import Path
+
+path = Path(os.environ["ROOT_DIR"]) / "artifacts/migration/fresh_db_project_anchor_replay_adapter_result_v1.json"
+if path.exists():
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    print(payload.get("replay_payload_rows") or "")
+PY
+}
+
+run_adapter() {
+  echo "[project.master.replay] step=adapter"
+  MIGRATION_REPO_ROOT="$MIGRATION_REPO_ROOT" \
+    MIGRATION_ARTIFACT_ROOT="$MIGRATION_ARTIFACT_ROOT" \
+    python3 "$ADAPTER_SCRIPT"
+  if [[ -z "$PROJECT_ANCHOR_EXPECTED_ROWS" ]]; then
+    PROJECT_ANCHOR_EXPECTED_ROWS="$(adapter_expected_rows)"
+    export PROJECT_ANCHOR_EXPECTED_ROWS
+  fi
+  echo "[project.master.replay] adapter_expected_rows=${PROJECT_ANCHOR_EXPECTED_ROWS:-unset}"
+}
+
+run_odoo_script() {
+  local script_path="$1"
+  DB_NAME="$DB_NAME" \
+    COMPOSE_PROJECT_NAME="${PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME:-}" \
+    PROJECT="${PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME:-}" \
+    MIGRATION_REPO_ROOT="$MIGRATION_REPO_ROOT_ODOO" \
+    MIGRATION_ARTIFACT_ROOT="$MIGRATION_ARTIFACT_ROOT_ODOO" \
+    MIGRATION_REPLAY_DB_ALLOWLIST="$MIGRATION_REPLAY_DB_ALLOWLIST" \
+    PROJECT_ANCHOR_EXPECTED_ROWS="$PROJECT_ANCHOR_EXPECTED_ROWS" \
+    bash "$SHELL_EXEC" <"$script_path"
+}
+
+run_write() {
+  echo "[project.master.replay] step=write db=$DB_NAME"
+  run_odoo_script "$WRITE_SCRIPT"
+}
+
+run_postcheck() {
+  echo "[project.master.replay] step=postcheck db=$DB_NAME"
+  run_odoo_script "$POSTCHECK_SCRIPT"
+}
+
+require_db_for_write_modes
+mkdir -p "$ARTIFACT_ROOT"
+chmod 0777 "$ARTIFACT_ROOT" 2>/dev/null || true
+
+echo "[project.master.replay] mode=$MODE db=${DB_NAME:-none} artifact_root=$ARTIFACT_ROOT allowlist=$MIGRATION_REPLAY_DB_ALLOWLIST compose_project=${PROJECT_MASTER_REPLAY_COMPOSE_PROJECT_NAME:-default}"
+
+case "$MODE" in
+  adapter)
+    run_adapter
+    ;;
+  write)
+    if [[ -z "$PROJECT_ANCHOR_EXPECTED_ROWS" ]]; then
+      PROJECT_ANCHOR_EXPECTED_ROWS="$(adapter_expected_rows)"
+      export PROJECT_ANCHOR_EXPECTED_ROWS
+    fi
+    run_write
+    ;;
+  postcheck)
+    if [[ -z "$PROJECT_ANCHOR_EXPECTED_ROWS" ]]; then
+      PROJECT_ANCHOR_EXPECTED_ROWS="$(adapter_expected_rows)"
+      export PROJECT_ANCHOR_EXPECTED_ROWS
+    fi
+    run_postcheck
+    ;;
+  all)
+    run_adapter
+    run_write
+    run_postcheck
+    ;;
+  *)
+    echo "❌ unsupported PROJECT_MASTER_REPLAY_MODE=$MODE (adapter|write|postcheck|all)" >&2
+    exit 2
+    ;;
+esac
+
+echo "[project.master.replay] complete mode=$MODE artifact_root=$ARTIFACT_ROOT"

--- a/scripts/ops/odoo_shell_exec.sh
+++ b/scripts/ops/odoo_shell_exec.sh
@@ -11,7 +11,7 @@ fi
 ENV_FORWARD_ARGS=()
 while IFS='=' read -r env_name _; do
   case "$env_name" in
-    MIGRATION_*|FRESH_DB_*|LEGACY_USER_*|PARTNER_ASSET_XML|PARTNER_BUSINESS_ALIGNED_GATE_CSV)
+    MIGRATION_*|FRESH_DB_*|LEGACY_USER_*|PROJECT_ANCHOR_*|PARTNER_ASSET_XML|PARTNER_BUSINESS_ALIGNED_GATE_CSV)
       if [[ -n "${!env_name:-}" ]]; then
         ENV_FORWARD_ARGS+=("-e" "${env_name}=${!env_name}")
       fi


### PR DESCRIPTION
## Summary
- add a dedicated project master replay flow that combines adapter, guarded write, and postcheck modes
- add read-only acceptance postcheck for project anchors, model-normalized operation strategy, and visible contract linkage
- forward PROJECT_ANCHOR_* env vars into Odoo shell replay scripts

## Validation
- PROJECT_MASTER_REPLAY_MODE=adapter bash scripts/migration/project_master_upgrade_replay_flow.sh
- PROJECT_MASTER_REPLAY_MODE=all DB_NAME=sc_partner_acceptance MIGRATION_REPLAY_DB_ALLOWLIST=sc_partner_acceptance PROJECT_ANCHOR_EXPECTED_ROWS=798 bash scripts/migration/project_master_upgrade_replay_flow.sh
- bash -n scripts/migration/project_master_upgrade_replay_flow.sh scripts/ops/odoo_shell_exec.sh
- python3 -m py_compile scripts/migration/fresh_db_project_master_replay_postcheck.py scripts/migration/fresh_db_project_anchor_replay_write.py scripts/migration/fresh_db_project_anchor_replay_adapter.py
- git diff --check

Acceptance result: sc_partner_acceptance PASS, payload_rows=798, matched_project_rows=798, visible_contract_unlinked=0, operation_strategy database distribution direct=38/joint=760.