### PR TITLE
收敛角色首页用户交付面

### DIFF
--- a/addons/smart_construction_scene/profiles/workspace_home_scene_content.py
+++ b/addons/smart_construction_scene/profiles/workspace_home_scene_content.py
@@ -487,7 +487,7 @@ def build_v1_focus_map() -> Dict[str, List[str]]:
 
 
 def build_v1_zone_order() -> Dict[str, List[str]]:
-    role_home_order = ["today_focus", "analysis", "quick_entries", "hero"]
+    role_home_order = ["today_focus", "analysis", "quick_entries"]
     return {
         "pm": role_home_order,
         "finance": role_home_order,
@@ -534,14 +534,14 @@ def build_v1_page_profile(role_code: str) -> Dict[str, Any]:
     audience = audience_map.get(role, ["owner"])
     priority_model = "task_first" if role == "pm" else "metric_first" if role == "finance" else "role_first"
     mobile_priority_map = {
-        "pm": ["today_focus", "analysis", "quick_entries", "hero"],
-        "finance": ["today_focus", "analysis", "quick_entries", "hero"],
-        "owner": ["today_focus", "analysis", "quick_entries", "hero"],
+        "pm": ["today_focus", "analysis", "quick_entries"],
+        "finance": ["today_focus", "analysis", "quick_entries"],
+        "owner": ["today_focus", "analysis", "quick_entries"],
     }
     return {
         "audience": audience,
         "priority_model": priority_model,
-        "mobile_priority": mobile_priority_map.get(role, ["today_focus", "analysis", "quick_entries", "hero"]),
+        "mobile_priority": mobile_priority_map.get(role, ["today_focus", "analysis", "quick_entries"]),
     }
 
 
@@ -834,23 +834,6 @@ def build_v1_zones(role_code: str, audience: List[str], zone_rank: Dict[str, int
                     "actions": [],
                     "payload": {"show_percentage": True},
                 },
-                {
-                    "key": "activity_feed_risk",
-                    "block_type": "activity_feed",
-                    "title": "风险动态",
-                    "priority": 60,
-                    "importance": "medium",
-                    "tone": "info",
-                    "progress": "running",
-                    "section_key": "risk",
-                    "data_source": "ds_risk_alerts",
-                    "loading_strategy": "lazy",
-                    "refreshable": True,
-                    "collapsible": False,
-                    "visibility": {"roles": audience, "capabilities": [], "expr": None},
-                    "actions": [],
-                    "payload": {"stream": "risk.actions"},
-                },
             ],
         },
         {
@@ -884,11 +867,13 @@ def build_v1_zones(role_code: str, audience: List[str], zone_rank: Dict[str, int
     ]
 
     role_zone_order: Dict[str, List[str]] = {
-        "pm": ["today_focus", "analysis", "quick_entries", "hero"],
-        "finance": ["today_focus", "analysis", "quick_entries", "hero"],
-        "owner": ["today_focus", "analysis", "quick_entries", "hero"],
+        "pm": ["today_focus", "analysis", "quick_entries"],
+        "finance": ["today_focus", "analysis", "quick_entries"],
+        "owner": ["today_focus", "analysis", "quick_entries"],
     }
     preferred_order = role_zone_order.get(_to_text(role_code), role_zone_order["owner"])
+    allowed_zone_keys = set(preferred_order)
+    zones = [zone for zone in zones if _to_text(zone.get("key")) in allowed_zone_keys]
     max_priority = 100
     priority_step = 10
     priority_map = {key: max_priority - (idx * priority_step) for idx, key in enumerate(preferred_order)}

--- a/addons/smart_core/core/workspace_home_contract_builder.py
+++ b/addons/smart_core/core/workspace_home_contract_builder.py
@@ -1015,9 +1015,9 @@ def _workspace_v1_zone_order(role_code: str) -> List[str]:
                 pass
 
     default_order = {
-        "pm": ["today_focus", "analysis", "quick_entries", "hero"],
-        "finance": ["today_focus", "analysis", "quick_entries", "hero"],
-        "owner": ["today_focus", "analysis", "quick_entries", "hero"],
+        "pm": ["today_focus", "analysis", "quick_entries"],
+        "finance": ["today_focus", "analysis", "quick_entries"],
+        "owner": ["today_focus", "analysis", "quick_entries"],
     }
     return list(default_order.get(_to_text(role_code).lower(), default_order["owner"]))
 
@@ -2047,7 +2047,7 @@ def _v1_page_profile(role_code: str) -> Dict[str, Any]:
     }
     audience = audience_map.get(role_code, ["owner"])
     priority_model = "task_first" if role_code == "pm" else "metric_first" if role_code == "finance" else "role_first"
-    return {"audience": audience, "priority_model": priority_model, "mobile_priority": ["hero", "today_focus", "analysis"]}
+    return {"audience": audience, "priority_model": priority_model, "mobile_priority": ["today_focus", "analysis", "quick_entries"]}
 
 
 def _v1_data_sources() -> Dict[str, Dict[str, Any]]:
@@ -2340,7 +2340,7 @@ def _build_page_orchestration_v1(role_code: str, role_source_code: str | None = 
             "page.action.refresh": "刷新",
         }
     )
-    mobile_priority = profile.get("mobile_priority") if isinstance(profile.get("mobile_priority"), list) and profile.get("mobile_priority") else ["hero", "today_focus", "analysis"]
+    mobile_priority = profile.get("mobile_priority") if isinstance(profile.get("mobile_priority"), list) and profile.get("mobile_priority") else ["today_focus", "analysis", "quick_entries"]
 
     zones: List[Dict[str, Any]] = []
     provider = _load_data_provider()
@@ -2486,23 +2486,6 @@ def _build_page_orchestration_v1(role_code: str, role_source_code: str | None = 
                     "actions": [],
                     "payload": {"show_percentage": True},
                 },
-                {
-                    "key": "activity_feed_risk",
-                    "block_type": "activity_feed",
-                    "title": v1_copy.get("block.activity_feed_risk.title") or "风险动态",
-                    "priority": 60,
-                    "importance": "medium",
-                    "tone": "info",
-                    "progress": "running",
-                    "section_key": "risk",
-                    "data_source": "ds_risk_alerts",
-                    "loading_strategy": "lazy",
-                    "refreshable": True,
-                    "collapsible": False,
-                    "visibility": {"roles": audience, "capabilities": [], "expr": None},
-                    "actions": [],
-                    "payload": {"stream": "risk.actions"},
-                },
             ],
         },
         {
@@ -2546,6 +2529,8 @@ def _build_page_orchestration_v1(role_code: str, role_source_code: str | None = 
             break
     preferred_order = _workspace_v1_zone_order(role_code)
     effective_order = preferred_order
+    allowed_zone_keys = set(effective_order)
+    zones = [zone for zone in zones if _to_text(zone.get("key")) in allowed_zone_keys]
     priority_map = {key: 100 - (idx * 10) for idx, key in enumerate(effective_order)}
     for zone in zones:
         zone_key = _to_text(zone.get("key"))


### PR DESCRIPTION
## Summary
- remove the self-referential workspace hero zone from role-home orchestration
- remove duplicated risk activity feed from the analysis zone
- keep the role-home page focused on today focus, status analysis, and usable business entries

## Verification
- python3 -m compileall -q addons/smart_construction_scene/profiles/workspace_home_scene_content.py addons/smart_core/core/workspace_home_contract_builder.py
- browser check: /s/workspace.home as demo_role_pm shows no welcome/role-position/default-entry/risk-dynamic text, while today focus, high-priority risk, and usable business entries remain visible
- make verify.user.entry.delivery.browser_acceptance
- make verify.scene.no_action_scene.guard
- make verify.delivery.journey.role_matrix.guard
- pnpm -C frontend/apps/web typecheck
- pnpm -C frontend/apps/web build