### PR TITLE
Add project positive migration visibility refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,8 @@ MIGRATION_ASSET_LOCK ?= docs/migration_alignment/migration_asset_package_lock_v1
 MIGRATION_FILE_INDEX_CSV ?= /mnt/artifacts/migration/fresh_db_legacy_file_index_replay_payload_v1.csv
 CONSTRUCTION_CONTRACT_VISIBLE_XLSX ?= /mnt/artifacts/migration/source_extracts/construction_contract_visible_surface.xlsx
 CONSTRUCTION_CONTRACT_RAW_CSV ?= /mnt/tmp/raw/contract/contract.csv
+PROJECT_POSITIVE_MIGRATION_EXCEL_PATH ?= /mnt/tmp/001/672施工合同项目名称去重统计.xlsx
+PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV ?= $(CONSTRUCTION_CONTRACT_RAW_CSV)
 FORMAL_PROJECTION_ARTIFACT_ROOT ?= $(if $(MIGRATION_ARTIFACT_ROOT),$(MIGRATION_ARTIFACT_ROOT),/tmp/history_continuity/$(DB_NAME)/adhoc)
 
 # Snapshot DB knobs from invocation context before .env include so explicit
@@ -711,6 +713,13 @@ fresh_db.construction_contract.attachment.probe: guard.prod.forbid check-compose
 
 fresh_db.construction_contract.replay_manifest.refresh: guard.prod.forbid
 	@python3 scripts/migration/fresh_db_construction_contract_replay_manifest_refresh.py
+
+.PHONY: project.positive_migration.reconcile.probe project.positive_migration.visibility.refresh.write
+project.positive_migration.reconcile.probe: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" PROJECT_POSITIVE_MIGRATION_EXCEL_PATH="$(PROJECT_POSITIVE_MIGRATION_EXCEL_PATH)" PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV="$(PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV)" bash scripts/ops/odoo_shell_exec.sh < scripts/migration/project_contract_fact_alias_reconciliation.py
+
+project.positive_migration.visibility.refresh.write: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_REPLAY_DB_ALLOWLIST="$(or $(MIGRATION_REPLAY_DB_ALLOWLIST),$(DB_NAME))" MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" PROJECT_POSITIVE_MIGRATION_EXCEL_PATH="$(PROJECT_POSITIVE_MIGRATION_EXCEL_PATH)" PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV="$(PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV)" bash scripts/ops/odoo_shell_exec.sh < scripts/migration/project_positive_migration_visibility_refresh_write.py
 
 fresh_db.fund_account.projection.write: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_REPLAY_DB_ALLOWLIST="$(DB_NAME)" MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" bash scripts/ops/odoo_shell_exec.sh < scripts/migration/fresh_db_fund_account_projection_write.py

--- a/docs/migration_alignment/project_positive_migration_visibility_refresh_v1.md
+++ b/docs/migration_alignment/project_positive_migration_visibility_refresh_v1.md
@@ -1,0 +1,44 @@
+# Project Positive Migration Visibility Refresh v1
+
+Status: `user_approved_for_visibility_refresh`
+
+## Decision
+
+The project list is aligned by positive business facts instead of exact project
+name equality.
+
+Included project anchors:
+
+- project names in the user-provided 672-name construction-contract workbook,
+  except the three names the user confirmed as having no substantive business
+  data;
+- aliases that resolve through raw visible construction contract facts to a
+  canonical `project.project`;
+- same-name runtime project facts when contract names evolved;
+- `周超工程（德阳二重工程项目）`, retained by user decision and mapped to
+  canonical project `易静工程（德阳二重工程项目）`;
+- already separated direct projects, which are exempt from this archival pass.
+
+Excluded names:
+
+- `2024年大邑县S216水晶(平武)-邛崃  K433+900-K434+300段道路水毁抢险救灾工程`
+- `2026年春季乔木补植项目劳务分包合同`
+- `旌兴·和悦雲岸1#-11#楼项目采购室外园林景观工程`
+
+## Runtime Effect
+
+The write flow updates only `project.project.active`:
+
+- retained anchors are active;
+- all other projects are archived and no longer visible to users by default;
+- business fact tables are not modified.
+
+## Reproducible Entry
+
+Use the Makefile targets documented in
+`docs/ops/project_positive_migration_visibility_refresh_runbook_v1.md`:
+
+- `project.positive_migration.reconcile.probe`
+- `project.positive_migration.visibility.refresh.write`
+
+The write target is protected by `MIGRATION_REPLAY_DB_ALLOWLIST`.

--- a/docs/ops/iterations/delivery_context_switch_log_v1.md
+++ b/docs/ops/iterations/delivery_context_switch_log_v1.md
@@ -16,6 +16,16 @@ Each entry must include:
 
 ## Entries
 
+### 2026-05-13T16:13:51+08:00
+- blocker_key: `project_positive_migration_visibility_refresh`
+- layer_target: `Data Migration Ops`
+- module: `Makefile + scripts/migration + docs/ops + docs/migration_alignment`
+- reason: `用户拍板项目集合先按肯定式业务事实对齐：合同/收支/付款等事实纳入，已分直营项目保留，其余未纳入在库项目归档不再对用户可见；该效果需要进入主线后可由服务器升级流程复现。`
+- completed_step: `新增项目合同事实名称核对脚本与项目可见性刷新写入脚本；写入脚本仅更新 project.project.active，不改名称、不删除项目、不改业务事实；新增 project.positive_migration.reconcile.probe 与 project.positive_migration.visibility.refresh.write Makefile 入口；补充部署复现 runbook 与迁移决策文档；将用户确认的“周超工程（德阳二重工程项目）”固化映射到 canonical 项目“易静工程（德阳二重工程项目）”。`
+- verification: `python3 -m py_compile scripts/migration/project_contract_fact_alias_reconciliation.py scripts/migration/project_positive_migration_visibility_refresh_write.py PASS；DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo make project.positive_migration.visibility.refresh.write PASS visibility_exact_match=true positive_resolved_name_count=669 positive_unresolved_name_count=0 active_project_count_after=711 archived_project_count=183；DB_NAME=sc_demo make project.positive_migration.reconcile.probe PASS review_state_counts.resolved=50 ignored=3。`
+- active_commit: `f95b9743`
+- next_step: `提交本批迁移复现入口；通过 make pr.push 与 make pr.create 打开 PR。`
+
 ### 2026-05-13T09:42:06+08:00
 - blocker_key: `history_capability_promotion_c_tax_deduction`
 - layer_target: `Domain Projection / Formal Finance Capability`

--- a/docs/ops/project_positive_migration_visibility_refresh_runbook_v1.md
+++ b/docs/ops/project_positive_migration_visibility_refresh_runbook_v1.md
@@ -1,0 +1,112 @@
+# Project Positive Migration Visibility Refresh Runbook v1
+
+Status: `ready_for_dev_and_server_replay`
+
+## Purpose
+
+This runbook makes the user-approved project alignment rule reproducible after
+the branch enters main:
+
+- keep projects positively identified by contract or runtime business facts;
+- keep already separated direct projects;
+- archive all other in-database projects from user visibility;
+- do not delete projects;
+- do not rewrite project names;
+- do not rewrite contracts, receipts, payments, or other business facts.
+
+The implementation writes only `project.project.active`.
+
+## Inputs
+
+Required files inside the Odoo container:
+
+- `PROJECT_POSITIVE_MIGRATION_EXCEL_PATH`
+  - default: `/mnt/tmp/001/672施工合同项目名称去重统计.xlsx`
+  - user-recognized unique construction-contract project names
+- `PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV`
+  - default: `$(CONSTRUCTION_CONTRACT_RAW_CSV)`
+  - raw construction contract export used to link historical names to canonical project anchors
+
+Recommended artifact root:
+
+- `MIGRATION_ARTIFACT_ROOT=/tmp/project_positive_migration_visibility/<target_db>/<run_id>`
+
+If the artifact root is not writable in the container, the scripts fall back to
+`/tmp/project_positive_migration_visibility_refresh` or
+`/tmp/project_contract_fact_alias_reconciliation`.
+
+## Commands
+
+Read-only reconciliation probe:
+
+```bash
+ENV=dev ENV_FILE=.env.dev DB_NAME=<target_db> \
+MIGRATION_ARTIFACT_ROOT=/tmp/project_positive_migration_visibility/<target_db>/<run_id> \
+PROJECT_POSITIVE_MIGRATION_EXCEL_PATH=/mnt/tmp/001/672施工合同项目名称去重统计.xlsx \
+PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV=/mnt/tmp/raw/contract/contract.csv \
+make project.positive_migration.reconcile.probe
+```
+
+Write the visibility refresh:
+
+```bash
+ENV=dev ENV_FILE=.env.dev DB_NAME=<target_db> \
+MIGRATION_REPLAY_DB_ALLOWLIST=<target_db> \
+MIGRATION_ARTIFACT_ROOT=/tmp/project_positive_migration_visibility/<target_db>/<run_id> \
+PROJECT_POSITIVE_MIGRATION_EXCEL_PATH=/mnt/tmp/001/672施工合同项目名称去重统计.xlsx \
+PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV=/mnt/tmp/raw/contract/contract.csv \
+make project.positive_migration.visibility.refresh.write
+```
+
+For production-supervised execution, follow the production command policy and
+use the production runbook's environment wrapper. Do not run with `ENV=prod`
+under autonomous Codex mode.
+
+## Acceptance
+
+The write command must print
+`PROJECT_POSITIVE_MIGRATION_VISIBILITY_REFRESH=...` with:
+
+- `visibility_exact_match: true`
+- `missing_expected_active_ids: []`
+- `unexpected_active_ids: []`
+- `archived_kept_ids: []`
+
+Development baseline observed on `sc_demo`:
+
+- `excel_unique_names`: `672`
+- `positive_excel_names_after_user_discard`: `669`
+- `positive_resolved_name_count`: `669`
+- `positive_unresolved_name_count`: `0`
+- `user_discard_names`: `3`
+- `direct_project_exemptions`: `43`
+- `kept_project_count`: `711`
+- `archived_project_count`: `183`
+- `active_project_count_after`: `711`
+- `inactive_project_count_after`: `183`
+
+Different target databases may have different direct-project counts or total
+project counts if their project master replay baseline differs. The invariant is
+the exact active-set check above.
+
+## Outputs
+
+The reconciliation probe writes:
+
+- `project_contract_fact_alias_reconciliation_v1.csv`
+- `project_contract_fact_alias_reconciliation_v1.json`
+
+The write command writes:
+
+- `project_positive_migration_visibility_refresh_v1.csv`
+- `project_positive_migration_visibility_refresh_v1.json`
+
+The CSV includes retained and archived project ids, names, legacy project ids,
+operation strategy, reason, source name, and fact counts.
+
+## Rollback
+
+This refresh is a visibility-only migration. To roll back a specific run, use
+the output CSV to restore the previous visibility decision manually, or restore
+the database snapshot taken before the write target. Business facts are not
+deleted by this flow.

--- a/scripts/migration/project_contract_fact_alias_reconciliation.py
+++ b/scripts/migration/project_contract_fact_alias_reconciliation.py
@@ -1,0 +1,316 @@
+# -*- coding: utf-8 -*-
+"""Build a reviewed project-name reconciliation package.
+
+Run through Odoo shell, for example:
+ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo make odoo.shell.exec < scripts/migration/project_contract_fact_alias_reconciliation.py
+
+This script is intentionally read-only for business tables. It produces
+machine-readable artifacts under artifacts/migration.
+"""
+
+import csv
+import json
+import os
+import re
+from pathlib import Path
+from zipfile import ZipFile
+from xml.etree import ElementTree as ET
+
+
+REPO_ROOT = Path("/mnt/extra-addons")
+if not REPO_ROOT.exists():
+    REPO_ROOT = Path.cwd()
+
+EXCEL_PATH = Path(os.getenv("PROJECT_POSITIVE_MIGRATION_EXCEL_PATH", "/mnt/tmp/001/672施工合同项目名称去重统计.xlsx"))
+RAW_CONTRACT_CSV = Path(os.getenv("PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV", "/mnt/tmp/raw/contract/contract.csv"))
+OUTPUT_DIR = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", str(REPO_ROOT / "artifacts" / "migration")))
+OUTPUT_CSV = OUTPUT_DIR / "project_contract_fact_alias_reconciliation_v1.csv"
+OUTPUT_JSON = OUTPUT_DIR / "project_contract_fact_alias_reconciliation_v1.json"
+FALLBACK_OUTPUT_DIRS = (
+    Path("/mnt/tmp") / "migration" / "project_contract_fact_alias_reconciliation",
+    Path("/tmp") / "project_contract_fact_alias_reconciliation",
+)
+
+USER_KEEP_REVIEW = {
+    "周超工程（德阳二重工程项目）": "用户确认该名称有大量业务事实，名称可能发生演变，保留复核",
+}
+
+USER_MANUAL_CANONICAL_PROJECT = {
+    "周超工程（德阳二重工程项目）": {
+        "name": "易静工程（德阳二重工程项目）",
+        "reason": "用户确认需保留；追溯到当前 canonical 项目名称，且该项目存在大量合同、付款、收款事实",
+    },
+}
+
+USER_DISCARD = {
+    "2024年大邑县S216水晶(平武)-邛崃  K433+900-K434+300段道路水毁抢险救灾工程": "用户确认无实质性业务数据",
+    "2026年春季乔木补植项目劳务分包合同": "用户确认无实质性业务数据",
+    "旌兴·和悦雲岸1#-11#楼项目采购室外园林景观工程": "用户确认无实质性业务数据",
+}
+
+RAW_NAME_FIELDS = ("f_XMMC", "HTBT", "XMBM", "f_XMJC", "GCCBFW", "GCDZ")
+FACT_MODELS = ("construction.contract", "sc.general.contract", "sc.payment.execution", "sc.receipt.income")
+NS = {
+    "a": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+}
+
+
+def clean(value):
+    return str(value or "").strip()
+
+
+def norm(value):
+    text = re.sub(r"\s+", "", clean(value))
+    return text.replace("（", "(").replace("）", ")").replace("，", ",").replace("。", ".")
+
+
+def raw_visible(row):
+    return (
+        clean(row.get("DEL")) != "1"
+        and clean(row.get("DJZT")) in {"2", "1", ""}
+        and bool(clean(row.get("HTBT")))
+        and bool(clean(row.get("FBF")))
+    )
+
+
+def read_excel_names(path):
+    with ZipFile(path) as archive:
+        shared = []
+        root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+        for item in root.findall("a:si", NS):
+            shared.append("".join(node.text or "" for node in item.findall(".//a:t", NS)))
+
+        workbook = ET.fromstring(archive.read("xl/workbook.xml"))
+        rels = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+        relmap = {rel.attrib["Id"]: rel.attrib["Target"] for rel in rels}
+        sheet = workbook.find("a:sheets/a:sheet", NS)
+        sheet_ref = sheet.attrib["{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"]
+        sheet_path = "xl/" + relmap[sheet_ref].lstrip("/")
+        sheet_root = ET.fromstring(archive.read(sheet_path))
+
+        names = []
+        for row in sheet_root.findall(".//a:sheetData/a:row", NS):
+            values = []
+            for cell in row.findall("a:c", NS):
+                value = cell.find("a:v", NS)
+                text = "" if value is None else (value.text or "")
+                if cell.attrib.get("t") == "s" and text:
+                    text = shared[int(text)]
+                values.append(text)
+            if len(values) >= 2 and values[0].isdigit() and clean(values[1]):
+                names.append(clean(values[1]))
+        return names
+
+
+def read_raw_contracts(path):
+    with path.open(encoding="utf-8-sig", newline="") as handle:
+        return [row for row in csv.DictReader(handle) if raw_visible(row)]
+
+
+def project_payload(project):
+    if not project:
+        return {"project_id": "", "canonical_project_name": "", "canonical_legacy_project_id": ""}
+    return {
+        "project_id": project.id,
+        "canonical_project_name": clean(project.name),
+        "canonical_legacy_project_id": clean(getattr(project, "legacy_project_id", "")),
+    }
+
+
+def fact_counts_for_project(project):
+    if not project:
+        return {model_name: 0 for model_name in FACT_MODELS}
+    counts = {}
+    for model_name in FACT_MODELS:
+        model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+        counts[model_name] = model.search_count([("project_id", "=", project.id)]) if "project_id" in model._fields else 0
+    return counts
+
+
+def main():
+    excel_names = read_excel_names(EXCEL_PATH)
+    excel_by_norm = {norm(name): name for name in excel_names}
+    raw_rows = read_raw_contracts(RAW_CONTRACT_CSV)
+
+    raw_by_name = {}
+    for row in raw_rows:
+        for field_name in RAW_NAME_FIELDS:
+            value = norm(row.get(field_name))
+            if value:
+                raw_by_name.setdefault(value, []).append((field_name, row))
+
+    project_model = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+    contract_model = env["construction.contract"].sudo().with_context(active_test=False)  # noqa: F821
+    contract_groups = contract_model.read_group(
+        [("project_id", "!=", False), ("legacy_contract_id", "!=", False), ("type", "=", "out")],
+        ["project_id"],
+        ["project_id"],
+        lazy=False,
+    )
+    contract_project_ids = [int(group["project_id"][0]) for group in contract_groups if group.get("project_id")]
+    contract_projects = project_model.browse(contract_project_ids).exists()
+    db_contract_project_names = {
+        norm(project.name)
+        for project in contract_projects
+        if clean(project.name) and clean(getattr(project, "operation_strategy", "")) != "direct"
+    }
+
+    missing_names = sorted(set(excel_by_norm) - db_contract_project_names)
+    project_by_legacy = {
+        clean(project.legacy_project_id): project
+        for project in project_model.search([("legacy_project_id", "!=", False)])
+    }
+    contract_by_legacy = {
+        clean(contract.legacy_contract_id): contract
+        for contract in contract_model.search([("legacy_contract_id", "!=", False), ("type", "=", "out")])
+    }
+
+    rows = []
+    for key in missing_names:
+        source_name = excel_by_norm[key]
+        source_name_key = norm(source_name)
+        raw_matches = raw_by_name.get(source_name_key, [])
+        raw_contract_ids = sorted({clean(row.get("Id")) for _field, row in raw_matches if clean(row.get("Id"))})
+        raw_xmids = sorted({clean(row.get("XMID")) for _field, row in raw_matches if clean(row.get("XMID"))})
+        raw_fields = sorted({field for field, _row in raw_matches})
+
+        target_project = None
+        target_contracts = []
+        for contract_id in raw_contract_ids:
+            contract = contract_by_legacy.get(contract_id)
+            if contract:
+                target_contracts.append(contract)
+                if not target_project:
+                    target_project = contract.project_id
+        if not target_project:
+            for xmid in raw_xmids:
+                target_project = project_by_legacy.get(xmid)
+                if target_project:
+                    break
+
+        same_name_project = project_model.search([("name", "=", source_name)], limit=1)
+        same_name_counts = fact_counts_for_project(same_name_project)
+        same_name_has_fact = any(same_name_counts.values())
+        manual_target = USER_MANUAL_CANONICAL_PROJECT.get(source_name)
+        manual_project = project_model.browse()
+        if manual_target:
+            manual_project = project_model.search([("name", "=", manual_target["name"])], limit=1)
+
+        if target_project:
+            decision = "alias_to_canonical_project"
+            confidence = "high"
+            review_state = "resolved"
+            match_reason = "raw_visible_construction_contract_name_to_legacy_contract_or_xmid"
+            project = target_project
+            fact_counts = fact_counts_for_project(project)
+        elif manual_project:
+            decision = "manual_alias_to_canonical_project"
+            confidence = "user_confirmed"
+            review_state = "resolved"
+            match_reason = manual_target["reason"]
+            project = manual_project
+            fact_counts = fact_counts_for_project(project)
+        elif source_name in USER_KEEP_REVIEW:
+            decision = "keep_for_manual_review"
+            confidence = "manual_review"
+            review_state = "review"
+            match_reason = USER_KEEP_REVIEW[source_name]
+            project = same_name_project
+            fact_counts = same_name_counts
+        elif source_name in USER_DISCARD:
+            decision = "ignore_no_substantive_business_data"
+            confidence = "user_confirmed"
+            review_state = "ignored"
+            match_reason = USER_DISCARD[source_name]
+            project = same_name_project
+            fact_counts = same_name_counts
+        elif same_name_project and same_name_has_fact:
+            decision = "project_fact_alias"
+            confidence = "medium"
+            review_state = "resolved"
+            match_reason = "same_project_name_exists_with_runtime_project_facts_but_not_visible_out_contract_xmid"
+            project = same_name_project
+            fact_counts = same_name_counts
+        else:
+            decision = "review_required"
+            confidence = "low"
+            review_state = "review"
+            match_reason = "no_raw_visible_contract_or_runtime_project_fact_anchor"
+            project = same_name_project
+            fact_counts = same_name_counts
+
+        payload = project_payload(project)
+        rows.append(
+            {
+                "source_name": source_name,
+                "source_name_key": source_name_key,
+                "decision": decision,
+                "confidence": confidence,
+                "review_state": review_state,
+                "match_reason": match_reason,
+                **payload,
+                "raw_match_fields": ";".join(raw_fields),
+                "raw_contract_ids": ";".join(raw_contract_ids),
+                "raw_xmids": ";".join(raw_xmids),
+                "target_contract_ids": ";".join(str(contract.id) for contract in target_contracts),
+                "fact_counts_json": json.dumps(fact_counts, ensure_ascii=False, sort_keys=True),
+            }
+        )
+
+    output_dir = OUTPUT_DIR
+    output_csv = OUTPUT_CSV
+    output_json = OUTPUT_JSON
+    for candidate in (OUTPUT_DIR, *FALLBACK_OUTPUT_DIRS):
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        output_dir = candidate
+        output_csv = output_dir / OUTPUT_CSV.name
+        output_json = output_dir / OUTPUT_JSON.name
+        break
+    else:
+        raise RuntimeError("No writable output directory for project reconciliation artifacts")
+
+    summary = {
+        "database": env.cr.dbname,  # noqa: F821
+        "excel_unique_names": len(set(excel_names)),
+        "raw_visible_contract_rows": len(raw_rows),
+        "db_legacy_out_non_direct_project_names": len(db_contract_project_names),
+        "reconciliation_rows": len(rows),
+        "decision_counts": {},
+        "review_state_counts": {},
+        "outputs": {"csv": str(output_csv), "json": str(output_json)},
+        "repo_artifact_write_fallback": str(output_dir) != str(OUTPUT_DIR),
+    }
+    for row in rows:
+        summary["decision_counts"][row["decision"]] = summary["decision_counts"].get(row["decision"], 0) + 1
+        summary["review_state_counts"][row["review_state"]] = summary["review_state_counts"].get(row["review_state"], 0) + 1
+
+    fieldnames = [
+        "source_name",
+        "source_name_key",
+        "decision",
+        "confidence",
+        "review_state",
+        "match_reason",
+        "project_id",
+        "canonical_project_name",
+        "canonical_legacy_project_id",
+        "raw_match_fields",
+        "raw_contract_ids",
+        "raw_xmids",
+        "target_contract_ids",
+        "fact_counts_json",
+    ]
+    with output_csv.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    output_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    print("PROJECT_CONTRACT_FACT_ALIAS_RECONCILIATION=" + json.dumps(summary, ensure_ascii=False, sort_keys=True))
+
+
+main()

--- a/scripts/migration/project_positive_migration_visibility_refresh_write.py
+++ b/scripts/migration/project_positive_migration_visibility_refresh_write.py
@@ -1,0 +1,331 @@
+# -*- coding: utf-8 -*-
+"""Apply the positive project migration visibility decision to a dev database.
+
+Run through Odoo shell, for example:
+ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo \
+  make odoo.shell.exec < scripts/migration/project_positive_migration_visibility_refresh_write.py
+
+This script only changes project.project.active. It does not delete projects or
+rewrite business facts.
+"""
+
+import csv
+import json
+import os
+import re
+from pathlib import Path
+from zipfile import ZipFile
+from xml.etree import ElementTree as ET
+
+
+REPO_ROOT = Path("/mnt/extra-addons")
+if not REPO_ROOT.exists():
+    REPO_ROOT = Path.cwd()
+
+EXCEL_PATH = Path(os.getenv("PROJECT_POSITIVE_MIGRATION_EXCEL_PATH", "/mnt/tmp/001/672施工合同项目名称去重统计.xlsx"))
+RAW_CONTRACT_CSV = Path(os.getenv("PROJECT_POSITIVE_MIGRATION_RAW_CONTRACT_CSV", "/mnt/tmp/raw/contract/contract.csv"))
+OUTPUT_DIR = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", str(REPO_ROOT / "artifacts" / "migration")))
+OUTPUT_CSV = OUTPUT_DIR / "project_positive_migration_visibility_refresh_v1.csv"
+OUTPUT_JSON = OUTPUT_DIR / "project_positive_migration_visibility_refresh_v1.json"
+FALLBACK_OUTPUT_DIRS = (
+    Path("/mnt/tmp") / "migration" / "project_positive_migration_visibility_refresh",
+    Path("/tmp") / "project_positive_migration_visibility_refresh",
+)
+
+USER_KEEP_REVIEW = {
+    "周超工程（德阳二重工程项目）": "用户确认该名称有大量业务事实，名称可能发生演变，保留为肯定式迁移项目",
+}
+
+USER_MANUAL_CANONICAL_PROJECT = {
+    "周超工程（德阳二重工程项目）": {
+        "name": "易静工程（德阳二重工程项目）",
+        "reason": "positive_user_confirmed_manual_alias_to_canonical_project",
+    },
+}
+
+USER_DISCARD = {
+    "2024年大邑县S216水晶(平武)-邛崃  K433+900-K434+300段道路水毁抢险救灾工程": "用户确认无实质性业务数据",
+    "2026年春季乔木补植项目劳务分包合同": "用户确认无实质性业务数据",
+    "旌兴·和悦雲岸1#-11#楼项目采购室外园林景观工程": "用户确认无实质性业务数据",
+}
+
+RAW_NAME_FIELDS = ("f_XMMC", "HTBT", "XMBM", "f_XMJC", "GCCBFW", "GCDZ")
+FACT_MODELS = ("construction.contract", "sc.general.contract", "sc.payment.execution", "sc.receipt.income")
+NS = {
+    "a": "http://schemas.openxmlformats.org/spreadsheetml/2006/main",
+    "r": "http://schemas.openxmlformats.org/officeDocument/2006/relationships",
+}
+
+
+def clean(value):
+    return str(value or "").strip()
+
+
+def norm(value):
+    text = re.sub(r"\s+", "", clean(value))
+    return text.replace("（", "(").replace("）", ")").replace("，", ",").replace("。", ".")
+
+
+def raw_visible(row):
+    return (
+        clean(row.get("DEL")) != "1"
+        and clean(row.get("DJZT")) in {"2", "1", ""}
+        and bool(clean(row.get("HTBT")))
+        and bool(clean(row.get("FBF")))
+    )
+
+
+def guard_database():
+    dbname = env.cr.dbname  # noqa: F821
+    allowlist = {item.strip() for item in os.environ.get("MIGRATION_REPLAY_DB_ALLOWLIST", "").split(",") if item.strip()}
+    if dbname not in allowlist:
+        raise RuntimeError(
+            "Refusing to write project visibility: database %r is not in MIGRATION_REPLAY_DB_ALLOWLIST=%r"
+            % (dbname, sorted(allowlist))
+        )
+    return dbname
+
+
+def read_excel_names(path):
+    with ZipFile(path) as archive:
+        shared = []
+        root = ET.fromstring(archive.read("xl/sharedStrings.xml"))
+        for item in root.findall("a:si", NS):
+            shared.append("".join(node.text or "" for node in item.findall(".//a:t", NS)))
+
+        workbook = ET.fromstring(archive.read("xl/workbook.xml"))
+        rels = ET.fromstring(archive.read("xl/_rels/workbook.xml.rels"))
+        relmap = {rel.attrib["Id"]: rel.attrib["Target"] for rel in rels}
+        sheet = workbook.find("a:sheets/a:sheet", NS)
+        sheet_ref = sheet.attrib["{http://schemas.openxmlformats.org/officeDocument/2006/relationships}id"]
+        sheet_path = "xl/" + relmap[sheet_ref].lstrip("/")
+        sheet_root = ET.fromstring(archive.read(sheet_path))
+
+        names = []
+        for row in sheet_root.findall(".//a:sheetData/a:row", NS):
+            values = []
+            for cell in row.findall("a:c", NS):
+                value = cell.find("a:v", NS)
+                text = "" if value is None else (value.text or "")
+                if cell.attrib.get("t") == "s" and text:
+                    text = shared[int(text)]
+                values.append(text)
+            if len(values) >= 2 and values[0].isdigit() and clean(values[1]):
+                names.append(clean(values[1]))
+        return names
+
+
+def read_raw_contracts(path):
+    with path.open(encoding="utf-8-sig", newline="") as handle:
+        return [row for row in csv.DictReader(handle) if raw_visible(row)]
+
+
+def fact_counts_for_project(project):
+    counts = {}
+    for model_name in FACT_MODELS:
+        model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+        counts[model_name] = model.search_count([("project_id", "=", project.id)]) if "project_id" in model._fields else 0
+    return counts
+
+
+def find_same_name_project(project_model, source_name):
+    exact = project_model.search([("name", "=", source_name)], limit=1)
+    if exact:
+        return exact
+    source_key = norm(source_name)
+    for project in project_model.search([("name", "!=", False)]):
+        if norm(project.name) == source_key:
+            return project
+    return project_model.browse()
+
+
+def output_paths():
+    for output_dir in (OUTPUT_DIR, *FALLBACK_OUTPUT_DIRS):
+        try:
+            output_dir.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            continue
+        return output_dir, output_dir / OUTPUT_CSV.name, output_dir / OUTPUT_JSON.name
+    raise RuntimeError("No writable output directory for project visibility refresh artifacts")
+
+
+def main():
+    dbname = guard_database()
+    project_model = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+    contract_model = env["construction.contract"].sudo().with_context(active_test=False)  # noqa: F821
+
+    excel_names = read_excel_names(EXCEL_PATH)
+    excel_unique = {norm(name): name for name in excel_names}
+    discard_keys = {norm(name) for name in USER_DISCARD}
+    positive_keys = set(excel_unique) - discard_keys
+    raw_rows = read_raw_contracts(RAW_CONTRACT_CSV)
+
+    raw_by_name = {}
+    for row in raw_rows:
+        for field_name in RAW_NAME_FIELDS:
+            value = norm(row.get(field_name))
+            if value:
+                raw_by_name.setdefault(value, []).append((field_name, row))
+
+    project_by_legacy = {
+        clean(project.legacy_project_id): project
+        for project in project_model.search([("legacy_project_id", "!=", False)])
+    }
+    contract_by_legacy = {
+        clean(contract.legacy_contract_id): contract
+        for contract in contract_model.search([("legacy_contract_id", "!=", False), ("type", "=", "out")])
+    }
+
+    contract_projects = contract_model.search(
+        [("project_id", "!=", False), ("legacy_contract_id", "!=", False), ("type", "=", "out")]
+    ).mapped("project_id")
+
+    keep_map = {}
+    resolved_positive_keys = set()
+
+    def keep(project, reason, source_name="", source_key=""):
+        if not project:
+            return
+        if source_key:
+            resolved_positive_keys.add(source_key)
+        keep_map[project.id] = {
+            "project_id": project.id,
+            "project_name": clean(project.name),
+            "legacy_project_id": clean(getattr(project, "legacy_project_id", "")),
+            "operation_strategy": clean(getattr(project, "operation_strategy", "")),
+            "reason": reason,
+            "source_name": source_name,
+            "fact_counts_json": json.dumps(fact_counts_for_project(project), ensure_ascii=False, sort_keys=True),
+        }
+
+    direct_projects = project_model.search([("operation_strategy", "=", "direct")])
+    for project in direct_projects:
+        keep(project, "direct_project_exemption")
+
+    for project in contract_projects:
+        project_key = norm(project.name)
+        if project_key in positive_keys:
+            keep(
+                project,
+                "positive_excel_name_matches_current_out_contract_project",
+                excel_unique[project_key],
+                project_key,
+            )
+
+    for source_key in sorted(positive_keys):
+        source_name = excel_unique[source_key]
+        raw_matches = raw_by_name.get(source_key, [])
+        raw_contract_ids = sorted({clean(row.get("Id")) for _field, row in raw_matches if clean(row.get("Id"))})
+        raw_xmids = sorted({clean(row.get("XMID")) for _field, row in raw_matches if clean(row.get("XMID"))})
+
+        target_project = project_model.browse()
+        for contract_id in raw_contract_ids:
+            contract = contract_by_legacy.get(contract_id)
+            if contract and contract.project_id:
+                target_project = contract.project_id
+                break
+        if not target_project:
+            for xmid in raw_xmids:
+                target_project = project_by_legacy.get(xmid) or project_model.browse()
+                if target_project:
+                    break
+        if target_project:
+            keep(target_project, "positive_raw_contract_alias_to_canonical_project", source_name, source_key)
+            continue
+
+        manual_target = USER_MANUAL_CANONICAL_PROJECT.get(source_name)
+        if manual_target:
+            manual_project = project_model.search([("name", "=", manual_target["name"])], limit=1)
+            if manual_project and any(fact_counts_for_project(manual_project).values()):
+                keep(manual_project, manual_target["reason"], source_name, source_key)
+                continue
+
+        same_name_project = find_same_name_project(project_model, source_name)
+        if same_name_project:
+            same_name_counts = fact_counts_for_project(same_name_project)
+            if any(same_name_counts.values()) or source_name in USER_KEEP_REVIEW:
+                keep(same_name_project, "positive_project_fact_alias_or_user_keep_review", source_name, source_key)
+
+    unresolved_positive_keys = sorted(positive_keys - resolved_positive_keys)
+    if unresolved_positive_keys:
+        unresolved_names = [excel_unique[key] for key in unresolved_positive_keys[:20]]
+        raise RuntimeError(
+            "Refusing to archive projects: %s positive project names were not resolved to project anchors. "
+            "First unresolved names: %s" % (len(unresolved_positive_keys), unresolved_names)
+        )
+
+    keep_ids = set(keep_map)
+    all_projects = project_model.search([])
+    archive_projects = all_projects.filtered(lambda project: project.id not in keep_ids)
+    activate_projects = project_model.browse(sorted(keep_ids)).filtered(lambda project: not project.active)
+    already_active_kept = project_model.browse(sorted(keep_ids)).filtered(lambda project: project.active)
+
+    if archive_projects:
+        archive_projects.write({"active": False})
+    if activate_projects:
+        activate_projects.write({"active": True})
+
+    output_dir, output_csv, output_json = output_paths()
+    rows = list(keep_map.values())
+    rows.extend(
+        {
+            "project_id": project.id,
+            "project_name": clean(project.name),
+            "legacy_project_id": clean(getattr(project, "legacy_project_id", "")),
+            "operation_strategy": clean(getattr(project, "operation_strategy", "")),
+            "reason": "archived_not_in_positive_migration_or_direct_exemption",
+            "source_name": "",
+            "fact_counts_json": json.dumps(fact_counts_for_project(project), ensure_ascii=False, sort_keys=True),
+        }
+        for project in archive_projects
+    )
+    rows.sort(key=lambda row: (row["reason"], row["project_name"], row["project_id"]))
+
+    fieldnames = [
+        "project_id",
+        "project_name",
+        "legacy_project_id",
+        "operation_strategy",
+        "reason",
+        "source_name",
+        "fact_counts_json",
+    ]
+    with output_csv.open("w", encoding="utf-8-sig", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    active_ids_after = set(project_model.search([("active", "=", True)]).ids)
+    inactive_ids_after = set(project_model.search([("active", "=", False)]).ids)
+    missing_expected_active_ids = sorted(keep_ids - active_ids_after)
+    unexpected_active_ids = sorted(active_ids_after - keep_ids)
+    archived_kept_ids = sorted(keep_ids & inactive_ids_after)
+
+    summary = {
+        "database": dbname,
+        "excel_unique_names": len(excel_unique),
+        "positive_excel_names_after_user_discard": len(positive_keys),
+        "positive_resolved_name_count": len(resolved_positive_keys),
+        "positive_unresolved_name_count": len(unresolved_positive_keys),
+        "user_discard_names": len(USER_DISCARD),
+        "direct_project_exemptions": len(direct_projects),
+        "kept_project_count": len(keep_ids),
+        "kept_already_active_count": len(already_active_kept),
+        "activated_project_count": len(activate_projects),
+        "archived_project_count": len(archive_projects),
+        "active_project_count_after": len(active_ids_after),
+        "inactive_project_count_after": len(inactive_ids_after),
+        "visibility_exact_match": not missing_expected_active_ids and not unexpected_active_ids and not archived_kept_ids,
+        "missing_expected_active_ids": missing_expected_active_ids[:20],
+        "unexpected_active_ids": unexpected_active_ids[:20],
+        "archived_kept_ids": archived_kept_ids[:20],
+        "outputs": {"csv": str(output_csv), "json": str(output_json)},
+        "repo_artifact_write_fallback": str(output_dir) != str(OUTPUT_DIR),
+    }
+    output_json.write_text(json.dumps(summary, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+    env.cr.commit()  # noqa: F821
+    print("PROJECT_POSITIVE_MIGRATION_VISIBILITY_REFRESH=" + json.dumps(summary, ensure_ascii=False, sort_keys=True))
+
+
+main()


### PR DESCRIPTION
## Summary

- Add reproducible project positive-migration reconciliation and visibility refresh scripts.
- Add Makefile targets for server replay: `project.positive_migration.reconcile.probe` and `project.positive_migration.visibility.refresh.write`.
- Document the user-approved rule, inputs, acceptance criteria, and rollback path.

## Architecture Impact

- Data migration ops only.
- No Odoo model/schema/view/security change.
- No frontend, scene contract, startup chain, or public intent change.
- The write path only updates `project.project.active`; it does not delete projects or rewrite business facts.

## Layer Target

- Data Migration Ops.

## Affected Modules

- `Makefile`
- `scripts/migration/project_contract_fact_alias_reconciliation.py`
- `scripts/migration/project_positive_migration_visibility_refresh_write.py`
- `docs/ops/project_positive_migration_visibility_refresh_runbook_v1.md`
- `docs/migration_alignment/project_positive_migration_visibility_refresh_v1.md`
- `docs/ops/iterations/delivery_context_switch_log_v1.md`

## Verification

- `python3 -m py_compile scripts/migration/project_contract_fact_alias_reconciliation.py scripts/migration/project_positive_migration_visibility_refresh_write.py`: PASS
- `make -n project.positive_migration.visibility.refresh.write DB_NAME=sc_demo`: PASS
- `ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo make project.positive_migration.visibility.refresh.write`: PASS
  - `visibility_exact_match=true`
  - `positive_resolved_name_count=669`
  - `positive_unresolved_name_count=0`
  - `active_project_count_after=711`
  - `archived_project_count=183`
- `ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo make project.positive_migration.reconcile.probe`: PASS
  - `review_state_counts={"ignored": 3, "resolved": 50}`
- `make verify.docs.links`: PASS
- `git diff --check`: PASS

## Notes

- `周超工程（德阳二重工程项目）` is preserved through an explicit user-confirmed alias to canonical project `易静工程（德阳二重工程项目）`.
- The write target is guarded by `MIGRATION_REPLAY_DB_ALLOWLIST`.
