### PR TITLE
fix: preserve selection fields in v2 project forms

### DIFF
--- a/addons/smart_core/core/unified_page_contract_v2_assembler.py
+++ b/addons/smart_core/core/unified_page_contract_v2_assembler.py
@@ -838,6 +838,19 @@ def _native_field_node(node: dict[str, Any], field: dict[str, Any], *, layout_ty
     return out
 
 
+def _field_source_with_node_info(node: dict[str, Any], field: dict[str, Any], *, fallback_name: str = "") -> dict[str, Any]:
+    field_name = _stable_id(node.get("name") or node.get("field") or field.get("name") or fallback_name, "field")
+    field_source = deepcopy(field) if isinstance(field, dict) else {}
+    field_info = _dict(node.get("fieldInfo") or node.get("field_info"))
+    field_source.update({k: deepcopy(v) for k, v in field_info.items() if k not in {"label", "string"}})
+    field_source["name"] = field_name
+    field_source.setdefault("string", _text(node.get("string") or node.get("label") or field_info.get("label"), field_name))
+    field_source.setdefault("label", field_source.get("string", field_name))
+    if _text(node.get("widget")):
+        field_source["widget"] = _text(node.get("widget"))
+    return field_source
+
+
 def _direct_field_widgets_from_nodes(
     nodes: list[dict[str, Any]],
     fields_by_name: dict[str, dict[str, Any]],
@@ -854,12 +867,7 @@ def _direct_field_widgets_from_nodes(
         field = _dict(fields_by_name.get(field_name))
         if not field:
             field = {"name": field_name, "string": _text(node.get("string") or node.get("label"), field_name)}
-        field_source = deepcopy(field)
-        field_source["name"] = field_name
-        field_source.setdefault("string", _text(node.get("string") or node.get("label"), field_name))
-        field_source.setdefault("label", field_source.get("string", field_name))
-        if _text(node.get("widget")):
-            field_source["widget"] = _text(node.get("widget"))
+        field_source = _field_source_with_node_info(node, field, fallback_name=field_name)
         widgets.append(_field_widget(field_source, layout_type=layout_type))
     return widgets
 
@@ -898,9 +906,10 @@ def _normalize_native_layout_nodes(
                     field_info["subview"] = deepcopy(subview)
                     normalized["fieldInfo"] = field_info
                     normalized["field_info"] = deepcopy(field_info)
-            widget = _field_widget({**field, "name": node_name or field.get("name"), "string": normalized.get("string"), "label": normalized.get("label"), "widget": normalized.get("widget")}, layout_type=layout_type)
+            widget_source = _field_source_with_node_info(normalized, field, fallback_name=node_name or _text(field.get("name")))
+            widget = _field_widget(widget_source, layout_type=layout_type)
             component_keys.add(widget["componentKey"])
-            widget_status.append(_field_status({**field, "name": node_name or field.get("name"), "string": normalized.get("string"), "label": normalized.get("label"), "widget": normalized.get("widget")}, widget["widgetId"]))
+            widget_status.append(_field_status(widget_source, widget["widgetId"]))
             out.append(normalized)
             continue
         container_id = _text(node.get("containerId") or node.get("container_id") or node_name)

--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import Any, Dict, Optional
 
 from ..core.base_handler import BaseIntentHandler
@@ -97,6 +98,13 @@ class UiContractV2Handler(BaseIntentHandler):
         if isinstance(nested_ui_contract, dict):
             source_contract.update(nested_ui_contract)
         nested_data = ui_data.get("data") if isinstance(ui_data.get("data"), dict) else {}
+        source_record = (
+            ui_data.get("record")
+            if isinstance(ui_data.get("record"), dict)
+            else nested_data.get("record")
+            if isinstance(nested_data.get("record"), dict)
+            else {}
+        )
         source_contract.update({
             "model": model,
             "view_type": view_type,
@@ -111,15 +119,18 @@ class UiContractV2Handler(BaseIntentHandler):
                 or params.get("context")
                 or {}
             ),
-            "record": (
-                ui_data.get("record")
-                if isinstance(ui_data.get("record"), dict)
-                else nested_data.get("record")
-                if isinstance(nested_data.get("record"), dict)
-                else {}
-            ),
+            "record": source_record,
             "source_meta": ui_meta,
         })
+        hydrated_record = self._hydrate_record_snapshot(
+            model=str(model or "").strip(),
+            record_id=params.get("record_id") or params.get("recordId") or ui_params.get("record_id") or ui_params.get("recordId"),
+            source_contract=source_contract,
+            current_record=source_record,
+            view_type=str(view_type or "").strip().lower(),
+        )
+        if hydrated_record:
+            source_contract["record"] = hydrated_record
         contract_v2 = assemble_unified_page_contract_v2(
             source_contract,
             source_type="ui.contract",
@@ -151,6 +162,51 @@ class UiContractV2Handler(BaseIntentHandler):
                 "source_authority": self.source_authority_contract(),
             },
         )
+
+    def _hydrate_record_snapshot(
+        self,
+        *,
+        model: str,
+        record_id: Any,
+        source_contract: dict[str, Any],
+        current_record: dict[str, Any],
+        view_type: str,
+    ) -> dict[str, Any]:
+        if view_type != "form" or not model:
+            return dict(current_record or {}) if isinstance(current_record, dict) else {}
+        record_id_int, _record_id_error = parse_positive_int(record_id, allow_empty=True)
+        record_id_int = int(record_id_int or 0)
+        if record_id_int <= 0:
+            return dict(current_record or {}) if isinstance(current_record, dict) else {}
+        field_map = source_contract.get("fields") if isinstance(source_contract.get("fields"), dict) else {}
+        field_names = [str(name).strip() for name in field_map.keys() if str(name).strip()]
+        if "id" not in field_names:
+            field_names.insert(0, "id")
+        if not field_names:
+            return dict(current_record or {}) if isinstance(current_record, dict) else {}
+        merged = deepcopy(current_record) if isinstance(current_record, dict) else {}
+        try:
+            record = self.env[model].browse(record_id_int).exists()
+            if not record:
+                return merged
+            rows = record.read(field_names)
+            if rows and isinstance(rows[0], dict):
+                merged.update(rows[0])
+        except Exception:
+            _logger.debug("ui.contract.v2 bulk record hydration skipped; falling back to per-field read", exc_info=True)
+            try:
+                record = self.env[model].browse(record_id_int).exists()
+            except Exception:
+                record = None
+            if record:
+                for name in field_names:
+                    try:
+                        rows = record.read([name])
+                        if rows and isinstance(rows[0], dict) and name in rows[0]:
+                            merged[name] = rows[0].get(name)
+                    except Exception:
+                        _logger.debug("ui.contract.v2 field hydration skipped: %s.%s", model, name, exc_info=True)
+        return merged
 
     def _handle_scene_contract(self, params: dict[str, Any], *, client_type: str, delivery_profile: str):
         scene_key = str(params.get("scene_key") or params.get("sceneKey") or "").strip()

--- a/frontend/apps/web/src/app/contracts/unifiedPageContractV2.ts
+++ b/frontend/apps/web/src/app/contracts/unifiedPageContractV2.ts
@@ -160,11 +160,30 @@ function synthesizeUnifiedPageContractV2Widget(row: Dict): UnifiedPageContractV2
       ...(componentConfig || {}),
       ...(asText(fieldInfo.type || fieldInfo.ttype) ? { fieldType: asText(fieldInfo.type || fieldInfo.ttype) } : {}),
       ...(asText(fieldInfo.relation) ? { relation: asText(fieldInfo.relation) } : {}),
+      ...(Array.isArray(fieldInfo.selection) ? { selection: fieldInfo.selection } : {}),
       ...(Object.keys(relationEntry).length ? { relationEntry } : {}),
-      ...(asDict(fieldInfo.widget_options).color_field ? { widgetOptions: asDict(fieldInfo.widget_options) } : {}),
+      ...(Object.keys(asDict(fieldInfo.widget_options)).length ? { widgetOptions: asDict(fieldInfo.widget_options) } : {}),
     },
     fieldType: asText(fieldInfo.type || fieldInfo.ttype) || undefined,
     relation: asText(fieldInfo.relation) || undefined,
+  };
+}
+
+function mergeUnifiedPageContractV2Widget(existing: UnifiedPageContractV2Widget, candidate: UnifiedPageContractV2Widget): UnifiedPageContractV2Widget {
+  const existingConfig = asDict(existing.componentConfig);
+  const candidateConfig = asDict(candidate.componentConfig);
+  return {
+    ...existing,
+    widgetType: existing.widgetType || candidate.widgetType,
+    fieldCode: existing.fieldCode || candidate.fieldCode,
+    label: existing.label || candidate.label,
+    componentKey: existing.componentKey || candidate.componentKey,
+    componentConfig: {
+      ...existingConfig,
+      ...candidateConfig,
+    },
+    fieldType: existing.fieldType || candidate.fieldType,
+    relation: existing.relation || candidate.relation,
   };
 }
 
@@ -196,19 +215,29 @@ export function collectUnifiedPageContractV2Widgets(contract: unknown): UnifiedP
   const v2 = resolveUnifiedPageContractV2(contract);
   if (!v2) return [];
   const out: UnifiedPageContractV2Widget[] = [];
-  const seen = new Set<string>();
+  const byWidgetId = new Map<string, number>();
   walkUnifiedPageContractV2LayoutNodes(v2.layoutContract.containerTree, (row) => {
     asList(row.widgetList).forEach((widgetRaw) => {
       const widget = asDict(widgetRaw);
       const synthesized = synthesizeUnifiedPageContractV2Widget(widget);
-      if (!synthesized || seen.has(synthesized.widgetId)) return;
-      seen.add(synthesized.widgetId);
+      if (!synthesized) return;
+      const existingIndex = byWidgetId.get(synthesized.widgetId);
+      if (typeof existingIndex === 'number') {
+        out[existingIndex] = mergeUnifiedPageContractV2Widget(out[existingIndex], synthesized);
+        return;
+      }
+      byWidgetId.set(synthesized.widgetId, out.length);
       out.push(synthesized);
     });
     if (asText(row.type || row.kind).toLowerCase() !== 'field') return;
     const synthesized = synthesizeUnifiedPageContractV2Widget(row);
-    if (!synthesized || seen.has(synthesized.widgetId)) return;
-    seen.add(synthesized.widgetId);
+    if (!synthesized) return;
+    const existingIndex = byWidgetId.get(synthesized.widgetId);
+    if (typeof existingIndex === 'number') {
+      out[existingIndex] = mergeUnifiedPageContractV2Widget(out[existingIndex], synthesized);
+      return;
+    }
+    byWidgetId.set(synthesized.widgetId, out.length);
     out.push(synthesized);
   });
   return out;


### PR DESCRIPTION
## Summary
- hydrate V2 form record snapshots from backend read data so selection fields keep current values
- preserve native field metadata when assembling V2 layout widgets
- merge duplicate frontend V2 widgets so richer native field facts are not dropped

## Verification
- python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/core/unified_page_contract_v2_assembler.py
- pnpm -C frontend/apps/web typecheck
- pnpm -C frontend/apps/web build
- bash scripts/dev/frontend_static_build.sh
- browser verified wutao can switch project operation strategy from direct to joint and reload keeps joint with project category synced