### PR TITLE
Fix api data context preservation

### DIFF
--- a/addons/smart_core/handlers/api_data.py
+++ b/addons/smart_core/handlers/api_data.py
@@ -133,6 +133,26 @@ class ApiDataHandler(BaseIntentHandler):
                         merged[k] = v
         return merged
 
+    def _request_context(self, p: Dict[str, Any]) -> Dict[str, Any]:
+        """Merge client context over the authenticated Odoo context.
+
+        ``with_context(dict)`` replaces the existing context in Odoo.  Keeping
+        the server context preserves lang/tz/company defaults for translated
+        fields while still allowing request-level overrides.
+        """
+        context = dict(getattr(self.env, "context", {}) or {})
+        payload_context = self._dig(p, "context") or {}
+        if not isinstance(payload_context, dict):
+            payload_context = {}
+        envelope_context = p.get("context") if isinstance(p.get("context"), dict) else {}
+        if envelope_context:
+            context.update(envelope_context)
+        if payload_context:
+            context.update(payload_context)
+        if "active_test" not in context:
+            context["active_test"] = self._get_bool(p, "active_test", True)
+        return context
+
     def _dig(self, p: Dict[str, Any], key: str, default=None):
         if not isinstance(p, dict):
             return default
@@ -1121,14 +1141,7 @@ class ApiDataHandler(BaseIntentHandler):
         if model not in self.env:
             return self._err(404, f"未知模型: {model}")
 
-        context = self._dig(p, "context") or {}
-        if not isinstance(context, dict):
-            context = {}
-        envelope_context = p.get("context") if isinstance(p.get("context"), dict) else {}
-        if envelope_context:
-            context = {**envelope_context, **context}
-        if "active_test" not in context:
-            context["active_test"] = self._get_bool(p, "active_test", True)
+        context = self._request_context(p)
         if_none_match = self._read_if_none_match(p)
 
         use_sudo = resolve_api_data_sudo(p)

--- a/addons/smart_core/tests/test_api_data_list_param_boundaries.py
+++ b/addons/smart_core/tests/test_api_data_list_param_boundaries.py
@@ -207,6 +207,28 @@ class TestApiDataListParamBoundaries(unittest.TestCase):
             {"search_default_project_id": 99},
         )
 
+    def test_request_context_preserves_env_lang_when_client_context_is_sparse(self):
+        module = _load_handler()
+        env = types.SimpleNamespace(uid=7, context={"lang": "zh_CN", "tz": "Asia/Shanghai"}, user=None)
+        handler = module.ApiDataHandler(env=env)
+
+        context = handler._request_context({"context": {"active_test": True}})
+
+        self.assertEqual(context["lang"], "zh_CN")
+        self.assertEqual(context["tz"], "Asia/Shanghai")
+        self.assertIs(context["active_test"], True)
+
+    def test_request_context_allows_explicit_client_lang_override(self):
+        module = _load_handler()
+        env = types.SimpleNamespace(uid=7, context={"lang": "zh_CN", "tz": "Asia/Shanghai"}, user=None)
+        handler = module.ApiDataHandler(env=env)
+
+        context = handler._request_context({"context": {"lang": "en_US", "active_test": False}})
+
+        self.assertEqual(context["lang"], "en_US")
+        self.assertEqual(context["tz"], "Asia/Shanghai")
+        self.assertIs(context["active_test"], False)
+
     def test_list_rejects_invalid_fields_domain_and_group_by(self):
         cases = [
             ({"fields": 7}, "fields 无效"),


### PR DESCRIPTION
## Summary

- Preserve authenticated Odoo request context when api.data receives sparse client context.
- Keep request-level context overrides explicit while retaining server defaults such as `lang` and `tz`.
- Add direct regression coverage for sparse context and explicit language override behavior.

## Architecture Impact

- No cross-layer behavior change.
- The change stays inside the platform API data handler and preserves existing client override semantics.

## Layer Target

- Platform API handler layer.

## Affected Modules

- `addons/smart_core/handlers/api_data.py`
- `addons/smart_core/tests/test_api_data_list_param_boundaries.py`

## Verification

- `python3 -B addons/smart_core/tests/test_api_data_list_param_boundaries.py`
- `git diff --check -- addons/smart_core/handlers/api_data.py addons/smart_core/tests/test_api_data_list_param_boundaries.py`
