### PR TITLE
修复当前项目下拉搜索与缓存污染

### DIFF
--- a/addons/smart_core/core/project_context.py
+++ b/addons/smart_core/core/project_context.py
@@ -135,16 +135,23 @@ def _record_context_domain(Model, search: str) -> list:
     term = str(search or "").strip()
     if not term:
         return []
+    fields = getattr(Model, "_fields", {}) or {}
     conditions = [
         (field_name, "ilike", term)
         for field_name in ("name", "display_name", "code", "project_code", "x_code")
-        if field_name in Model._fields
+        if _field_searchable(fields.get(field_name))
     ]
     if not conditions:
         return [("id", "=", 0)]
     if len(conditions) == 1:
         return [conditions[0]]
     return ["|"] * (len(conditions) - 1) + conditions
+
+
+def _field_searchable(field) -> bool:
+    if not field:
+        return False
+    return bool(getattr(field, "store", False) or getattr(field, "search", None))
 
 
 def _project_domain(Project, search: str) -> list:

--- a/addons/smart_core/tests/test_project_context_boundaries.py
+++ b/addons/smart_core/tests/test_project_context_boundaries.py
@@ -68,6 +68,29 @@ def _load_handler():
     return module
 
 
+def _load_project_context_core():
+    root = Path(__file__).resolve().parents[1]
+    _install_module("odoo")
+    _install_module("odoo.exceptions", AccessError=type("AccessError", (Exception,), {}))
+    _install_module("odoo.addons")
+    smart_core_mod = _install_module("odoo.addons.smart_core")
+    utils_mod = _install_module("odoo.addons.smart_core.utils")
+    smart_core_mod.__path__ = [str(root)]
+    utils_mod.__path__ = [str(root / "utils")]
+    _install_module(
+        "odoo.addons.smart_core.utils.extension_hooks",
+        call_extension_hook_first=lambda *args, **kwargs: None,
+    )
+
+    module_name = "odoo.addons.smart_core.core.project_context"
+    sys.modules.pop(module_name, None)
+    spec = importlib.util.spec_from_file_location(module_name, root / "core" / "project_context.py")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
 class TestProjectContextBoundaries(unittest.TestCase):
     def setUp(self):
         self.module = _load_handler()
@@ -99,6 +122,35 @@ class TestProjectContextBoundaries(unittest.TestCase):
         self.assertEqual(result.data["selector"]["limit"], 7)
         self.assertEqual(self.module._captured["search"], "abc")
         self.assertEqual(self.module._captured["limit"], 7)
+
+    def test_record_context_domain_excludes_unsearchable_display_name(self):
+        core = _load_project_context_core()
+
+        class Field:
+            def __init__(self, *, store=False, search=None):
+                self.store = store
+                self.search = search
+
+        class Model:
+            _fields = {
+                "name": Field(store=True),
+                "display_name": Field(store=False),
+                "code": Field(store=True),
+                "project_code": Field(store=True),
+            }
+
+        domain = core._record_context_domain(Model, "五洲")
+
+        self.assertEqual(
+            domain,
+            [
+                "|",
+                "|",
+                ("name", "ilike", "五洲"),
+                ("code", "ilike", "五洲"),
+                ("project_code", "ilike", "五洲"),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/frontend/apps/web/src/layouts/AppShell.vue
+++ b/frontend/apps/web/src/layouts/AppShell.vue
@@ -46,7 +46,7 @@
             type="search"
             :placeholder="projectSearchPlaceholder"
             @input="queueProjectSearch"
-            @keydown.enter.prevent="selectFirstProject"
+            @keydown.enter.prevent="submitProjectSearch"
           />
           <div class="project-options">
             <button
@@ -459,8 +459,22 @@ function queueProjectSearch() {
     clearTimeout(projectSearchTimer);
   }
   projectSearchTimer = setTimeout(() => {
+    projectSearchTimer = null;
     void loadProjectOptions();
   }, 260);
+}
+
+async function submitProjectSearch(event: KeyboardEvent) {
+  if (event.isComposing) return;
+  const target = event.currentTarget;
+  if (target instanceof HTMLInputElement) {
+    projectSearch.value = target.value;
+  }
+  if (projectSearchTimer) {
+    clearTimeout(projectSearchTimer);
+    projectSearchTimer = null;
+  }
+  await loadProjectOptions();
 }
 
 async function toggleProjectMenu() {
@@ -482,13 +496,6 @@ async function clearProjectSelection() {
   projectMenuOpen.value = false;
   await session.selectProjectContext(null);
   emitProjectContextChanged();
-}
-
-async function selectFirstProject() {
-  const first = projectOptions.value[0];
-  if (first) {
-    await selectProject(first);
-  }
 }
 
 function resolveActionBusinessTitle(action: unknown) {

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -438,7 +438,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onErrorCaptured, reactive, ref, watch } from 'vue';
+import { computed, nextTick, onBeforeUnmount, onErrorCaptured, onMounted, reactive, ref, watch } from 'vue';
 import { useRoute, useRouter } from 'vue-router';
 import FieldValue from '../components/FieldValue.vue';
 import StatusPanel from '../components/StatusPanel.vue';
@@ -711,6 +711,7 @@ class ContractAccessPolicyError extends Error {
 const route = useRoute();
 const router = useRouter();
 const session = useSessionStore();
+const PROJECT_CONTEXT_CHANGED_EVENT = 'sc:project-context-changed';
 
 function resolveWorkspaceContextQuery() {
   return readWorkspaceContext(route.query as Record<string, unknown>);
@@ -5865,6 +5866,32 @@ watch(
   { immediate: true },
 );
 
+function projectContextChangedProjectId(event: Event): number {
+  const detail = event instanceof CustomEvent && event.detail && typeof event.detail === 'object'
+    ? event.detail as Record<string, unknown>
+    : {};
+  return Number(detail.selected_project_id || session.projectContext?.selected?.id || 0) || 0;
+}
+
+function handleProjectContextChanged(event: Event): void {
+  const selectedProjectId = projectContextChangedProjectId(event);
+  if (model.value === 'project.project' && selectedProjectId > 0) {
+    void router.replace({
+      name: 'record',
+      params: { model: 'project.project', id: String(selectedProjectId) },
+      query: resolveWorkspaceContextQuery(),
+    });
+    return;
+  }
+  void router.replace({
+    path: '/s/projects.list',
+    query: {
+      ...resolveWorkspaceContextQuery(),
+      ...(selectedProjectId > 0 ? { project_id: String(selectedProjectId) } : {}),
+    },
+  });
+}
+
 watch(
   () => [
     intakeAutosaveKey.value,
@@ -5882,11 +5909,19 @@ watch(
   },
 );
 
-if (typeof document !== 'undefined') {
-  document.addEventListener('keydown', onRelationDialogDocumentKeydown);
-}
+onMounted(() => {
+  if (typeof window !== 'undefined') {
+    window.addEventListener(PROJECT_CONTEXT_CHANGED_EVENT, handleProjectContextChanged);
+  }
+  if (typeof document !== 'undefined') {
+    document.addEventListener('keydown', onRelationDialogDocumentKeydown);
+  }
+});
 
 onBeforeUnmount(() => {
+  if (typeof window !== 'undefined') {
+    window.removeEventListener(PROJECT_CONTEXT_CHANGED_EVENT, handleProjectContextChanged);
+  }
   if (typeof document !== 'undefined') {
     document.removeEventListener('keydown', onRelationDialogDocumentKeydown);
   }

--- a/frontend/apps/web/src/stores/session.ts
+++ b/frontend/apps/web/src/stores/session.ts
@@ -355,7 +355,7 @@ export interface SessionState {
 }
 
 const DB_SCOPE = String(config.odooDb || 'default').trim() || 'default';
-const STORAGE_KEY = `sc_frontend_session_v0_4:${DB_SCOPE}`;
+const STORAGE_KEY = `sc_frontend_session_v0_5:${DB_SCOPE}`;
 const TOKEN_STORAGE_KEY_LEGACY = 'sc_auth_token';
 const TOKEN_STORAGE_KEY_SCOPED = `sc_auth_token:${DB_SCOPE}`;
 
@@ -445,6 +445,18 @@ function normalizeProjectContext(raw: unknown): ProjectContextContract | null {
       scope: asText(persistence.scope),
       server_preference: Boolean(persistence.server_preference),
     } : undefined,
+  };
+}
+
+function projectContextStorageSnapshot(raw: ProjectContextContract | null): ProjectContextContract | null {
+  if (!raw) return null;
+  return {
+    ...raw,
+    // Selector options are a live backend contract. Persisting them makes the
+    // sidebar dropdown look stale after contract/schema upgrades.
+    options: [],
+    total: raw.selected ? 1 : 0,
+    query: '',
   };
 }
 
@@ -727,7 +739,7 @@ export const useSessionStore = defineStore('session', {
           this.sceneVersion = parsed.sceneVersion ?? null;
           this.roleSurface = parsed.roleSurface ?? null;
           this.roleSurfaceMap = parsed.roleSurfaceMap ?? {};
-          this.projectContext = normalizeProjectContext(parsed.projectContext) ?? null;
+          this.projectContext = projectContextStorageSnapshot(normalizeProjectContext(parsed.projectContext));
           this.capabilityCatalog = parsed.capabilityCatalog ?? {};
           this.sceneActionHints = parsed.sceneActionHints ?? {};
           this.capabilityGroups = parsed.capabilityGroups ?? [];
@@ -832,7 +844,7 @@ export const useSessionStore = defineStore('session', {
         sceneVersion: this.sceneVersion,
         roleSurface: this.roleSurface,
         roleSurfaceMap: this.roleSurfaceMap,
-        projectContext: this.projectContext,
+        projectContext: projectContextStorageSnapshot(this.projectContext),
         capabilityCatalog: this.capabilityCatalog,
         sceneActionHints: this.sceneActionHints,
         capabilityGroups: this.capabilityGroups,


### PR DESCRIPTION
## Summary

- 撤回宽松兼容解析策略，当前项目下拉仍严格消费既有 `system.init.project_context` 契约。
- 将前端 session storage key 从 `v0_4` 提升到 `v0_5`，避免契约 v2 前后的旧本地缓存继续污染当前项目下拉。
- 持久化 session 时不再保存 `projectContext.options`；下拉 options 属于实时后端契约，应由 `system.init` / `project.context.search` 刷新提供。
- 修复搜索框回车会自动选择第一个项目的问题：回车现在只提交搜索刷新候选，只有点击候选才锁定当前项目。
- 回车提交搜索时直接读取输入框当前值，避免键盘事件早于 `v-model` 刷新导致搜索没有使用最新关键字。
- 修复后端 `project.context.search` domain：不可搜索的非存储字段 `display_name` 不再进入 OR domain，避免 Odoo 将搜索退化成全量返回。
- 修复项目表单页切换当前项目的边界：项目详情页切换到另一个项目时跳转到新项目表单，其他业务详情页切换项目时回到项目列表安全入口，不再用新项目上下文原地重载旧记录。
- 仍保留 selected project 的 session 语义，但恢复时只保留最小 selected 状态，避免旧 options 影响侧边栏下拉内容。

## Validation

- `python3 addons/smart_core/tests/test_project_context_boundaries.py`
- `pnpm -C frontend/apps/web typecheck:strict`
- `pnpm -C frontend/apps/web build`
- `git diff --check`
- `make restart`
- Odoo shell: `project.context.search` keyword `五洲` returns `total=4` instead of default `897`.
- Playwright browser verification with `wutao/sc_demo`: enter sends `search="五洲"`, candidate list narrows to 4 五洲 projects, Enter keeps 当前项目 as 全部项目, clicking first option locks 五洲广场办公室装修.
- Playwright browser verification from `/r/project.project/911`: selecting `西昌分部` redirects to `/r/project.project/909`, sidebar shows 西昌分部, and no `PROJECT_SCOPE_DENIED` / 页面加载失败 response appears.

## Notes

- 这不是 v1/v2 字段兼容层，也不吞掉错误契约。
- v2 不应该造成用户体验差异；这次问题由三个点叠加导致：前端本地持久化旧 selector options，后端搜索 domain 包含不可搜索字段导致响应全量返回，以及表单页把项目上下文切换错误处理成旧记录原地重载。