### PR TITLE
Clean legacy platform company-access XML IDs

### DIFF
--- a/addons/smart_core/models/subscription.py
+++ b/addons/smart_core/models/subscription.py
@@ -22,6 +22,36 @@ LEGACY_CONSTRUCTION_PLATFORM_ACCESS_XMLIDS = (
     "access_sc_ops_job_read",
     "access_sc_ops_job_admin",
 )
+LEGACY_CONSTRUCTION_PLATFORM_UI_XMLIDS = {
+    "ir.ui.menu": (
+        "menu_sc_ops_job",
+        "menu_sc_usage_counter",
+        "menu_sc_entitlement",
+        "menu_sc_subscription",
+        "menu_sc_subscription_plan",
+        "menu_smart_core_company_access_root",
+        "menu_smart_core_platform_root",
+    ),
+    "ir.actions.act_window": (
+        "action_sc_subscription_plan",
+        "action_sc_subscription",
+        "action_sc_entitlement",
+        "action_sc_usage_counter",
+        "action_sc_ops_job",
+    ),
+    "ir.ui.view": (
+        "view_sc_subscription_plan_tree",
+        "view_sc_subscription_plan_form",
+        "view_sc_subscription_tree",
+        "view_sc_subscription_form",
+        "view_sc_entitlement_tree",
+        "view_sc_entitlement_form",
+        "view_sc_usage_counter_tree",
+        "view_sc_usage_counter_form",
+        "view_sc_ops_job_tree",
+        "view_sc_ops_job_form",
+    ),
+}
 
 
 class ScSubscriptionPlan(models.Model):
@@ -71,7 +101,8 @@ class ScSubscriptionPlan(models.Model):
 
     @api.model
     def ensure_platform_access_ownership(self):
-        imds = self.env["ir.model.data"].sudo().search(
+        ModelData = self.env["ir.model.data"].sudo()
+        imds = ModelData.search(
             [
                 ("module", "=", "smart_construction_core"),
                 ("name", "in", list(LEGACY_CONSTRUCTION_PLATFORM_ACCESS_XMLIDS)),
@@ -83,6 +114,21 @@ class ScSubscriptionPlan(models.Model):
             imds.unlink()
         if access_recs:
             access_recs.unlink()
+
+        for model_name in ("ir.ui.menu", "ir.actions.act_window", "ir.ui.view"):
+            legacy_xmlids = LEGACY_CONSTRUCTION_PLATFORM_UI_XMLIDS[model_name]
+            ui_imds = ModelData.search(
+                [
+                    ("module", "=", "smart_construction_core"),
+                    ("name", "in", list(legacy_xmlids)),
+                    ("model", "=", model_name),
+                ]
+            )
+            ui_recs = self.env[model_name].sudo().browse([res_id for res_id in ui_imds.mapped("res_id") if res_id])
+            if ui_imds:
+                ui_imds.unlink()
+            if ui_recs:
+                ui_recs.exists().unlink()
         return True
 
 

--- a/scripts/verify/platform_company_access_kernel_probe.py
+++ b/scripts/verify/platform_company_access_kernel_probe.py
@@ -39,6 +39,36 @@ LEGACY_CONSTRUCTION_ACCESS_XMLIDS = [
     "access_sc_ops_job_read",
     "access_sc_ops_job_admin",
 ]
+LEGACY_CONSTRUCTION_UI_XMLIDS = {
+    "ir.ui.menu": [
+        "menu_sc_ops_job",
+        "menu_sc_usage_counter",
+        "menu_sc_entitlement",
+        "menu_sc_subscription",
+        "menu_sc_subscription_plan",
+        "menu_smart_core_company_access_root",
+        "menu_smart_core_platform_root",
+    ],
+    "ir.actions.act_window": [
+        "action_sc_subscription_plan",
+        "action_sc_subscription",
+        "action_sc_entitlement",
+        "action_sc_usage_counter",
+        "action_sc_ops_job",
+    ],
+    "ir.ui.view": [
+        "view_sc_subscription_plan_tree",
+        "view_sc_subscription_plan_form",
+        "view_sc_subscription_tree",
+        "view_sc_subscription_form",
+        "view_sc_entitlement_tree",
+        "view_sc_entitlement_form",
+        "view_sc_usage_counter_tree",
+        "view_sc_usage_counter_form",
+        "view_sc_ops_job_tree",
+        "view_sc_ops_job_form",
+    ],
+}
 
 
 def assert_true(condition, message):
@@ -86,6 +116,16 @@ legacy_access = env["ir.model.data"].sudo().search(
 )
 assert_true(not legacy_access, f"legacy construction ACL ownership remains: {legacy_access.mapped('name')}")
 
+for model_name, xmlids in LEGACY_CONSTRUCTION_UI_XMLIDS.items():
+    legacy_ui = env["ir.model.data"].sudo().search(
+        [
+            ("module", "=", "smart_construction_core"),
+            ("name", "in", xmlids),
+            ("model", "=", model_name),
+        ]
+    )
+    assert_true(not legacy_ui, f"legacy construction UI ownership remains: {model_name} {legacy_ui.mapped('name')}")
+
 plan = env["sc.subscription.plan"].sudo().search([("code", "=", "default"), ("active", "=", True)], limit=1)
 if not plan:
     raise AssertionError("missing active default platform subscription plan")
@@ -116,5 +156,5 @@ print(
     "PLATFORM_COMPANY_ACCESS_KERNEL_PROBE=PASS "
     f"models={len(REQUIRED_MODELS)} actions={len(REQUIRED_PLATFORM_XMLIDS['ir.actions.act_window'])} "
     f"menus={len(REQUIRED_PLATFORM_XMLIDS['ir.ui.menu'])} company_id={company.id} "
-    f"plan={entitlement.plan_id.code} legacy_acl=0"
+    f"plan={entitlement.plan_id.code} legacy_acl=0 legacy_ui=0"
 )

--- a/scripts/verify/platform_company_access_manifest_guard.py
+++ b/scripts/verify/platform_company_access_manifest_guard.py
@@ -33,6 +33,30 @@ REQUIRED_PLATFORM_XMLIDS = {
     "action_sc_usage_counter",
     "action_sc_ops_job",
 }
+LEGACY_PLATFORM_UI_XMLIDS = {
+    "menu_smart_core_platform_root",
+    "menu_smart_core_company_access_root",
+    "menu_sc_subscription_plan",
+    "menu_sc_subscription",
+    "menu_sc_entitlement",
+    "menu_sc_usage_counter",
+    "menu_sc_ops_job",
+    "view_sc_subscription_plan_tree",
+    "view_sc_subscription_plan_form",
+    "view_sc_subscription_tree",
+    "view_sc_subscription_form",
+    "view_sc_entitlement_tree",
+    "view_sc_entitlement_form",
+    "view_sc_usage_counter_tree",
+    "view_sc_usage_counter_form",
+    "view_sc_ops_job_tree",
+    "view_sc_ops_job_form",
+    "action_sc_subscription_plan",
+    "action_sc_subscription",
+    "action_sc_entitlement",
+    "action_sc_usage_counter",
+    "action_sc_ops_job",
+}
 PLATFORM_MODELS = {
     "sc.subscription.plan",
     "sc.subscription",
@@ -144,6 +168,13 @@ platform_seed = (ROOT / "addons" / "smart_core" / "data" / "sc_subscription_defa
 assert_true(
     "ensure_platform_access_ownership" in platform_seed,
     "smart_core platform seed must clean legacy construction ACL ownership",
+)
+
+subscription_model_text = (ROOT / "addons" / "smart_core" / "models" / "subscription.py").read_text(encoding="utf-8")
+missing_cleanup_xmlids = sorted(xmlid for xmlid in LEGACY_PLATFORM_UI_XMLIDS if xmlid not in subscription_model_text)
+assert_true(
+    not missing_cleanup_xmlids,
+    f"smart_core ownership cleanup missing legacy UI XML ids: {missing_cleanup_xmlids}",
 )
 
 helper_text = (ROOT / PLATFORM_ADMIN_HELPER).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- extend smart_core platform ownership cleanup to remove legacy smart_construction_core menus/actions/views for company access
- keep ACL cleanup and add runtime/static guards for legacy UI XML IDs
- addresses the Codex review on PR #677 about duplicate upgraded-db company-access surfaces

## Verification
- python3 -m py_compile addons/smart_core/models/subscription.py scripts/verify/platform_company_access_kernel_probe.py scripts/verify/platform_company_access_manifest_guard.py
- git diff --check
- make verify.platform_company_access_manifest.guard
- make mod.upgrade CODEX_NEED_UPGRADE=1 MODULE=smart_core
- make verify.platform_company_access_kernel.probe (legacy_acl=0 legacy_ui=0)
- make menu.role_visibility.governance.probe

Follow-up to #677 review comment: https://github.com/Leedefend/sce-backend-odoo/pull/677#discussion_r3237528136