### PR TITLE
fix(migration): include tender payloads in release package scope

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -880,7 +880,8 @@ migration.assets.release_package.verify: guard.prod.forbid
 	  rm -rf /tmp/sce_migration_asset_release_verify; \
 	  mkdir -p /tmp/sce_migration_asset_release_verify; \
 	  tar -xzf "$$package_path" -C /tmp/sce_migration_asset_release_verify; \
-	  cd /tmp/sce_migration_asset_release_verify && python3 scripts/migration/migration_asset_bus.py --asset-root migration_assets --catalog migration_assets/manifest/migration_asset_catalog_v1.json --verify-only --check
+	  cd /tmp/sce_migration_asset_release_verify && python3 scripts/migration/migration_asset_bus.py --asset-root migration_assets --catalog migration_assets/manifest/migration_asset_catalog_v1.json --verify-only --check; \
+	  cd /tmp/sce_migration_asset_release_verify && python3 scripts/migration/migration_asset_delivery_audit.py --asset-root migration_assets
 
 history.contract.core.gap.audit: guard.prod.forbid check-compose-project check-compose-env
 	@python3 scripts/migration/history_contract_core_gap_audit.py

--- a/docs/migration_alignment/migration_asset_delivery_audit_v1.md
+++ b/docs/migration_alignment/migration_asset_delivery_audit_v1.md
@@ -13,10 +13,12 @@ connect to Odoo, execute replay writes, or mutate migration assets.
 - asset files: `95`
 - referenced files: `93`
 - unreferenced files: `2`
-- total asset size MB: `347.26`
-- replay steps: `168`
-- required replay artifacts: `96`
+- total asset size MB: `347.97`
+- replay steps: `197`
+- required replay artifacts: `104`
 - missing required replay artifacts: `0`
+- mandatory business scopes: `1`
+- missing business-scope artifacts: `0`
 - duplicate materialized parts: `0`
 
 ## Decision

--- a/docs/migration_alignment/migration_asset_release_package_v1.md
+++ b/docs/migration_alignment/migration_asset_release_package_v1.md
@@ -2,12 +2,12 @@
 
 Status: `PASS`
 
-- package_id: `migration_assets_release_20260511T005829Z`
-- package_path: `/tmp/sce_migration_asset_release/migration_assets_release_20260511T005829Z.tar.gz`
-- sha256_path: `/tmp/sce_migration_asset_release/migration_assets_release_20260511T005829Z.tar.gz.sha256`
-- sha256: `0fe2b36c629c0660ac0f719a7f9d719efeaf53bd9701c49a203ea2146e9578a3`
-- package_size_mb: `327.52`
-- included_file_count: `2452`
+- package_id: `migration_assets_release_20260513T030706Z`
+- package_path: `/tmp/sce_migration_asset_release/migration_assets_release_20260513T030706Z.tar.gz`
+- sha256_path: `/tmp/sce_migration_asset_release/migration_assets_release_20260513T030706Z.tar.gz.sha256`
+- sha256: `833d4ba0cf9352e67618d3ff06ad6099d4241ed9bfe42c2bf352eae5f14b2789`
+- package_size_mb: `329.57`
+- included_file_count: `2560`
 - excluded_file_count: `0`
 - payload_mode: `packaged_artifacts`
 - deployment_entrypoint: `scripts/migration/history_continuity_oneclick.sh`
@@ -23,4 +23,5 @@ Status: `PASS`
 - Replay entrypoint, migration Python scripts, and migration shell scripts are packaged with the assets.
 - Verify the package with `MIGRATION_ASSET_RELEASE_PACKAGE=<package_path> make migration.assets.release_package.verify`.
 - Verify after extraction with `python3 scripts/migration/migration_asset_bus.py --asset-root migration_assets --catalog migration_assets/manifest/migration_asset_catalog_v1.json --verify-only --check`.
+- Verify packaged replay scope with `python3 scripts/migration/migration_asset_delivery_audit.py --asset-root migration_assets`.
 - Rehearse against a fresh target DB with `HISTORY_CONTINUITY_MODE=rehearse HISTORY_CONTINUITY_USE_PACKAGED_PAYLOADS=1 DB_NAME=<target_db> MIGRATION_REPLAY_DB_ALLOWLIST=<target_db> bash scripts/migration/history_continuity_oneclick.sh`.

--- a/scripts/migration/migration_asset_delivery_audit.py
+++ b/scripts/migration/migration_asset_delivery_audit.py
@@ -31,6 +31,20 @@ ONECLICK_SCRIPT_RE = re.compile(r'run_odoo_script\s+"\$ROOT_DIR/scripts/migratio
 EXTRA_REPLAY_SCRIPT_NAMES = [
     "fresh_db_replay_payload_precheck.py",
 ]
+MANDATORY_BUSINESS_SCOPE_ARTIFACTS = {
+    # Tender history is now part of the user-visible delivery scope.  The XML
+    # asset catalog only covers declared asset packages, so keep this replay
+    # payload as an explicit delivery-scope requirement for packaged replay.
+    "tender_history": {
+        "source_tables": ["dbo.P_ZTB_GCBMGL"],
+        "source_model": "sc.legacy.tender.registration.fact",
+        "projection_targets": ["tender.bid", "tender.doc.purchase", "tender.guarantee", "tender.opening"],
+        "artifacts": [
+            "artifacts/migration/fresh_db_legacy_tender_registration_replay_adapter_result_v1.json",
+            "artifacts/migration/fresh_db_legacy_tender_registration_replay_payload_v1.csv",
+        ],
+    },
+}
 BASELINE_EXCLUDED_REQUIRED_ARTIFACTS = {
     # Default-off privacy lanes. These are intentionally not shipped in the
     # baseline package because they may contain sensitive personal data.
@@ -219,7 +233,35 @@ def required_replay_artifacts() -> list[str]:
             if path in BASELINE_EXCLUDED_REQUIRED_ARTIFACTS:
                 continue
             required.add(path)
+    for scope in MANDATORY_BUSINESS_SCOPE_ARTIFACTS.values():
+        required.update(scope["artifacts"])
     return sorted(required)
+
+
+def business_scope_audit() -> dict[str, Any]:
+    scopes: list[dict[str, Any]] = []
+    missing: list[dict[str, str]] = []
+    for scope_id, scope in MANDATORY_BUSINESS_SCOPE_ARTIFACTS.items():
+        artifact_rows = []
+        for artifact in scope["artifacts"]:
+            exists = (REPO_ROOT / artifact).is_file()
+            artifact_rows.append({"path": artifact, "exists": exists})
+            if not exists:
+                missing.append({"scope": scope_id, "path": artifact})
+        scopes.append(
+            {
+                "scope": scope_id,
+                "source_tables": scope["source_tables"],
+                "source_model": scope["source_model"],
+                "projection_targets": scope["projection_targets"],
+                "artifacts": artifact_rows,
+            }
+        )
+    return {
+        "mandatory_scope_count": len(scopes),
+        "scopes": scopes,
+        "missing_scope_artifacts": missing,
+    }
 
 
 def replay_audit() -> dict[str, Any]:
@@ -271,6 +313,7 @@ def decide(payload: dict[str, Any]) -> tuple[str, list[str], list[str]]:
     catalog = payload["catalog"]
     packaging = payload["packaging"]
     replay = payload["replay"]
+    business_scope = payload["business_scope"]
 
     if catalog["missing_files"]:
         blockers.append("catalog references missing files")
@@ -288,6 +331,8 @@ def decide(payload: dict[str, Any]) -> tuple[str, list[str], list[str]]:
         blockers.append("required Makefile replay targets are missing")
     if replay["missing_required_replay_artifacts"]:
         blockers.append("packaged replay frozen artifacts are missing")
+    if business_scope["missing_scope_artifacts"]:
+        blockers.append("mandatory business-scope replay artifacts are missing")
 
     if packaging["duplicate_materialized_parts"]:
         actions.append("remove duplicated materialized XML or parts from the final release package after choosing one canonical form")
@@ -307,6 +352,7 @@ def write_outputs(payload: dict[str, Any]) -> None:
     catalog = payload["catalog"]
     packaging = payload["packaging"]
     replay = payload["replay"]
+    business_scope = payload["business_scope"]
     lines = [
         "# Migration Asset Delivery Audit v1",
         "",
@@ -327,6 +373,8 @@ def write_outputs(payload: dict[str, Any]) -> None:
         f"- replay steps: `{replay['step_count']}`",
         f"- required replay artifacts: `{replay['required_replay_artifact_count']}`",
         f"- missing required replay artifacts: `{len(replay['missing_required_replay_artifacts'])}`",
+        f"- mandatory business scopes: `{business_scope['mandatory_scope_count']}`",
+        f"- missing business-scope artifacts: `{len(business_scope['missing_scope_artifacts'])}`",
         f"- duplicate materialized parts: `{len(packaging['duplicate_materialized_parts'])}`",
         "",
         "## Decision",
@@ -342,6 +390,9 @@ def write_outputs(payload: dict[str, Any]) -> None:
         lines.extend(f"- `{item}`" for item in replay["missing_required_replay_artifacts"][:80])
         if len(replay["missing_required_replay_artifacts"]) > 80:
             lines.append(f"- ... +{len(replay['missing_required_replay_artifacts']) - 80} more")
+    if business_scope["missing_scope_artifacts"]:
+        lines.extend(["", "### Missing Business-Scope Artifacts", ""])
+        lines.extend(f"- `{item['scope']}`: `{item['path']}`" for item in business_scope["missing_scope_artifacts"])
     if payload["packaging_actions"]:
         lines.extend(["", "### Packaging Actions", ""])
         lines.extend(f"- {item}" for item in payload["packaging_actions"])
@@ -394,6 +445,7 @@ def main() -> int:
         "catalog": catalog_audit(asset_root),
         "packaging": packaging_audit(asset_root),
         "replay": replay_audit(),
+        "business_scope": business_scope_audit(),
     }
     status, blockers, actions = decide(payload)
     payload["status"] = status
@@ -412,6 +464,7 @@ def main() -> int:
                 "replay_steps": payload["replay"]["step_count"],
                 "required_replay_artifacts": payload["replay"]["required_replay_artifact_count"],
                 "missing_required_replay_artifacts": len(payload["replay"]["missing_required_replay_artifacts"]),
+                "missing_business_scope_artifacts": len(payload["business_scope"]["missing_scope_artifacts"]),
                 "blockers": len(blockers),
                 "db_writes": 0,
             },

--- a/scripts/migration/migration_asset_release_package.py
+++ b/scripts/migration/migration_asset_release_package.py
@@ -36,6 +36,7 @@ DEPLOYMENT_FILES = [
     "Makefile",
     "scripts/common/env.sh",
     "scripts/common/guard_prod.sh",
+    "scripts/deploy/fresh_production_history_init.sh",
     "scripts/ops/odoo_shell_exec.sh",
     "scripts/migration/history_continuity_oneclick.sh",
     "scripts/migration/migration_asset_bus.py",
@@ -50,6 +51,15 @@ ONECLICK_SCRIPT_RE = re.compile(r'run_odoo_script\s+"\$ROOT_DIR/scripts/migratio
 EXTRA_REPLAY_SCRIPT_NAMES = [
     "fresh_db_replay_payload_precheck.py",
 ]
+MANDATORY_BUSINESS_SCOPE_ARTIFACTS = {
+    # Tender history is part of the user-visible delivery scope.  These replay
+    # payloads are not XML catalog packages, so the release package must carry
+    # them explicitly for old-DB-free replay.
+    "tender_history": [
+        "artifacts/migration/fresh_db_legacy_tender_registration_replay_adapter_result_v1.json",
+        "artifacts/migration/fresh_db_legacy_tender_registration_replay_payload_v1.csv",
+    ],
+}
 BASELINE_EXCLUDED_REQUIRED_ARTIFACTS = {
     # Default-off privacy lanes. These are intentionally not shipped in the
     # baseline package because they may contain sensitive personal data.
@@ -129,6 +139,8 @@ def required_replay_artifacts() -> list[str]:
             if path in BASELINE_EXCLUDED_REQUIRED_ARTIFACTS:
                 continue
             required.add(path)
+    for artifacts in MANDATORY_BUSINESS_SCOPE_ARTIFACTS.values():
+        required.update(artifacts)
     return sorted(required)
 
 
@@ -246,9 +258,11 @@ def build_package(asset_root: Path, out_dir: Path, package_id: str) -> dict[str,
         "deployment_entrypoint": "scripts/migration/history_continuity_oneclick.sh",
         "deployment_verification_commands": [
             "python3 scripts/migration/migration_asset_bus.py --asset-root migration_assets --catalog migration_assets/manifest/migration_asset_catalog_v1.json --verify-only --check",
+            "python3 scripts/migration/migration_asset_delivery_audit.py --asset-root migration_assets",
             "HISTORY_CONTINUITY_MODE=rehearse HISTORY_CONTINUITY_USE_PACKAGED_PAYLOADS=1 DB_NAME=<target_db> MIGRATION_REPLAY_DB_ALLOWLIST=<target_db> bash scripts/migration/history_continuity_oneclick.sh",
             "HISTORY_CONTINUITY_MODE=replay HISTORY_CONTINUITY_USE_PACKAGED_PAYLOADS=1 DB_NAME=<target_db> MIGRATION_REPLAY_DB_ALLOWLIST=<target_db> bash scripts/migration/history_continuity_oneclick.sh",
         ],
+        "mandatory_business_scope_artifacts": MANDATORY_BUSINESS_SCOPE_ARTIFACTS,
         "file_count": len(files),
         "excluded_paths": excluded_paths,
         "files": files,
@@ -315,6 +329,7 @@ def build_package(asset_root: Path, out_dir: Path, package_id: str) -> dict[str,
             "- Replay entrypoint, migration Python scripts, and migration shell scripts are packaged with the assets.",
             "- Verify the package with `MIGRATION_ASSET_RELEASE_PACKAGE=<package_path> make migration.assets.release_package.verify`.",
             "- Verify after extraction with `python3 scripts/migration/migration_asset_bus.py --asset-root migration_assets --catalog migration_assets/manifest/migration_asset_catalog_v1.json --verify-only --check`.",
+            "- Verify packaged replay scope with `python3 scripts/migration/migration_asset_delivery_audit.py --asset-root migration_assets`.",
             "- Rehearse against a fresh target DB with `HISTORY_CONTINUITY_MODE=rehearse HISTORY_CONTINUITY_USE_PACKAGED_PAYLOADS=1 DB_NAME=<target_db> MIGRATION_REPLAY_DB_ALLOWLIST=<target_db> bash scripts/migration/history_continuity_oneclick.sh`.",
         ]
     )


### PR DESCRIPTION
## Summary

- Include tender replay payloads in the migration release package scope.
- Extend release-package verification to run delivery audit after checksum and extraction.
- Refresh migration asset delivery/release evidence for the newly verified package.

## Architecture Impact

- No runtime business model or frontend architecture change.
- Migration packaging guard now treats tender history replay payloads as mandatory user-visible delivery artifacts.
- Release verification now checks both catalog integrity and packaged replay scope.

## Layer Target

- Migration packaging / ops verification.

## Affected Modules

- `Makefile`
- `scripts/migration/migration_asset_delivery_audit.py`
- `scripts/migration/migration_asset_release_package.py`
- `docs/migration_alignment/migration_asset_delivery_audit_v1.md`
- `docs/migration_alignment/migration_asset_release_package_v1.md`

## Verification

- `make migration.assets.delivery_audit`: PASS_WITH_PACKAGING_ACTIONS, blockers=0, missing business-scope artifacts=0
- `make migration.assets.release_package`: PASS
- `MIGRATION_ASSET_RELEASE_PACKAGE=/tmp/sce_migration_asset_release/migration_assets_release_20260513T030706Z.tar.gz make migration.assets.release_package.verify`: PASS
- `git diff --check`: PASS
- `python3 -m compileall scripts/migration/migration_asset_delivery_audit.py scripts/migration/migration_asset_release_package.py`: PASS
- `make verify.restricted`: PASS after repairing local `sc_demo` multi-company verification seed

## Environment Note

- Local gate repair used `make ops.scene.company_secondary.seed APPLY=1 CREATE_COMPANY_IF_MISSING=1 CREATE_USER_IF_MISSING=1`.
- Resulting validation evidence includes company ids `[1, 2]` for multi-company scene readiness.
