### PR TITLE
修复模型配置并发创建竞态

### DIFF
--- a/addons/smart_core/app_config_engine/models/app_model_config.py
+++ b/addons/smart_core/app_config_engine/models/app_model_config.py
@@ -11,6 +11,7 @@ App Model Config
 
 from odoo import models, fields, api, _
 import json, hashlib, logging
+from psycopg2 import IntegrityError
 
 _logger = logging.getLogger(__name__)
 
@@ -119,8 +120,20 @@ class AppModelConfig(models.Model):
                 _logger.info('Model config unchanged for %s, keep version %s', model_name, cfg.version)
         else:
             vals['version'] = 1
-            cfg = self.sudo().create(vals)
-            _logger.info('Model config created for %s → version 1', model_name)
+            try:
+                with self.env.cr.savepoint():
+                    cfg = self.sudo().create(vals)
+                _logger.info('Model config created for %s → version 1', model_name)
+            except IntegrityError:
+                cfg = self.sudo().search([('model', '=', model_name)], limit=1)
+                if not cfg:
+                    raise
+                if (cfg.config_hash or '') != new_hash:
+                    vals['version'] = (cfg.version or 0) + 1
+                    cfg.write(vals)
+                    _logger.info('Model config recovered and updated for %s → version %s', model_name, cfg.version)
+                else:
+                    _logger.info('Model config recovered unchanged for %s, keep version %s', model_name, cfg.version)
 
         return cfg
 


### PR DESCRIPTION
## Summary
- handle app.model.config unique(model) create races with a savepoint and IntegrityError recovery path
- keep the existing advisory lock as the primary serialization path, with database uniqueness as a safe fallback

## Review
- latest remote branch inspected: origin/codex/fix-receipt-invoice-model-config-race
- scope is one backend file: addons/smart_core/app_config_engine/models/app_model_config.py
- this should enter main because the server issue is a production-style request race and the fix is defensive and localized

## Verification
- python3 -m py_compile addons/smart_core/app_config_engine/models/app_model_config.py
- git diff --check origin/main...HEAD
- Odoo shell sc_demo app model config probe: PASS for sc.receipt.invoice.line and sc.invoice.registration, repeated generation kept the same config records
