### PR TITLE
Fix my work return home action target

### DIFF
--- a/addons/smart_core/core/page_contracts_builder.py
+++ b/addons/smart_core/core/page_contracts_builder.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 import re
@@ -121,6 +122,14 @@ def _shared_action_target(action_key: str, page_key: str) -> Dict[str, Any]:
     global _ACTION_TARGET_RESOLVER
     if callable(_ACTION_TARGET_RESOLVER):
         return _ACTION_TARGET_RESOLVER(action_key, page_key)
+    try:
+        module = import_module("odoo.addons.smart_core.core.action_target_schema")
+        resolver = getattr(module, "resolve_action_target", None)
+        if callable(resolver):
+            _ACTION_TARGET_RESOLVER = resolver
+            return resolver(action_key, page_key)
+    except Exception:
+        pass
     helper_path = Path(__file__).with_name("action_target_schema.py")
     try:
         spec = spec_from_file_location("smart_core_action_target_schema_page_contracts", helper_path)
@@ -134,6 +143,13 @@ def _shared_action_target(action_key: str, page_key: str) -> Dict[str, Any]:
             return resolver(action_key, page_key)
     except Exception:
         pass
+    fallback_key = str(action_key or "").strip().lower()
+    if fallback_key in {"open_workbench", "open_landing"}:
+        return {"kind": "scene.key", "scene_key": "workspace.home"}
+    if fallback_key in {"open_my_work", "open_workspace_overview"}:
+        return {"kind": "scene.key", "scene_key": "my_work.workspace"}
+    if fallback_key in {"refresh_page", "refresh"}:
+        return {"kind": "page.refresh"}
     fallback_scene = str(page_key or "").strip().lower() or "workspace.home"
     return {"kind": "scene.key", "scene_key": fallback_scene}
 

--- a/addons/smart_core/core/workspace_home_contract_builder.py
+++ b/addons/smart_core/core/workspace_home_contract_builder.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import Counter
 from datetime import datetime
+from importlib import import_module
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Tuple
@@ -598,6 +599,14 @@ def _shared_action_target(action_key: str, page_key: str) -> Dict[str, Any]:
     global _ACTION_TARGET_RESOLVER
     if callable(_ACTION_TARGET_RESOLVER):
         return _ACTION_TARGET_RESOLVER(action_key, page_key)
+    try:
+        module = import_module("odoo.addons.smart_core.core.action_target_schema")
+        resolver = getattr(module, "resolve_action_target", None)
+        if callable(resolver):
+            _ACTION_TARGET_RESOLVER = resolver
+            return resolver(action_key, page_key)
+    except Exception:
+        pass
     helper_path = Path(__file__).with_name("action_target_schema.py")
     try:
         spec = spec_from_file_location("smart_core_action_target_schema_workspace_home", helper_path)
@@ -611,6 +620,13 @@ def _shared_action_target(action_key: str, page_key: str) -> Dict[str, Any]:
             return resolver(action_key, page_key)
     except Exception:
         pass
+    fallback_key = str(action_key or "").strip().lower()
+    if fallback_key in {"open_workbench", "open_landing"}:
+        return {"kind": "scene.key", "scene_key": "workspace.home"}
+    if fallback_key in {"open_my_work", "open_workspace_overview"}:
+        return {"kind": "scene.key", "scene_key": "my_work.workspace"}
+    if fallback_key in {"refresh_page", "refresh"}:
+        return {"kind": "page.refresh"}
     fallback_scene = str(page_key or "").strip().lower() or "workspace.home"
     return {"kind": "scene.key", "scene_key": fallback_scene}
 

--- a/scripts/verify/user_entry_delivery_browser_acceptance.js
+++ b/scripts/verify/user_entry_delivery_browser_acceptance.js
@@ -53,6 +53,16 @@ const ROLES = [
     targetPath: /^\/(my-work|s\/my_work\.workspace)$/,
   },
   {
+    role: 'pm_my_work_back_home',
+    login: process.env.ROLE_PM_LOGIN || 'demo_role_pm',
+    password: process.env.ROLE_PM_PASSWORD || DEFAULT_PASSWORD,
+    mode: 'my_work_back_home',
+    navigatePath: `/m/${MY_WORK_MENU_ID}`,
+    initialText: [/我的工作/, /待办|风险|已完成|失败/],
+    clickButton: /返回角色首页/,
+    targetPath: /^\/(s\/workspace\.home)?$/,
+  },
+  {
     role: 'finance',
     login: process.env.ROLE_FINANCE_LOGIN || 'demo_role_finance',
     password: process.env.ROLE_FINANCE_PASSWORD || DEFAULT_PASSWORD,
@@ -93,7 +103,7 @@ function writeReports(report) {
 }
 
 function hasBlockingError(text) {
-  return /NAV_MENU_NO_ACTION|当前账号暂无可用功能|当前无可用入口|页面加载失败|页面渲染失败|System exception/.test(String(text || ''));
+  return /NAV_MENU_NO_ACTION|scene not found|当前账号暂无可用功能|当前无可用入口|页面加载失败|页面渲染失败|System exception/i.test(String(text || ''));
 }
 
 function summarizeClickChain(events) {
@@ -170,7 +180,7 @@ function checkProductOrder(text, role) {
 }
 
 function checkMenuMyWorkIntent(row) {
-  if (row.mode !== 'menu_my_work') return true;
+  if (!['menu_my_work', 'my_work_back_home'].includes(row.mode)) return true;
   return row.captured_intents.includes('my.work.summary');
 }
 
@@ -293,7 +303,9 @@ async function runRole(browser, role) {
           ...row.click_chain,
           ...summarizeClickChain(intentEvents.slice(clickStartedAt)),
         };
-        row.click_chain_ok = row.click_chain.telemetry_ok && row.click_chain.business_intent_ok;
+        row.click_chain_ok = role.mode === 'my_work_back_home'
+          ? row.click_chain.telemetry_ok
+          : row.click_chain.telemetry_ok && row.click_chain.business_intent_ok;
         if (!row.click_chain_ok) {
           row.errors.push(`click_chain=${JSON.stringify(row.click_chain)}`);
         }


### PR DESCRIPTION
## Summary
- Load shared action target schema through package import before falling back to file-spec loading.
- Harden fallback targets so open_workbench and open_landing always resolve to workspace.home instead of the current page key.
- Extend browser acceptance to cover My Work -> 返回角色首页 and block scene not found regressions.

## Verification
- python3 -m compileall -q addons/smart_core/core/page_contracts_builder.py addons/smart_core/core/workspace_home_contract_builder.py
- node --check scripts/verify/user_entry_delivery_browser_acceptance.js
- make verify.user.entry.delivery.browser_acceptance
- pnpm -C frontend/apps/web typecheck
- pnpm -C frontend/apps/web build
- make verify.scene.no_action_scene.guard
- make verify.delivery.journey.role_matrix.guard

## Browser evidence
- /s/my_work.workspace?menu_id=941991035 -> click 返回角色首页 -> /s/workspace.home
- page shows role home content
- no scene not found: my_work
- no console errors