### PR TITLE
Align user delivery initialization surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1443,6 +1443,7 @@ policy.ensure.role_surface_demo: guard.prod.forbid check-compose-project check-c
 	  echo "[policy.ensure.role_surface_demo] applying auto-fix for role surface demo baseline"; \
 	  $(MAKE) --no-print-directory mod.install MODULE=smart_construction_custom DB_NAME=$(DB_NAME); \
 	  $(MAKE) --no-print-directory mod.install MODULE=smart_construction_seed DB_NAME=$(DB_NAME); \
+	  $(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/link_existing_demo_user_xmlids.sh; \
 	  $(MAKE) --no-print-directory mod.install MODULE=smart_construction_demo DB_NAME=$(DB_NAME); \
 	  $(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_SMOKE_PASSWORD="$${ROLE_SMOKE_PASSWORD:-demo}" bash scripts/ops/ensure_role_surface_demo.sh; \
 	  $(MAKE) --no-print-directory restart; \

--- a/addons/smart_construction_custom/models/security_policy.py
+++ b/addons/smart_construction_custom/models/security_policy.py
@@ -65,12 +65,8 @@ class ScSecurityPolicy(models.TransientModel):
 
         executive = self.env.ref("smart_construction_custom.group_sc_role_executive", raise_if_not_found=False)
         platform_admin = self.env.ref("smart_construction_core.group_sc_cap_config_admin", raise_if_not_found=False)
-        business_config = self.env.ref("smart_construction_core.group_sc_cap_business_config_admin", raise_if_not_found=False)
         if executive and platform_admin and platform_admin in executive.implied_ids:
             executive.write({"implied_ids": [(3, platform_admin.id)]})
-            updated = True
-        if executive and business_config and business_config not in executive.implied_ids:
-            executive.write({"implied_ids": [(4, business_config.id)]})
             updated = True
 
         user_map = {
@@ -121,6 +117,7 @@ class ScSecurityPolicy(models.TransientModel):
                 "base.group_no_one",
                 "project.group_project_manager",
                 "smart_construction_core.group_sc_cap_config_admin",
+                "smart_construction_core.group_sc_cap_business_config_admin",
                 "smart_construction_core.group_sc_super_admin",
                 "smart_construction_core.group_sc_task_entry_access",
             ],

--- a/addons/smart_construction_custom/security/role_matrix_groups.xml
+++ b/addons/smart_construction_custom/security/role_matrix_groups.xml
@@ -112,8 +112,7 @@
             <field name="category_id" ref="smart_construction_core.module_category_smart_construction"/>
             <field name="implied_ids" eval="[(6, 0, [
                 ref('smart_construction_custom.group_sc_role_pm'),
-                ref('smart_construction_custom.group_sc_role_finance'),
-                ref('smart_construction_core.group_sc_cap_business_config_admin')
+                ref('smart_construction_custom.group_sc_role_finance')
             ])]"/>
         </record>
     </data>

--- a/frontend/apps/web/src/app/action_runtime/useActionViewActionGroupingRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewActionGroupingRuntime.ts
@@ -10,7 +10,7 @@ type ActionGroup = {
   actions: ContractActionButton[];
 };
 
-type ActionPresentation = {
+export type ActionPresentation = {
   groups: ActionGroup[];
   primaryActions: ContractActionButton[];
   overflowActionGroups: ActionGroup[];

--- a/frontend/apps/web/src/app/action_runtime/useActionViewActionPresentationRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewActionPresentationRuntime.ts
@@ -1,5 +1,6 @@
 import { computed, type Ref } from 'vue';
 import { resolveUnifiedPageContractV2 } from '../contracts/unifiedPageContractV2';
+import type { ActionPresentation } from './useActionViewActionGroupingRuntime';
 
 type Dict = Record<string, unknown>;
 
@@ -46,7 +47,7 @@ type UseActionViewActionPresentationRuntimeOptions = {
     allButtons: ContractActionButton[];
     actionPrimaryBudget: number;
     pageText: (key: string, fallback: string) => string;
-  }) => any;
+  }) => ActionPresentation;
   pageText: (key: string, fallback: string) => string;
 };
 
@@ -70,35 +71,38 @@ function resolveV2RefreshPolicy(refreshMode: string): Dict | undefined {
 function normalizeV2ActionRows(contract: Dict | null): Array<Record<string, unknown>> {
   const v2 = resolveUnifiedPageContractV2(contract);
   if (!v2) return [];
-  return (v2.actionContract.actionRuleList || []).reduce<Array<Record<string, unknown>>>((acc, action) => {
-      const key = String(action.actionKey || action.actionId || '').trim();
-      if (!key) return acc;
-      const intent = String(action.intent || '').trim();
-      const target = action.target || {};
-      const button = action.button || {};
-      const isOpen = intent === 'ui.contract';
-      acc.push({
-        key,
-        label: String(action.label || key).trim() || key,
-        intent,
-        kind: isOpen ? 'open' : String(button.type || 'object'),
-        level: 'toolbar',
-        target,
-        payload: isOpen
-          ? target
-          : {
-              method: button.name || key,
-              type: button.type || 'object',
-            },
-        refresh_policy: resolveV2RefreshPolicy(action.refreshMode),
-        target_model: String(target.model || '').trim(),
-        selection: 'none',
-        unified_page_contract_v2_action_id: action.actionId,
-        unified_page_contract_v2_source_widget_id: action.sourceWidgetId,
-        unified_page_contract_v2_refresh_mode: action.refreshMode,
-      });
-      return acc;
-    }, []);
+  const rows = Array.isArray(v2.actionContract.actionRuleList) ? v2.actionContract.actionRuleList : [];
+  const normalized: Array<Record<string, unknown>> = [];
+  for (const action of rows) {
+    if (!action || typeof action !== 'object') continue;
+    const key = String(action.actionKey || action.actionId || '').trim();
+    if (!key) continue;
+    const intent = String(action.intent || '').trim();
+    const target = action.target && typeof action.target === 'object' && !Array.isArray(action.target) ? action.target : {};
+    const button = action.button && typeof action.button === 'object' && !Array.isArray(action.button) ? action.button : {};
+    const isOpen = intent === 'ui.contract';
+    normalized.push({
+      key,
+      label: String(action.label || key).trim() || key,
+      intent,
+      kind: isOpen ? 'open' : String(button.type || 'object'),
+      level: 'toolbar',
+      target,
+      payload: isOpen
+        ? target
+        : {
+            method: button.name || key,
+            type: button.type || 'object',
+          },
+      refresh_policy: resolveV2RefreshPolicy(action.refreshMode),
+      target_model: String(target.model || '').trim(),
+      selection: 'none',
+      unified_page_contract_v2_action_id: action.actionId,
+      unified_page_contract_v2_source_widget_id: action.sourceWidgetId,
+      unified_page_contract_v2_refresh_mode: action.refreshMode,
+    });
+  }
+  return normalized;
 }
 
 export function useActionViewActionPresentationRuntime(options: UseActionViewActionPresentationRuntimeOptions) {

--- a/frontend/apps/web/src/app/action_runtime/useActionViewActionRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewActionRuntime.ts
@@ -30,6 +30,29 @@ type ContractActionButtonLike = {
   refreshPolicy?: Dict;
 };
 
+type ProjectionRefreshInput = {
+  policy: Dict;
+  refreshScene: () => Promise<void>;
+  refreshWorkbench: () => Promise<void>;
+  refreshRoleSurface: () => Promise<void>;
+  recordTrace: (input: { intent: string; writeMode: string; latencyMs?: number }) => void;
+};
+
+type SceneMutationInput = {
+  mutation: MutationPayload;
+  actionKey: string;
+  recordId?: number | null;
+  model?: string;
+  context?: Dict;
+};
+
+type ExecuteButtonInput = {
+  model: string;
+  res_id: number;
+  button: { name: string; type: string };
+  context?: Dict;
+};
+
 type UseActionViewActionRuntimeOptions = {
   selectedIds: Ref<number[]>;
   batchBusy: Ref<boolean>;
@@ -52,9 +75,9 @@ type UseActionViewActionRuntimeOptions = {
   resolveRequiresRecordContextMessage: (text: (key: string, fallback: string) => string) => string;
   resolveSelectionBlockMessage: (input: { selection: ContractActionSelection; selectedCount: number; text: (key: string, fallback: string) => string }) => string;
   resolveMissingModelMessage: (text: (key: string, fallback: string) => string) => string;
-  executeProjectionRefresh: (options: any) => Promise<void>;
-  executeSceneMutation: (options: any) => Promise<unknown>;
-  executeButton: (payload: any) => Promise<unknown>;
+  executeProjectionRefresh: (options: ProjectionRefreshInput) => Promise<void>;
+  executeSceneMutation: (options: SceneMutationInput) => Promise<unknown>;
+  executeButton: (payload: ExecuteButtonInput) => Promise<unknown>;
   buildButtonRequest: (input: {
     model: string;
     recordId: number;

--- a/frontend/apps/web/src/app/action_runtime/useActionViewHeaderRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewHeaderRuntime.ts
@@ -9,7 +9,15 @@ type UseActionViewHeaderRuntimeOptions = {
   resolveFocusActionPushState: (input: { action: unknown; workspaceContextQuery: Record<string, unknown> }) => { target: unknown };
   resolveWorkspaceContextQuery: () => Record<string, unknown>;
   routerPush: (target: unknown) => Promise<unknown>;
-  executePageContractAction: (input: any) => Promise<boolean>;
+  executePageContractAction: (input: {
+    actionKey: string;
+    router: unknown;
+    actionIntent: unknown;
+    actionTarget: unknown;
+    query: Record<string, unknown>;
+    onRefresh: () => void;
+    onFallback: (key: string) => Promise<boolean>;
+  }) => Promise<boolean>;
   router: unknown;
   pageActionIntent: unknown;
   pageActionTarget: unknown;

--- a/frontend/apps/web/src/app/action_runtime/useActionViewPageDisplayStateRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewPageDisplayStateRuntime.ts
@@ -1,8 +1,6 @@
 import { computed, type ComputedRef, type Ref } from 'vue';
 import type { RouteLocationNormalizedLoaded } from 'vue-router';
 
-type Dict = Record<string, unknown>;
-
 type ActionContractLike = {
   head?: {
     title?: string;

--- a/frontend/apps/web/src/app/action_runtime/useActionViewRequestContextRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewRequestContextRuntime.ts
@@ -47,23 +47,6 @@ type UseActionViewRequestContextRuntimeOptions = {
   activeGroupByField: Ref<string>;
 };
 
-function parseContextRaw(raw: unknown): Dict {
-  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
-    return { ...(raw as Dict) };
-  }
-  const text = String(raw || '').trim();
-  if (!text) return {};
-  try {
-    const parsed = JSON.parse(text);
-    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-      return parsed as Dict;
-    }
-  } catch {
-    return {};
-  }
-  return {};
-}
-
 export function useActionViewRequestContextRuntime(options: UseActionViewRequestContextRuntimeOptions) {
   function resolveContractFilterDomain() {
     return resolveFilterDomain(options.contractFilterChips.value, options.activeContractFilterKey.value);

--- a/frontend/apps/web/src/app/pageContractActionRuntime.ts
+++ b/frontend/apps/web/src/app/pageContractActionRuntime.ts
@@ -14,7 +14,6 @@ export type ContractActionDeps = {
 };
 
 export async function executePageContractAction(deps: ContractActionDeps): Promise<boolean> {
-  const intent = deps.actionIntent(deps.actionKey, 'ui.contract');
   const target = deps.actionTarget(deps.actionKey);
   const kind = String(target.kind || '');
   const scene = String(target.scene_key || '');

--- a/frontend/apps/web/src/components/template/NativeFormTreeRenderer.vue
+++ b/frontend/apps/web/src/components/template/NativeFormTreeRenderer.vue
@@ -45,7 +45,7 @@
         <template v-else>
           <FormSection
             v-if="fieldSchemasForNodes(fieldChildren(node)).length"
-            :title="fieldSectionTitle(node)"
+            :title="fieldSectionTitle()"
             :columns="columns"
             :fields="fieldSchemasForNodes(fieldChildren(node))"
             tone="core"
@@ -122,7 +122,7 @@
 
       <FormSection
         v-else-if="nodeType(node) === 'field' && fieldSchemasForNodes([node]).length"
-        :title="fieldSectionTitle(node)"
+          :title="fieldSectionTitle()"
         :columns="columns"
         :fields="fieldSchemasForNodes([node])"
         tone="core"
@@ -194,9 +194,9 @@ const emit = defineEmits<{
 const activePageIndex = ref(0);
 const openMoreKeys = ref<Record<string, boolean>>({});
 const SMART_BUTTON_DIRECT_LIMIT = 4;
-const visibleNodes = computed(() => (props.nodes || []).filter((node) => isNodeVisible(node)));
+const visibleNodes = computed(() => (props.nodes || []).filter((node) => isNodeRenderable(node)));
 
-function isNodeVisible(node: NativeFormLayoutNode) {
+function isNodeRenderable(node: NativeFormLayoutNode) {
   return props.isNodeVisible(node);
 }
 
@@ -230,11 +230,11 @@ function rawChildren(node: NativeFormLayoutNode) {
 }
 
 function fieldChildren(node: NativeFormLayoutNode) {
-  return rawChildren(node).filter((child) => nodeType(child) === 'field' && isNodeVisible(child));
+  return rawChildren(node).filter((child) => nodeType(child) === 'field' && isNodeRenderable(child));
 }
 
 function buttonChildren(node: NativeFormLayoutNode) {
-  return rawChildren(node).filter((child) => nodeType(child) === 'button' && isNodeVisible(child));
+  return rawChildren(node).filter((child) => nodeType(child) === 'button' && isNodeRenderable(child));
 }
 
 function visibleActionButtons(node: NativeFormLayoutNode) {
@@ -259,7 +259,7 @@ function overflowActionButtons(node: NativeFormLayoutNode) {
 }
 
 function widgetChildren(node: NativeFormLayoutNode) {
-  return rawChildren(node).filter((child) => nodeType(child) === 'widget' && isNodeVisible(child));
+  return rawChildren(node).filter((child) => nodeType(child) === 'widget' && isNodeRenderable(child));
 }
 
 function containerChildren(node: NativeFormLayoutNode) {
@@ -276,7 +276,7 @@ function activeNotebookChildren(node: NativeFormLayoutNode) {
   return page ? rawChildren(page) : [];
 }
 
-function fieldSectionTitle(node: NativeFormLayoutNode) {
+function fieldSectionTitle() {
   return '';
 }
 

--- a/frontend/apps/web/src/config.ts
+++ b/frontend/apps/web/src/config.ts
@@ -12,8 +12,9 @@ const runtimeDb = typeof window !== 'undefined'
 // Auto-forcing may cause token/db mismatch when frontend host is not localhost.
 const enforcedDb = '';
 const envDbNormalized = envDb.toLowerCase();
-const localBlockedEnvDb = isLocalHost && envDbNormalized === 'sc_delivery_local' ? '' : envDb;
-const allowLocalFallbackDb = appEnv === 'dev' || appEnv === 'test' || appEnv === 'local';
+const localBlockedProductionDb = isLocalHost && ['sc_delivery_local', 'sc_prod_sim'].includes(envDbNormalized);
+const localBlockedEnvDb = localBlockedProductionDb ? '' : envDb;
+const allowLocalFallbackDb = isLocalHost || appEnv === 'dev' || appEnv === 'test' || appEnv === 'local';
 // For local dev/test only, fallback to sc_demo when db env is not explicitly set.
 const localDefaultDb = allowLocalFallbackDb && !runtimeDb && !localBlockedEnvDb && isLocalHost ? 'sc_demo' : '';
 const pinnedDb = localBlockedEnvDb || enforcedDb || runtimeDb;
@@ -26,7 +27,7 @@ export const config = {
     .split(',')
     .map((flag: string) => flag.trim())
     .filter(Boolean),
-  odooDb: pinnedDb || resolveActiveDb(localDefaultDb),
+  odooDb: pinnedDb || (localBlockedProductionDb ? localDefaultDb : resolveActiveDb(localDefaultDb)),
   odooDbPinned: Boolean(pinnedDb),
 };
 

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -222,8 +222,8 @@
           </template>
         </NativeFormTreeRenderer>
         <FormSectionTemplate
-          v-else
           v-for="section in templateSections"
+          v-else
           :key="section.key"
           :title="section.title"
           :hint="section.hint"
@@ -1031,7 +1031,6 @@ const submitButtonLabel = computed(() => {
   }
   return formUiLabel('save');
 });
-const normalCreateButtonLabel = computed(() => (busy.value && busyKind.value === 'save' ? '创建中...' : '创建项目'));
 const showDiscardAction = computed(() => !isProjectIntakeCreateMode.value && Boolean(recordId.value) && hasChanges.value);
 
 const headerActionsVisible = computed(() => {
@@ -5038,7 +5037,7 @@ async function runAction(action: ContractAction) {
 function isTierValidationActionHidden(methodName: string): boolean {
   const method = String(methodName || '').trim();
   const validationStatus = String(formData.validation_status || '').trim();
-  if ((method === 'validate_tier' || method === 'reject_tier') && !Boolean(formData.can_review)) {
+  if ((method === 'validate_tier' || method === 'reject_tier') && !formData.can_review) {
     return true;
   }
   if (

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1093,14 +1093,6 @@ watch(
   { immediate: true },
 );
 
-function onGroupSampleLimitSelectChange(event: Event) {
-  const value = Number((event.target as HTMLSelectElement | null)?.value || 0);
-  if (!Number.isFinite(value)) return;
-  const normalized = Math.trunc(value);
-  if (!groupSampleLimitOptions.value.includes(normalized)) return;
-  props.onGroupSampleLimitChange?.(normalized);
-}
-
 const groupSampleLimitOptions = computed(() => {
   const values = Array.isArray(props.listProfile?.grouping?.sample_limits)
     ? props.listProfile?.grouping?.sample_limits || []
@@ -1196,16 +1188,6 @@ const totalPages = computed(() => {
   return Math.max(1, Math.ceil(total / listLimit.value));
 });
 const currentPage = computed(() => Math.min(totalPages.value, Math.floor(listOffset.value / listLimit.value) + 1));
-const rangeStart = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return 0;
-  return Math.min(total, listOffset.value + 1);
-});
-const rangeEnd = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return 0;
-  return Math.min(total, listOffset.value + props.records.length);
-});
 const showPagination = computed(() => listTotal.value !== null && props.status === 'ok' && !showGroupedRows.value);
 const toolbarSubtitle = computed(() => {
   if (listTotal.value !== null) {
@@ -1217,15 +1199,6 @@ const canPagePrev = computed(() => listOffset.value > 0);
 const canPageNext = computed(() => {
   const total = listTotal.value || 0;
   return listOffset.value + listLimit.value < total;
-});
-const paginationSummary = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return uiLabel('pagination_total_empty', '共 0 条');
-  return uiLabel('pagination_summary', '共 {total} 条，当前 {start}-{end} 条', {
-    total,
-    start: rangeStart.value,
-    end: rangeEnd.value,
-  });
 });
 const paginationPageText = computed(() =>
   uiLabel('pagination_page', '第 {current} / {total} 页', {

--- a/frontend/apps/web/src/views/ActionView.vue
+++ b/frontend/apps/web/src/views/ActionView.vue
@@ -532,6 +532,7 @@ import { getUserViewPreference, setUserViewPreference } from '../api/preferences
 import { executeButton } from '../api/executeButton';
 import { trackUsageEvent } from '../api/usage';
 import { resolveAction } from '../app/resolvers/actionResolver';
+import { resolveMenuAction } from '../app/resolvers/menuResolver';
 import { loadActionContract } from '../api/contract';
 import { config } from '../config';
 import { useSessionStore } from '../stores/session';
@@ -545,8 +546,7 @@ import { deriveListStatus } from '../app/view_state';
 import { isHudEnabled } from '../config/debug';
 import { ErrorCodes } from '../app/error_codes';
 import { evaluateCapabilityPolicy } from '../app/capabilityPolicy';
-import { resolveSuggestedAction, useStatus } from '../composables/useStatus';
-import { describeSuggestedAction, runSuggestedAction } from '../composables/useSuggestedAction';
+import { useStatus } from '../composables/useStatus';
 import {
   parseContractContextRaw,
   resolveContractAccessPolicy,
@@ -694,9 +694,6 @@ import {
   shouldNavigateContractAction,
 } from '../app/runtime/actionViewContractActionRuntime';
 import {
-  resolveExportDoneMessage,
-} from '../app/runtime/actionViewAssigneeExportRuntime';
-import {
   buildBatchUpdateRequest,
   resolveBatchActionFailureMessage,
   resolveBatchActionGuardMessage,
@@ -818,8 +815,6 @@ const session = useSessionStore();
 const PROJECT_CONTEXT_CHANGED_EVENT = 'sc:project-context-changed';
 const {
   resolveSceneCode,
-  resolveNodeSceneKey,
-  findMenuNode,
 } = useActionViewSceneIdentityRuntime();
 const pageContract = usePageContract('action');
 const pageText = pageContract.text;
@@ -1400,11 +1395,9 @@ const {
   resolveActionViewSurfaceKind,
 });
 const {
-  sortOptions,
   subtitle,
   statusLabel,
   pageStatus,
-  recordCount,
 } = useActionViewDisplayComputedRuntime({
   actionContract,
   records,
@@ -1540,7 +1533,6 @@ const {
   contractSavedFilterChips,
   savedFilterPrimaryChips,
   savedFilterOverflowChips,
-  contractGroupByChips,
   customFilterFields,
   customGroupByChips,
   routeGroupByChips,
@@ -2105,8 +2097,8 @@ const { runContractAction } = useActionViewActionRuntime({
       recordTrace: (input: { intent: string; writeMode: string; latencyMs?: number }) => void;
     });
   },
-  executeSceneMutation: executeSceneMutation as (options: any) => Promise<unknown>,
-  executeButton: executeButton as (payload: any) => Promise<unknown>,
+  executeSceneMutation,
+  executeButton,
   buildButtonRequest: buildContractActionButtonRequest,
   resolveResponseActionId: resolveContractActionResponseActionId,
   shouldNavigate: shouldNavigateContractAction,
@@ -2809,9 +2801,79 @@ const {
 });
 clearSelectionInvoker = selectionRuntimeClearSelection;
 
+function findMenuNodeByLabel(nodes: Array<Record<string, unknown>>, label: string): Record<string, unknown> | null {
+  const expected = String(label || '').trim();
+  if (!expected || !Array.isArray(nodes)) return null;
+  for (const node of nodes) {
+    if (!node || typeof node !== 'object') continue;
+    const current = String(node.label || node.title || node.name || '').trim();
+    if (current === expected) return node;
+    const found = findMenuNodeByLabel((node.children as Array<Record<string, unknown>>) || [], expected);
+    if (found) return found;
+  }
+  return null;
+}
+
+async function redirectMenuOnlyRouteIfNeeded(): Promise<boolean> {
+  const currentMenuId = Number(menuId.value || 0);
+  if (Number(actionId.value || 0) > 0 || currentMenuId <= 0) {
+    return false;
+  }
+  let result = resolveMenuAction(session.menuTree, currentMenuId);
+  if (result.kind === 'broken' && result.reason === 'menu not found') {
+    const fallbackNode = findMenuNodeByLabel(
+      session.menuTree as unknown as Array<Record<string, unknown>>,
+      String(route.query.label || ''),
+    );
+    const fallbackMenuId = Number(fallbackNode?.menu_id || fallbackNode?.id || 0);
+    if (fallbackMenuId > 0) {
+      result = resolveMenuAction(session.menuTree, fallbackMenuId);
+    }
+  }
+  if (result.kind === 'leaf') {
+    const targetActionId = Number(result.meta.action_id || 0);
+    if (targetActionId <= 0) return false;
+    session.setActionMeta(result.meta);
+    await router.replace({
+      name: 'action',
+      params: { actionId: targetActionId },
+      query: resolveCarryQuery({ menu_id: currentMenuId, action_id: targetActionId }),
+    });
+    return true;
+  }
+  if (result.kind === 'redirect') {
+    if (result.target.scene_key) {
+      await router.replace({
+        path: `/s/${result.target.scene_key}`,
+        query: resolveCarryQuery({ menu_id: result.target.menu_id || currentMenuId }),
+      });
+      return true;
+    }
+    const targetActionId = Number(result.target.action_id || 0);
+    if (targetActionId > 0) {
+      if (result.target.meta) {
+        session.setActionMeta(result.target.meta);
+      }
+      await router.replace({
+        name: 'action',
+        params: { actionId: targetActionId },
+        query: resolveCarryQuery({
+          menu_id: result.target.menu_id || currentMenuId,
+          action_id: targetActionId,
+        }),
+      });
+      return true;
+    }
+  }
+  return false;
+}
+
 onMounted(async () => {
   renderErrorMessage.value = '';
   applyRoutePreset();
+  if (await redirectMenuOnlyRouteIfNeeded()) {
+    return;
+  }
   await requestLoadPage();
   if (typeof window !== 'undefined') {
     window.addEventListener(PROJECT_CONTEXT_CHANGED_EVENT, handleProjectContextChanged);
@@ -2837,7 +2899,7 @@ onErrorCaptured((err) => {
 
 watch(
   () => route.fullPath,
-  () => {
+  async () => {
     if (suppressNextRouteReload.value) {
       suppressNextRouteReload.value = false;
       applyRoutePreset();
@@ -2847,6 +2909,9 @@ watch(
     listOffset.value = 0;
     clearSelection();
     applyRoutePreset();
+    if (await redirectMenuOnlyRouteIfNeeded()) {
+      return;
+    }
     void requestLoadPage();
   },
 );

--- a/frontend/apps/web/src/views/HomeView.vue
+++ b/frontend/apps/web/src/views/HomeView.vue
@@ -572,7 +572,6 @@ const heroQuickActions = computed(() => {
 });
 const productFacts = computed(() => session.productFacts);
 const roleSurface = computed(() => session.roleSurface);
-const capabilityGroups = computed(() => session.capabilityGroups);
 const workspaceHome = computed(() => (session.workspaceHome || {}) as Record<string, unknown>);
 const workspaceLayout = computed(() => (
   workspaceHome.value.layout && typeof workspaceHome.value.layout === 'object'
@@ -655,11 +654,6 @@ const workspacePageOrchestration = computed(() => (
 const workspacePageOrchestrationV1 = computed(() => (
   workspaceHome.value.page_orchestration_v1 && typeof workspaceHome.value.page_orchestration_v1 === 'object'
     ? workspaceHome.value.page_orchestration_v1 as Record<string, unknown>
-    : {}
-));
-const workspaceSceneContractV1 = computed(() => (
-  workspaceHome.value.scene_contract_v1 && typeof workspaceHome.value.scene_contract_v1 === 'object'
-    ? workspaceHome.value.scene_contract_v1 as Record<string, unknown>
     : {}
 ));
 const workspacePageOrchestrationV1DataSources = computed(() => (
@@ -826,13 +820,6 @@ const capabilityGroupCards = computed(() => {
       denyCount: group.denyCount,
       examples: group.examples || [],
     }));
-});
-const capabilityGroupScoreMap = computed(() => {
-  const map = new Map<string, number>();
-  session.workspaceCapabilityGroupRows.forEach((group: WorkspaceCapabilityGroupRow) => {
-    map.set(group.key, group.score);
-  });
-  return map;
 });
 const licenseLevelLabel = computed(() => String(productFacts.value?.license?.level || '').trim() || 'unknown');
 const bundleNameLabel = computed(() => String(productFacts.value?.bundle?.name || '').trim() || 'default');

--- a/scripts/audit/apply_business_full_policy.sh
+++ b/scripts/audit/apply_business_full_policy.sh
@@ -13,5 +13,6 @@ make mod.upgrade MODULE="$POLICY_MODULE" DB_NAME="$DB_NAME"
 
 DB_NAME="$DB_NAME" docker compose exec -T odoo odoo shell -d "$DB_NAME" -c /var/lib/odoo/odoo.conf <<'PY'
 res = env["sc.security.policy"].apply_business_full_policy()
+env.cr.commit()
 print("apply_business_full_policy:", res)
 PY

--- a/scripts/ops/ensure_role_surface_demo.sh
+++ b/scripts/ops/ensure_role_surface_demo.sh
@@ -42,6 +42,7 @@ for login in required_logins:
     user.write(vals)
     updated.append({"login": login, "active": bool(user.active)})
 
+env.cr.commit()
 print("[policy.ensure.role_surface_demo] PASS set role demo passwords")
 print(json.dumps({"db": env.cr.dbname, "updated": updated}, ensure_ascii=False, indent=2))
 PY

--- a/scripts/ops/link_existing_demo_user_xmlids.sh
+++ b/scripts/ops/link_existing_demo_user_xmlids.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+source "$ROOT_DIR/scripts/common/env.sh"
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+source "$ROOT_DIR/scripts/_lib/common.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME required}"
+
+compose ${COMPOSE_FILES} exec -T odoo sh -lc "odoo shell -d '${DB_NAME}' -c '${ODOO_CONF}'" <<'PY'
+import json
+
+module = "smart_construction_demo"
+login_to_xmlid = {
+    "demo_role_project_read": "user_demo_project_read",
+    "demo_role_project_user": "user_demo_project_user",
+    "demo_role_project_manager": "user_demo_project_manager",
+    "svc_e2e_smoke": "user_demo_e2e_smoke",
+    "demo_role_owner": "user_demo_role_owner",
+    "demo_role_pm": "user_demo_role_pm",
+    "demo_role_finance": "user_demo_role_finance",
+    "demo_role_executive": "user_demo_role_executive",
+}
+
+Users = env["res.users"].sudo().with_context(active_test=False)
+ModelData = env["ir.model.data"].sudo()
+
+linked = []
+skipped = []
+for login, name in login_to_xmlid.items():
+    user = Users.search([("login", "=", login)], limit=1)
+    if not user:
+        skipped.append({"login": login, "reason": "missing_user"})
+        continue
+
+    existing = ModelData.search([("module", "=", module), ("name", "=", name)], limit=1)
+    if existing:
+        if existing.model == "res.users" and existing.res_id == user.id:
+            skipped.append({"login": login, "xmlid": f"{module}.{name}", "reason": "already_linked"})
+            continue
+        skipped.append(
+            {
+                "login": login,
+                "xmlid": f"{module}.{name}",
+                "reason": "xmlid_points_elsewhere",
+                "model": existing.model,
+                "res_id": existing.res_id,
+            }
+        )
+        continue
+
+    ModelData.create(
+        {
+            "module": module,
+            "name": name,
+            "model": "res.users",
+            "res_id": user.id,
+            "noupdate": True,
+        }
+    )
+    linked.append({"login": login, "id": user.id, "xmlid": f"{module}.{name}"})
+
+env.cr.commit()
+print("[link_existing_demo_user_xmlids] PASS")
+print(json.dumps({"db": env.cr.dbname, "linked": linked, "skipped": skipped}, ensure_ascii=False, indent=2))
+PY


### PR DESCRIPTION
## Summary
- keep local daily development login on sc_demo when localhost serves a production-mode build
- route the legacy menu-only user info and permissions URL to the real user account management action
- make role-surface demo initialization idempotent when demo users already exist, and keep business configuration admin separate from executive role
- clean up frontend action-view gate issues and harden V2 action normalization

## Validation
- pnpm -C frontend gate
- make policy.ensure.role_surface_demo
- make verify.portal.role_surface_preflight.container
- make verify.portal.role_surface_smoke.container
- Browser: http://localhost:18081/login?redirect=/workbench...menu_id=422 with wutao/123456 defaults to sc_demo and lands on /a/704?menu_id=426&action_id=704 with user account/permission maintenance visible and no console/API errors

## Known follow-up
- scene base contract source mix role matrix still has an existing minimum scene-count baseline mismatch for role snapshots; not treated as this user-maintenance delivery blocker.