### PR TITLE
Audit form view orchestration boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,7 @@ verify.user_role_approval_matrix.guard: check-compose-project check-compose-env
 verify.user_permission_view_contract_boundary.guard: check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/user_permission_view_contract_boundary_guard.py
 
-.PHONY: verify.form_structure.contract.guard verify.form_structure.contract_runtime.audit verify.form_structure.contract verify.form_view.native_structure.boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit
+.PHONY: verify.form_structure.contract.guard verify.form_structure.contract_runtime.audit verify.form_structure.contract verify.form_view.native_structure.boundary_guard verify.form_view.orchestration_boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit
 verify.form_view.scope.boundary_guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/form_view_scope_boundary_guard.py
 	@python3 scripts/verify/form_view_scope_boundary_guard.py
@@ -647,14 +647,18 @@ verify.form_view.native_structure.boundary_guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/form_view_native_structure_boundary_guard.py
 	@python3 scripts/verify/form_view_native_structure_boundary_guard.py
 
+verify.form_view.orchestration_boundary_guard: guard.prod.forbid
+	@python3 -m py_compile addons/smart_core/core/form_view_orchestration_contract.py scripts/verify/form_view_orchestration_boundary_guard.py
+	@python3 scripts/verify/form_view_orchestration_boundary_guard.py
+
 verify.form_structure.contract.guard: guard.prod.forbid
 	@python3 -m py_compile addons/smart_core/core/unified_page_contract_v2_assembler.py scripts/verify/form_structure_contract_standardizer_guard.py scripts/verify/form_structure_contract_runtime_audit.py
 	@python3 scripts/verify/form_structure_contract_standardizer_guard.py
 
-verify.form_structure.contract_runtime.audit: guard.prod.forbid check-compose-project check-compose-env verify.form_structure.contract.guard verify.form_view.native_structure.boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit
+verify.form_structure.contract_runtime.audit: guard.prod.forbid check-compose-project check-compose-env verify.form_structure.contract.guard verify.form_view.native_structure.boundary_guard verify.form_view.orchestration_boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/form_structure_contract_runtime_audit.sh
 
-verify.form_structure.contract: verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit verify.form_view.native_structure.boundary_guard verify.form_structure.contract_runtime.audit
+verify.form_structure.contract: verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit verify.form_view.native_structure.boundary_guard verify.form_view.orchestration_boundary_guard verify.form_structure.contract_runtime.audit
 	@echo "[OK] verify.form_structure.contract done"
 
 history.users.verify: guard.prod.forbid check-compose-project check-compose-env

--- a/addons/smart_core/core/form_view_orchestration_contract.py
+++ b/addons/smart_core/core/form_view_orchestration_contract.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+"""Boundary contract for business form-view orchestration.
+
+This module is intentionally declarative for now.  It names the layer that must
+own business layout composition before we introduce runtime models/services for
+industry templates and customer view profiles.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .source_authority import build_source_authority_contract
+
+
+SOURCE_KIND = "business_form_view_orchestration_boundary"
+SOURCE_AUTHORITIES = (
+    "odoo_native_view_parse_snapshot",
+    "ir.model.fields",
+    "ir.actions.act_window",
+    "industry_form_view_template",
+    "customer_form_view_profile",
+    "ui.form.field.policy",
+)
+NO_BUSINESS_FACT_AUTHORITY = True
+
+FORM_VIEW_ORCHESTRATION_LAYERS = (
+    "model_capability",
+    "native_view_parse_snapshot",
+    "business_form_orchestration",
+    "contract_projection",
+    "user_preference",
+)
+
+FORM_VIEW_ORCHESTRATOR_INPUTS = (
+    "model_capabilities",
+    "native_view_parse_snapshot",
+    "action_scope",
+    "source_view_scope",
+    "industry_template",
+    "customer_profile",
+    "company_overlay",
+    "role_profile",
+    "field_policy_overlay",
+)
+
+FORM_VIEW_ORCHESTRATOR_OUTPUTS = (
+    "container_tree",
+    "field_order",
+    "visible_field_policy",
+    "business_action_slots",
+    "relation_entry_slots",
+    "collaboration_slots",
+    "source_trace",
+)
+
+PARSER_ALLOWED_OUTPUTS = (
+    "native_layout_snapshot",
+    "native_field_nodes",
+    "native_container_nodes",
+    "native_buttons",
+    "native_modifiers",
+    "native_subviews",
+    "native_chatter",
+)
+
+PARSER_FORBIDDEN_RESPONSIBILITIES = (
+    "industry_template_selection",
+    "customer_profile_selection",
+    "business_group_renaming",
+    "business_field_reordering",
+    "business_action_repositioning",
+    "user_specific_structure",
+)
+
+
+def source_authority_contract() -> dict[str, Any]:
+    return build_source_authority_contract(
+        kind=SOURCE_KIND,
+        authorities=list(SOURCE_AUTHORITIES),
+        no_business_fact_authority=NO_BUSINESS_FACT_AUTHORITY,
+        runtime_carrier="form_view_orchestration_contract",
+    )

--- a/docs/audit/native/form_view_orchestration_boundary_20260515.md
+++ b/docs/audit/native/form_view_orchestration_boundary_20260515.md
@@ -1,0 +1,90 @@
+# 表单视图编排层边界审计
+
+## 结论
+
+当前矛盾不是“要不要借用 Odoo 原生视图”，而是“借用后谁有权决定最终业务视图”。Odoo 原生视图必须借用，解析也必须保留；但解析结果不能直接成为最终用户可见结构。缺失的是一个独立的表单业务编排层。
+
+## 当前事实
+
+| 层 | 当前事实 | 证据文件 | 判断 |
+| --- | --- | --- | --- |
+| Odoo 原生视图输入 | `get_view` / `fields_view_get` 提供合并后的 arch、fields、toolbar | `app_view_config.py`, `contract_Parser.py` | 必须保留，作为输入事实 |
+| 解析层 | `app.view.parser.parse_odoo_view()` 与 fallback 都声明 `no_business_fact_authority=True` | `native_parse_service.py`, `parse_fallback_service.py`, `contract_Parser.py` | 职责声明正确 |
+| 投影缓存层 | `_generate_from_fields_view_get()` 直接把 parser/fallback 结果写入 `arch_parsed` | `app_view_config.py` | 这里混入了“解析即契约”的旧路径 |
+| 页面装配层 | `PageAssembler` 直接读取 `app.view.config.get_contract_api()` 填入 `views[vt]` | `page_assembler.py` | 编排层没有独立出现 |
+| V2 契约层 | `unified_page_contract_v2_assembler` 把 native layout 归一化为容器树，并补语义注解 | `unified_page_contract_v2_assembler.py` | 应只做契约投影，不应成为业务布局决策层 |
+| 低代码字段策略 | 当前只写 `model/action_id/view_id/company_id` 的字段级 overlay | `form_field_configuration.py`, `ui_form_field_policy.py` | 只能作为编排输入，不能代表完整视图定义 |
+| 现有编排能力 | `page_orchestration_v1` 存在，但主要服务页面/场景，不是表单视图编排 | `page_contracts_builder.py`, `page_contract_semantic_orchestration_bridge.py` | 能借鉴机制，不能直接等同表单编排 |
+
+## 新边界
+
+1. **模型能力层**
+   - 负责字段、类型、关系、权限、domain、onchange、button 能力。
+   - 可以直接借用 Odoo。
+
+2. **原生视图解析层**
+   - 负责保真解析 Odoo 原生结构：sheet、group、notebook/page、field、button、modifiers、subviews、chatter。
+   - 只能产出 `native_view_parse_snapshot`。
+   - 不负责行业模板选择、客户视图 profile、业务分组命名、业务字段重排。
+
+3. **表单业务编排层**
+   - 唯一负责最终业务结构。
+   - 输入包括：模型能力、原生解析快照、action/view scope、行业模板、客户 profile、公司 overlay、角色 profile、字段策略 overlay。
+   - 输出包括：容器树、字段顺序、字段显隐、业务动作槽位、关系入口槽位、协作槽位、来源追踪。
+
+4. **契约投影层**
+   - 只把编排结果投影成前端契约。
+   - 可以做 schema 归一化、组件映射、状态映射。
+   - 不负责决定哪些字段属于哪个业务分组。
+
+5. **用户偏好层**
+   - 只能保存折叠状态、列宽、最近筛选等弱偏好。
+   - 不能参与结构事实和字段策略。
+
+## 当前主要缺口
+
+1. 缺少 `FormViewOrchestrator` 运行时服务。
+2. 缺少行业模板与客户表单 profile 的持久模型。
+3. `app.view.config.arch_parsed` 当前命名和职责偏旧，实际上混合了 native parse 与最终契约输入。
+4. 低代码入口当前编辑字段策略，未来应编辑“表单编排 profile 输入”。
+5. V2 assembler 里仍有语义猜测逻辑，只能保留为内部 annotation，不能上升为业务结构事实。
+
+## 调整改进方向
+
+### P0：锁边界
+
+- Parser 和 fallback 继续保真解析，不做业务命名和业务重排。
+- `PageAssembler` 不再新增业务布局规则；新增规则必须进入表单编排层。
+- 低代码字段策略保持字段级 overlay，不扩展成 page/group/notebook 决策。
+- V2 assembler 的语义补充只能写 `semanticTitle/semanticAnchor/sourceAuthority`，不能写用户可见 `title/label/string`。
+
+### P1：建立表单编排输入模型
+
+- `ui.form.view.template`：行业模板，定义行业默认分组、字段区域、动作槽位。
+- `ui.form.view.profile`：客户/公司/角色/动作/视图 profile，绑定 `model/action_id/view_id/company_id/role_key`。
+- `ui.form.view.profile.line`：字段落位、顺序、显示名、显隐、必填、默认折叠等。
+
+### P2：建立表单编排服务
+
+- `FormViewOrchestrator.compose(...)` 接收模型能力、native parse snapshot、template/profile/policy。
+- 输出 orchestrated contract，并保留每个节点的 `source_trace`。
+- `app.view.config` 存储编排后的 projection，同时保留 native parse snapshot 指纹。
+
+### P3：迁移低代码入口
+
+- 当前“字段顺序/显示名称/新增字段/分组改名”都应写入 profile。
+- `ui.form.field.policy` 降级为字段 overlay 兼容层，最终由 orchestrator 消费。
+- 前端继续无脑渲染契约，不理解 Odoo 原生视图、不理解行业模板。
+
+## 门禁
+
+```bash
+make verify.form_view.orchestration_boundary_guard
+```
+
+门禁先锁住方向：
+
+- parser/fallback 必须声明无业务事实权威。
+- 语义标准化不能写用户可见 `title/label/string`。
+- 低代码字段策略不能新增用户结构 scope。
+- 新增表单结构决策必须指向 `business_form_orchestration` 边界。

--- a/scripts/verify/form_view_orchestration_boundary_guard.py
+++ b/scripts/verify/form_view_orchestration_boundary_guard.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Guard business form-view orchestration boundaries."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTRACT = ROOT / "addons/smart_core/core/form_view_orchestration_contract.py"
+NATIVE_PARSE = ROOT / "addons/smart_core/app_config_engine/services/native_parse_service.py"
+FALLBACK_PARSE = ROOT / "addons/smart_core/app_config_engine/services/parse_fallback_service.py"
+ODOO_PARSER = ROOT / "addons/smart_core/app_config_engine/services/view_Parser/contract_Parser.py"
+V2_ASSEMBLER = ROOT / "addons/smart_core/core/unified_page_contract_v2_assembler.py"
+FIELD_HANDLER = ROOT / "addons/smart_core/handlers/form_field_configuration.py"
+FIELD_POLICY = ROOT / "addons/smart_core/model/ui_form_field_policy.py"
+DOC = ROOT / "docs/audit/native/form_view_orchestration_boundary_20260515.md"
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _assert(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def _function_body(source: str, name: str) -> str:
+    marker = f"def {name}"
+    start = source.find(marker)
+    if start < 0:
+        return ""
+    next_def = source.find("\ndef ", start + len(marker))
+    next_class = source.find("\nclass ", start + len(marker))
+    stops = [idx for idx in (next_def, next_class) if idx > start]
+    end = min(stops) if stops else len(source)
+    return source[start:end]
+
+
+def main() -> int:
+    errors: list[str] = []
+    contract = _read(CONTRACT)
+    native_parse = _read(NATIVE_PARSE)
+    fallback_parse = _read(FALLBACK_PARSE)
+    odoo_parser = _read(ODOO_PARSER)
+    v2 = _read(V2_ASSEMBLER)
+    field_handler = _read(FIELD_HANDLER)
+    field_policy = _read(FIELD_POLICY)
+    doc = _read(DOC)
+
+    for label, source in (
+        ("NativeParseService", native_parse),
+        ("ParseFallbackService", fallback_parse),
+        ("OdooViewParser", odoo_parser),
+    ):
+        _assert(
+            "NO_BUSINESS_FACT_AUTHORITY = True" in source and '"no_business_fact_authority"' in source,
+            f"{label} must remain parse/projection only",
+            errors,
+        )
+
+    _assert(
+        "business_form_orchestration" in contract
+        and "PARSER_FORBIDDEN_RESPONSIBILITIES" in contract
+        and "FORM_VIEW_ORCHESTRATOR_INPUTS" in contract,
+        "form view orchestration boundary contract must name inputs and forbidden parser responsibilities",
+        errors,
+    )
+    _assert(
+        "industry_form_view_template" in contract and "customer_form_view_profile" in contract,
+        "orchestration boundary must include industry template and customer profile authorities",
+        errors,
+    )
+
+    semantic_body = _function_body(v2, "_apply_semantic_container_annotation")
+    _assert(
+        "semanticTitle" in semantic_body and "semanticAnchor" in semantic_body,
+        "semantic standardizer must write semantic annotations",
+        errors,
+    )
+    _assert(
+        'node["title"]' not in semantic_body
+        and 'node["label"]' not in semantic_body
+        and 'node["string"]' not in semantic_body,
+        "semantic standardizer must not write user-visible container labels",
+        errors,
+    )
+
+    _assert(
+        '"action_id"' in field_handler
+        and '"view_id"' in field_handler
+        and '"company_id"' in field_handler,
+        "low-code field handlers must keep action/view/company field policy scope",
+        errors,
+    )
+    _assert(
+        "user_id" not in field_policy,
+        "ui.form.field.policy must not introduce user-specific structural scope",
+        errors,
+    )
+
+    for phrase in (
+        "缺失的是一个独立的表单业务编排层",
+        "原生视图解析层",
+        "表单业务编排层",
+        "契约投影层",
+        "ui.form.view.template",
+        "ui.form.view.profile",
+        "FormViewOrchestrator.compose",
+    ):
+        _assert(phrase in doc, f"boundary audit doc missing phrase: {phrase}", errors)
+
+    if errors:
+        print("[form_view_orchestration_boundary_guard] FAIL")
+        for error in errors:
+            print(f" - {error}")
+        return 1
+    print("[form_view_orchestration_boundary_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- lock the form-view architecture fact that Odoo native views and parser output are inputs, not the final business contract
- add a declarative form-view orchestration boundary contract naming parser limits, orchestration inputs, and expected outputs
- add a boundary audit document and Makefile guard for future form-structure changes

## Validation
- python3 -m py_compile addons/smart_core/core/form_view_orchestration_contract.py scripts/verify/form_view_orchestration_boundary_guard.py
- make verify.form_view.orchestration_boundary_guard
- make verify.form_view.native_structure.boundary_guard
- git diff --check