### PR TITLE
Align historical business model projections

### DIFF
--- a/docs/ops/audit/historical_business_data_model_alignment_plan.md
+++ b/docs/ops/audit/historical_business_data_model_alignment_plan.md
@@ -1,0 +1,39 @@
+# Historical Business Data Model Alignment Plan
+
+## Boundary
+
+- Phase 1 replay/import only restores historical facts and source evidence.
+- Phase 2 user-usable initialization must project those facts into current formal business models.
+- User-visible pages are accepted only when the formal model has data, the user can read it, and the model/view framework audit passes.
+
+## Current Baseline
+
+| gate | command | current result |
+|---|---|---|
+| Formal backfill carrying | `make verify.formal_business_backfill.audit DB_NAME=sc_demo` | PASS, `gap_count=0` |
+| User-visible fact alignment | `make verify.user_visible_business_fact_alignment DB_NAME=sc_demo` | PASS, `verified_count=55`, `errors=[]` |
+| Model/view framework | `make verify.model_view.standardization.plan DB_NAME=sc_demo MODEL_VIEW_AUDIT_LOGIN=wutao` | PASS, `P0=0`, `P1=0`, `OK=116` |
+| User-usable runtime | `make history.business.usable.probe DB_NAME=sc_demo` | PASS, `gap_count=0` |
+
+## Added Alignment Scope
+
+`project.cost.ledger` is now part of the historical business data alignment scope:
+
+| source fact | formal visible model | acceptance count in `sc_demo` |
+|---|---|---:|
+| `sc.payment.execution` | `project.cost.ledger` | 12363 |
+| `sc.expense.claim` | `project.cost.ledger` | 27991 |
+| `sc.subcontract.settlement` | `project.cost.ledger` | 52 |
+| `sc.settlement.order` | `project.cost.ledger` | 2 |
+
+The total user-visible cost ledger coverage is 40408 runtime fact rows, with `wutao` read permission parity.
+
+## Rebuild Rule
+
+Any historical replay intended for business use must run:
+
+```bash
+make history.business.usable.init DB_NAME=<db>
+```
+
+That stage now includes `project_cost_ledger_projection_write.py`, so cost ledger pages are rebuilt from backend facts rather than relying on a one-off local projection.

--- a/scripts/migration/history_business_usable_init.sh
+++ b/scripts/migration/history_business_usable_init.sh
@@ -23,6 +23,19 @@ run_odoo_script() {
     bash "$ROOT_DIR/scripts/ops/odoo_shell_exec.sh" <"$script_path"
 }
 
+run_partner_role_alignment() {
+  local label="partner_business_fact_role_alignment"
+  local script_path="$ROOT_DIR/scripts/migration/partner_business_fact_role_alignment_write.py"
+  echo "[history.business.usable.init] step=${label}"
+  DB_NAME="$DB_NAME" \
+    COMPOSE_FILES="${COMPOSE_FILES:-}" \
+    MIGRATION_ARTIFACT_ROOT="$ARTIFACT_ROOT" \
+    MIGRATION_REPLAY_DB_ALLOWLIST="$ALLOWLIST" \
+    MIGRATION_WRITE_MODE=write \
+    PARTNER_FACT_ALIGNMENT_DEMOTE_NO_FACT=1 \
+    bash "$ROOT_DIR/scripts/ops/odoo_shell_exec.sh" <"$script_path"
+}
+
 echo "[history.business.usable.init] db=${DB_NAME} artifact_root=${ARTIFACT_ROOT}"
 
 run_odoo_script real_user_normalize "$ROOT_DIR/scripts/migration/history_real_user_normalize_write.py"
@@ -69,6 +82,7 @@ run_odoo_script material_category_projection "$ROOT_DIR/scripts/migration/fresh_
 run_odoo_script material_catalog_projection "$ROOT_DIR/scripts/migration/fresh_db_material_catalog_projection_write.py"
 run_odoo_script material_stock_document_projection "$ROOT_DIR/scripts/migration/fresh_db_material_stock_document_projection_write.py"
 run_odoo_script project_budget_projection "$ROOT_DIR/scripts/migration/fresh_db_project_budget_projection_write.py"
+run_odoo_script project_cost_ledger_projection "$ROOT_DIR/scripts/migration/project_cost_ledger_projection_write.py"
 run_odoo_script labor_equipment_projection "$ROOT_DIR/scripts/migration/fresh_db_labor_equipment_projection_write.py"
 run_odoo_script work_breakdown_projection "$ROOT_DIR/scripts/migration/fresh_db_work_breakdown_projection_write.py"
 run_odoo_script office_admin_leave_projection "$ROOT_DIR/scripts/migration/fresh_db_office_admin_leave_projection_write.py"
@@ -80,6 +94,7 @@ run_odoo_script document_certificate_projection "$ROOT_DIR/scripts/migration/fre
 run_odoo_script document_borrow_projection "$ROOT_DIR/scripts/migration/fresh_db_document_borrow_projection_write.py"
 run_odoo_script document_admin_archive_projection "$ROOT_DIR/scripts/migration/fresh_db_document_admin_archive_projection_write.py"
 run_odoo_script business_user_priority_menu_plan "$ROOT_DIR/scripts/migration/business_user_priority_menu_plan_write.py"
+run_partner_role_alignment
 run_odoo_script formal_projection_refresh_probe "$ROOT_DIR/scripts/verify/formal_projection_refresh_probe.py"
 run_odoo_script formal_business_backfill_audit_probe "$ROOT_DIR/scripts/verify/formal_business_backfill_audit_probe.py"
 run_odoo_script business_usable_probe "$ROOT_DIR/scripts/migration/history_business_usable_probe.py"

--- a/scripts/migration/user_visible_business_fact_alignment_probe.py
+++ b/scripts/migration/user_visible_business_fact_alignment_probe.py
@@ -68,6 +68,23 @@ def target_values(model_name: str, field_name: str, domain: list[tuple] | None =
     return {clean(value) for value in values if clean(value)}
 
 
+def record_keys(model_name: str, domain: list[tuple] | None = None) -> set[str]:
+    if model_name not in env:  # noqa: F821
+        return set()
+    Model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+    return {f"{model_name}:{record.id}" for record in Model.search(domain or [])}
+
+
+def cost_ledger_source_keys(source_models: Iterable[str]) -> set[str]:
+    if "project.cost.ledger" not in env:  # noqa: F821
+        return set()
+    Ledger = env["project.cost.ledger"].sudo().with_context(active_test=False)  # noqa: F821
+    keys: set[str] = set()
+    for record in Ledger.search([("source_model", "in", list(source_models)), ("source_line_id", "!=", False)]):
+        keys.add(f"{record.source_model}:{record.source_line_id}")
+    return keys
+
+
 def note_marker_values(model_name: str, token: str) -> set[str]:
     if model_name not in env:  # noqa: F821
         return set()
@@ -187,6 +204,40 @@ OUTPUT_REPORT = ARTIFACT_ROOT / "user_visible_business_fact_alignment_probe_repo
 
 payment_target_ids = target_values("payment.request", "legacy_record_id")
 receipt_note_ids = note_marker_values("payment.request", "legacy_receipt_id=")
+cost_ledger_source_models = [
+    "sc.payment.execution",
+    "sc.expense.claim",
+    "sc.subcontract.settlement",
+    "sc.settlement.order",
+]
+cost_ledger_source_ids = (
+    record_keys(
+        "sc.payment.execution",
+        [("project_id", "!=", False), ("paid_amount", ">", 0), ("state", "not in", ["draft", "cancel"])],
+    )
+    | record_keys(
+        "sc.expense.claim",
+        [
+            ("project_id", "!=", False),
+            ("direction", "=", "outflow"),
+            ("amount", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+    )
+    | record_keys(
+        "sc.subcontract.settlement",
+        [("project_id", "!=", False), ("amount_total", ">", 0), ("state", "not in", ["draft", "cancel"])],
+    )
+    | record_keys(
+        "sc.settlement.order",
+        [
+            ("project_id", "!=", False),
+            ("settlement_type", "=", "out"),
+            ("amount_total", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+    )
+)
 
 lanes = [
     lane(
@@ -255,6 +306,14 @@ lanes = [
         target_values("sc.legacy.fund.daily.line", "legacy_line_id"),
         target_model="sc.legacy.fund.daily.line",
         target_domain=[("legacy_line_id", "!=", False)],
+    ),
+    lane(
+        "project_cost_ledger",
+        "成本台账运行事实",
+        cost_ledger_source_ids,
+        cost_ledger_source_keys(cost_ledger_source_models),
+        target_model="project.cost.ledger",
+        target_domain=[("source_model", "in", cost_ledger_source_models)],
     ),
 ]
 

--- a/scripts/verify/formal_business_backfill_audit_probe.py
+++ b/scripts/verify/formal_business_backfill_audit_probe.py
@@ -148,6 +148,52 @@ TARGETS = [
         "target_model": "sc.receipt.income",
         "target_domain": [("source_kind", "=", "receipt_income"), ("receipt_type", "=", "到款确认表")],
     },
+    {
+        "key": "payment_execution_cost_ledger",
+        "source_model": "sc.payment.execution",
+        "source_domain": [
+            ("project_id", "!=", False),
+            ("paid_amount", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+        "target_model": "project.cost.ledger",
+        "target_domain": [("source_model", "=", "sc.payment.execution")],
+    },
+    {
+        "key": "expense_claim_cost_ledger",
+        "source_model": "sc.expense.claim",
+        "source_domain": [
+            ("project_id", "!=", False),
+            ("direction", "=", "outflow"),
+            ("amount", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+        "target_model": "project.cost.ledger",
+        "target_domain": [("source_model", "=", "sc.expense.claim")],
+    },
+    {
+        "key": "subcontract_settlement_cost_ledger",
+        "source_model": "sc.subcontract.settlement",
+        "source_domain": [
+            ("project_id", "!=", False),
+            ("amount_total", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+        "target_model": "project.cost.ledger",
+        "target_domain": [("source_model", "=", "sc.subcontract.settlement")],
+    },
+    {
+        "key": "settlement_order_cost_ledger",
+        "source_model": "sc.settlement.order",
+        "source_domain": [
+            ("project_id", "!=", False),
+            ("settlement_type", "=", "out"),
+            ("amount_total", ">", 0),
+            ("state", "not in", ["draft", "cancel"]),
+        ],
+        "target_model": "project.cost.ledger",
+        "target_domain": [("source_model", "=", "sc.settlement.order")],
+    },
 ]
 
 items = []

--- a/scripts/verify/formal_projection_refresh_probe.py
+++ b/scripts/verify/formal_projection_refresh_probe.py
@@ -68,10 +68,31 @@ def count_legacy_or_all(table_name: str) -> int:
     return count_table(table_name)
 
 
+def partner_business_role_counts() -> dict[str, int]:
+    Partner = env["res.partner"].sudo().with_context(active_test=False)  # noqa: F821
+    facts = Partner._sc_collect_partner_business_facts()
+    customer_ids = {partner_id for partner_id, data in facts.items() if data and data["customer"]}
+    supplier_ids = {
+        partner_id
+        for partner_id, data in facts.items()
+        if data and data["supplier"] and Partner._sc_is_supplier_business_counterparty(Partner.browse(partner_id))
+    }
+    customer_rank_ids = set(Partner.search([("customer_rank", ">", 0)]).ids)
+    supplier_rank_ids = set(Partner.search([("supplier_rank", ">", 0)]).ids)
+    return {
+        "partner_semantic_customer_target": len(customer_ids),
+        "partner_semantic_supplier_target": len(supplier_ids),
+        "partner_semantic_customer_rank_mismatch": len(customer_ids ^ customer_rank_ids),
+        "partner_semantic_supplier_rank_mismatch": len(supplier_ids ^ supplier_rank_ids),
+    }
+
+
 def add_gap(gaps: list[dict[str, object]], key: str, source: int, target: int, detail: str) -> None:
     if source > 0 and target <= 0:
         gaps.append({"key": key, "source": source, "target": target, "detail": detail})
 
+
+partner_role_counts = partner_business_role_counts()
 
 counts = {
     "legacy_account_master": count_table("sc_legacy_account_master"),
@@ -133,94 +154,7 @@ counts = {
     "treasury_reconciliation": count_table("sc_treasury_reconciliation", "source_origin = 'legacy'"),
     "account_transaction_line": count_table("sc_legacy_account_transaction_line"),
     "treasury_ledger": count_legacy_or_all("sc_treasury_ledger"),
-    "partner_semantic_customer_target": count_query(
-        """
-        SELECT DISTINCT partner_id
-          FROM construction_contract
-         WHERE type = 'out'
-           AND partner_id IS NOT NULL
-        UNION
-        SELECT DISTINCT partner_id
-          FROM sc_receipt_income
-         WHERE partner_id IS NOT NULL
-           AND state IN ('received', 'legacy_confirmed')
-           AND COALESCE(amount, 0) > 0
-        UNION
-        SELECT DISTINCT partner_id
-          FROM sc_legacy_receipt_income_fact
-         WHERE partner_id IS NOT NULL
-           AND COALESCE(source_amount, 0) > 0
-        """
-    ),
-    "partner_semantic_supplier_target": count_query(
-        """
-        SELECT DISTINCT partner_id
-          FROM construction_contract
-         WHERE type = 'in'
-           AND partner_id IS NOT NULL
-        UNION
-        SELECT DISTINCT partner_id
-          FROM sc_general_contract
-         WHERE partner_id IS NOT NULL
-        UNION
-        SELECT DISTINCT partner_id
-          FROM sc_payment_execution
-         WHERE partner_id IS NOT NULL
-           AND source_kind = 'actual_outflow'
-           AND state IN ('paid', 'legacy_confirmed')
-           AND COALESCE(paid_amount, 0) > 0
-        """
-    ),
-    "partner_semantic_customer_rank_mismatch": count_query(
-        """
-        WITH customer_target AS (
-            SELECT DISTINCT partner_id
-              FROM construction_contract
-             WHERE type = 'out'
-               AND partner_id IS NOT NULL
-            UNION
-            SELECT DISTINCT partner_id
-              FROM sc_receipt_income
-             WHERE partner_id IS NOT NULL
-               AND state IN ('received', 'legacy_confirmed')
-               AND COALESCE(amount, 0) > 0
-            UNION
-            SELECT DISTINCT partner_id
-              FROM sc_legacy_receipt_income_fact
-             WHERE partner_id IS NOT NULL
-               AND COALESCE(source_amount, 0) > 0
-        )
-        SELECT p.id
-          FROM res_partner p
-          LEFT JOIN customer_target t ON t.partner_id = p.id
-         WHERE (t.partner_id IS NOT NULL) IS DISTINCT FROM (COALESCE(p.customer_rank, 0) > 0)
-        """
-    ),
-    "partner_semantic_supplier_rank_mismatch": count_query(
-        """
-        WITH supplier_target AS (
-            SELECT DISTINCT partner_id
-              FROM construction_contract
-             WHERE type = 'in'
-               AND partner_id IS NOT NULL
-            UNION
-            SELECT DISTINCT partner_id
-              FROM sc_general_contract
-             WHERE partner_id IS NOT NULL
-            UNION
-            SELECT DISTINCT partner_id
-              FROM sc_payment_execution
-             WHERE partner_id IS NOT NULL
-               AND source_kind = 'actual_outflow'
-               AND state IN ('paid', 'legacy_confirmed')
-               AND COALESCE(paid_amount, 0) > 0
-        )
-        SELECT p.id
-          FROM res_partner p
-          LEFT JOIN supplier_target t ON t.partner_id = p.id
-         WHERE (t.partner_id IS NOT NULL) IS DISTINCT FROM (COALESCE(p.supplier_rank, 0) > 0)
-        """
-    ),
+    **partner_role_counts,
 }
 
 gaps: list[dict[str, object]] = []


### PR DESCRIPTION
## Summary
- add project cost ledger to historical business usable initialization and user-visible fact alignment
- make formal projection partner role checks reuse the canonical res.partner business-fact semantics
- document the current historical business data model alignment gates and rebuild rule

## Validation
- python3 -m py_compile scripts/migration/user_visible_business_fact_alignment_probe.py scripts/verify/formal_business_backfill_audit_probe.py scripts/verify/formal_projection_refresh_probe.py scripts/migration/project_cost_ledger_projection_write.py
- bash -n scripts/migration/history_business_usable_init.sh
- make verify.formal_business_backfill.audit DB_NAME=sc_demo
- make verify.user_visible_business_fact_alignment DB_NAME=sc_demo
- make verify.prod.sim.formal.projections DB_NAME=sc_demo
- make history.business.usable.probe DB_NAME=sc_demo
- make verify.model_view.standardization.plan DB_NAME=sc_demo MODEL_VIEW_AUDIT_LOGIN=wutao

## Runtime data note
- ran partner_business_fact_role_alignment_write.py on sc_demo with write mode; updated 6740 partners and cleared formal projection role mismatches.