### PR TITLE
完善用户数据删除与业务分组契约

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2172,6 +2172,9 @@ verify.frontend.group_summary_runtime.guard: guard.prod.forbid
 verify.frontend.grouped_rows_runtime.guard: guard.prod.forbid
 	@python3 scripts/verify/grouped_rows_runtime_guard.py
 
+verify.payment_request_receipt_type.browser_group_smoke: guard.prod.forbid
+	@node scripts/verify/payment_request_receipt_type_browser_group_smoke.js
+
 verify.frontend.grouped_pagination_semantic.guard: guard.prod.forbid
 	@python3 scripts/verify/grouped_pagination_semantic_guard.py
 
@@ -2329,6 +2332,10 @@ verify.user_delete_data.closure_guard: guard.prod.forbid
 .PHONY: verify.receipt_income_type_mapping.guard
 verify.receipt_income_type_mapping.guard: guard.prod.forbid
 	@python3 scripts/verify/receipt_income_type_mapping_guard.py
+
+.PHONY: verify.payment_request_receipt_type.guard
+verify.payment_request_receipt_type.guard: guard.prod.forbid
+	@python3 scripts/verify/payment_request_receipt_type_guard.py
 
 verify.capability.lint: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) bash scripts/verify/capability_lint.sh

--- a/Makefile
+++ b/Makefile
@@ -630,7 +630,7 @@ verify.user_role_approval_matrix.guard: check-compose-project check-compose-env
 verify.user_permission_view_contract_boundary.guard: check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/user_permission_view_contract_boundary_guard.py
 
-.PHONY: verify.form_structure.contract.guard verify.form_structure.contract_runtime.audit verify.form_structure.contract verify.form_view.native_structure.boundary_guard verify.view.orchestration_boundary_guard verify.view.orchestration_user_surface.browser verify.form_view.orchestration_boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit
+.PHONY: verify.form_structure.contract.guard verify.form_structure.contract_runtime.audit verify.form_structure.contract verify.form_view.native_structure.boundary_guard verify.view.orchestration_boundary_guard verify.view.orchestration_user_surface.browser verify.form_view.orchestration_boundary_guard verify.form_view.scope.boundary_guard verify.form_view.scope.runtime_chain_guard verify.form_view.scope.action_projection_audit verify.action_default_group.contract_audit
 verify.form_view.scope.boundary_guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/form_view_scope_boundary_guard.py
 	@python3 scripts/verify/form_view_scope_boundary_guard.py
@@ -642,6 +642,10 @@ verify.form_view.scope.runtime_chain_guard: guard.prod.forbid
 verify.form_view.scope.action_projection_audit: guard.prod.forbid check-compose-project check-compose-env
 	@python3 -m py_compile scripts/verify/form_view_scope_action_projection_audit.py
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/verify/form_view_scope_action_projection_audit.sh
+
+verify.action_default_group.contract_audit: guard.prod.forbid check-compose-project check-compose-env
+	@python3 -m py_compile scripts/verify/action_default_group_contract_audit.py
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/action_default_group_contract_audit.py
 
 verify.form_view.native_structure.boundary_guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/form_view_native_structure_boundary_guard.py

--- a/Makefile
+++ b/Makefile
@@ -2175,6 +2175,12 @@ verify.frontend.grouped_rows_runtime.guard: guard.prod.forbid
 verify.payment_request_receipt_type.browser_group_smoke: guard.prod.forbid
 	@node scripts/verify/payment_request_receipt_type_browser_group_smoke.js
 
+verify.invoice_entry_fact.contract_guard: guard.prod.forbid
+	@python3 scripts/verify/invoice_entry_fact_contract_guard.py
+
+verify.invoice_entry_fact.runtime_smoke: guard.prod.forbid
+	@node scripts/verify/invoice_entry_fact_runtime_smoke.js
+
 verify.frontend.grouped_pagination_semantic.guard: guard.prod.forbid
 	@python3 scripts/verify/grouped_pagination_semantic_guard.py
 

--- a/Makefile
+++ b/Makefile
@@ -2181,6 +2181,9 @@ verify.invoice_entry_fact.contract_guard: guard.prod.forbid
 verify.invoice_entry_fact.runtime_smoke: guard.prod.forbid
 	@node scripts/verify/invoice_entry_fact_runtime_smoke.js
 
+verify.invoice_entry_fact.browser_smoke: guard.prod.forbid
+	@node scripts/verify/invoice_entry_fact_browser_smoke.js
+
 verify.frontend.grouped_pagination_semantic.guard: guard.prod.forbid
 	@python3 scripts/verify/grouped_pagination_semantic_guard.py
 

--- a/Makefile
+++ b/Makefile
@@ -2322,6 +2322,14 @@ verify.e2e.ops_batch_smoke: guard.prod.forbid check-compose-project check-compos
 verify.list_batch_action.closure_guard: guard.prod.forbid
 	@python3 scripts/verify/list_batch_action_closure_guard.py
 
+.PHONY: verify.user_delete_data.closure_guard
+verify.user_delete_data.closure_guard: guard.prod.forbid
+	@python3 scripts/verify/user_delete_data_closure_guard.py
+
+.PHONY: verify.receipt_income_type_mapping.guard
+verify.receipt_income_type_mapping.guard: guard.prod.forbid
+	@python3 scripts/verify/receipt_income_type_mapping_guard.py
+
 verify.capability.lint: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) bash scripts/verify/capability_lint.sh
 

--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -154,6 +154,71 @@ API_DATA_MUTATION_POLICIES = {
         "source": "smart_construction_core",
     },
 }
+
+DRAFT_DELETE_ALLOWED_STATES = ("cancel", "cancelled", "draft")
+
+
+def _state_unlink_policy(model_name: str, business_label: str, allowed_states=DRAFT_DELETE_ALLOWED_STATES):
+    return {
+        "allowed": True,
+        "delete_mode": "unlink",
+        "policy_kind": "state_limited_business_document",
+        "state_field": "state",
+        "allowed_states": list(allowed_states),
+        "reason_code": "DRAFT_BUSINESS_DOCUMENT_DELETE_ALLOWED",
+        "message": f"允许删除未形成业务事实的{business_label}；仅限草稿/取消等未提交状态，并继续受模型 ACL 与记录规则约束。",
+        "source": "smart_construction_core",
+    }
+
+
+API_DATA_DRAFT_UNLINK_POLICIES = {
+    "construction.contract": _state_unlink_policy("construction.contract", "合同记录"),
+    "construction.contract.income": _state_unlink_policy("construction.contract.income", "收入合同"),
+    "construction.contract.expense": _state_unlink_policy("construction.contract.expense", "支出合同"),
+    "payment.request": _state_unlink_policy("payment.request", "付款申请"),
+    "sc.general.contract": _state_unlink_policy("sc.general.contract", "综合合同"),
+    "sc.expense.claim": _state_unlink_policy("sc.expense.claim", "费用与保证金单据"),
+    "sc.payment.execution": _state_unlink_policy("sc.payment.execution", "付款执行单"),
+    "sc.receipt.income": _state_unlink_policy("sc.receipt.income", "收款收入登记"),
+    "sc.fund.account.operation": _state_unlink_policy("sc.fund.account.operation", "资金账户操作单"),
+    "sc.settlement.order": _state_unlink_policy("sc.settlement.order", "结算单"),
+    "sc.settlement.adjustment": _state_unlink_policy("sc.settlement.adjustment", "结算调整单"),
+    "sc.material.purchase.request": _state_unlink_policy("sc.material.purchase.request", "材料采购申请"),
+    "sc.material.acceptance": _state_unlink_policy("sc.material.acceptance", "材料验收单"),
+    "sc.material.inbound": _state_unlink_policy("sc.material.inbound", "材料入库单"),
+    "sc.material.outbound": _state_unlink_policy("sc.material.outbound", "材料出库单"),
+    "sc.material.rfq": _state_unlink_policy("sc.material.rfq", "材料询比价"),
+    "sc.material.settlement": _state_unlink_policy("sc.material.settlement", "材料结算单"),
+    "sc.material.rental.plan": _state_unlink_policy("sc.material.rental.plan", "材料租赁计划"),
+    "sc.material.rental.order": _state_unlink_policy("sc.material.rental.order", "材料租赁订单"),
+    "sc.material.rental.settlement": _state_unlink_policy("sc.material.rental.settlement", "材料租赁结算"),
+    "sc.labor.plan": _state_unlink_policy("sc.labor.plan", "劳务计划"),
+    "sc.labor.request": _state_unlink_policy("sc.labor.request", "劳务申请"),
+    "sc.labor.usage": _state_unlink_policy("sc.labor.usage", "劳务使用记录"),
+    "sc.labor.settlement": _state_unlink_policy("sc.labor.settlement", "劳务结算"),
+    "sc.labor.price": _state_unlink_policy("sc.labor.price", "劳务价格单"),
+    "sc.equipment.plan": _state_unlink_policy("sc.equipment.plan", "设备计划"),
+    "sc.equipment.request": _state_unlink_policy("sc.equipment.request", "设备申请"),
+    "sc.equipment.usage": _state_unlink_policy("sc.equipment.usage", "设备使用记录"),
+    "sc.equipment.settlement": _state_unlink_policy("sc.equipment.settlement", "设备结算"),
+    "sc.equipment.price": _state_unlink_policy("sc.equipment.price", "设备价格单"),
+    "sc.safety.plan": _state_unlink_policy("sc.safety.plan", "安全方案"),
+    "sc.safety.disclosure": _state_unlink_policy("sc.safety.disclosure", "安全交底"),
+    "sc.safety.issue": _state_unlink_policy("sc.safety.issue", "安全问题"),
+    "sc.safety.patrol.task": _state_unlink_policy("sc.safety.patrol.task", "安全巡检任务"),
+    "sc.quality.issue": _state_unlink_policy("sc.quality.issue", "质量问题"),
+    "sc.construction.diary": _state_unlink_policy("sc.construction.diary", "施工日志"),
+    "project.progress.entry": _state_unlink_policy("project.progress.entry", "进度填报"),
+    "project.risk.action": _state_unlink_policy("project.risk.action", "风险措施"),
+    "sc.plan": _state_unlink_policy("sc.plan", "项目计划"),
+    "sc.plan.line": _state_unlink_policy("sc.plan.line", "项目计划明细"),
+    "sc.plan.version": _state_unlink_policy("sc.plan.version", "计划版本"),
+    "sc.plan.report": _state_unlink_policy("sc.plan.report", "计划上报"),
+    "tender.bid": _state_unlink_policy("tender.bid", "投标主单", ("prepare", "estimating")),
+    "tender.doc.purchase": _state_unlink_policy("tender.doc.purchase", "投标文件购买申请"),
+    "tender.doc.review": _state_unlink_policy("tender.doc.review", "投标文件审查"),
+    "tender.guarantee": _state_unlink_policy("tender.guarantee", "投标保证金"),
+}
 API_DATA_UNLINK_POLICIES = {
     "construction.contract": {
         "allowed": True,
@@ -282,6 +347,7 @@ API_DATA_UNLINK_POLICIES = {
         "source": "smart_construction_core",
     },
 }
+API_DATA_UNLINK_POLICIES.update(API_DATA_DRAFT_UNLINK_POLICIES)
 API_DATA_UNLINK_ALLOWED_MODELS = list(API_DATA_UNLINK_POLICIES)
 
 MODEL_CODE_MAPPING = {
@@ -734,9 +800,11 @@ def get_api_data_unlink_allowed_model_contributions(env):
         policies["project.project"] = {
             "allowed": True,
             "delete_mode": "unlink",
-            "reason_code": "DELETE_POLICY_ALLOWED",
-            "message": "允许业务配置管理员删除项目；如存在业务依赖会由项目删除规则阻断。",
+            "reason_code": "PROJECT_MASTER_DELETE_ALLOWED",
+            "message": "允许业务配置管理员删除无业务依赖的项目主数据；存在业务依赖时由项目删除规则阻断。",
             "source": "smart_construction_core",
+            "requires_group": "smart_construction_core.group_sc_cap_business_config_admin",
+            "dependency_guard": "project.project._raise_project_unlink_blockers",
         }
     return policies
 

--- a/addons/smart_construction_core/models/core/payment_request.py
+++ b/addons/smart_construction_core/models/core/payment_request.py
@@ -84,6 +84,12 @@ class PaymentRequest(models.Model):
         required=True,
         tracking=True,
     )
+    receipt_type = fields.Char(
+        string="登记类型",
+        index=True,
+        tracking=True,
+        help="收款申请来源登记类型，历史数据来自 C_JFHKLR.type。",
+    )
     # 兼容部分搜索条件（有时被带入 account.move 的 move_type 过滤）
     move_type = fields.Selection(
         [("pay", "付款"), ("receive", "收款")],

--- a/addons/smart_construction_core/views/core/expense_contract_ledger_views.xml
+++ b/addons/smart_construction_core/views/core/expense_contract_ledger_views.xml
@@ -112,7 +112,7 @@
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_contract_read'))]"/>
     </record>
 
-    <record id="action_construction_contract_expense" model="ir.actions.act_window">
+    <record id="action_sc_expense_contract_ledger_alias" model="ir.actions.act_window">
         <field name="name">支出合同</field>
         <field name="res_model">sc.expense.contract.ledger</field>
         <field name="view_mode">tree,form</field>

--- a/addons/smart_construction_core/views/core/invoice_registration_views.xml
+++ b/addons/smart_construction_core/views/core/invoice_registration_views.xml
@@ -5,8 +5,10 @@
             <field name="name">sc.invoice.registration.search</field>
             <field name="model">sc.invoice.registration</field>
             <field name="arch" type="xml">
-                <search string="发票登记">
+                <search string="发票总台账">
                     <field name="name"/>
+                    <field name="source_kind"/>
+                    <field name="direction"/>
                     <field name="document_no"/>
                     <field name="invoice_no"/>
                     <field name="invoice_code"/>
@@ -19,6 +21,9 @@
                     <filter string="进项税额" name="source_kind_input_invoice_tax" domain="[('source_kind', '=', 'input_invoice_tax')]"/>
                     <filter string="销项税额" name="source_kind_output_invoice_tax" domain="[('source_kind', '=', 'output_invoice_tax')]"/>
                     <filter string="预缴税" name="source_kind_prepaid_tax" domain="[('source_kind', '=', 'prepaid_tax')]"/>
+                    <filter string="有发票号" name="has_invoice_no" domain="[('invoice_no', '!=', False), ('invoice_no', '!=', '')]"/>
+                    <filter string="无发票号" name="missing_invoice_no" domain="['|', ('invoice_no', '=', False), ('invoice_no', '=', '')]"/>
+                    <filter string="历史迁移" name="source_origin_legacy" domain="[('source_origin', '=', 'legacy')]"/>
                     <filter string="已确认" name="state_confirmed" domain="[('state', 'in', ['confirmed', 'legacy_confirmed'])]"/>
                     <filter string="已登记" name="state_registered" domain="[('state', '=', 'registered')]"/>
                     <filter string="公司直营" name="operation_direct" domain="[('operation_strategy', '=', 'direct')]"/>
@@ -41,34 +46,36 @@
             <field name="name">sc.invoice.registration.tree</field>
             <field name="model">sc.invoice.registration</field>
             <field name="arch" type="xml">
-                <tree string="发票登记">
+                <tree string="发票总台账">
                     <field name="name"/>
-                    <field name="invoice_date"/>
-                    <field name="document_no"/>
-                    <field name="document_date"/>
-                    <field name="project_id"/>
-                    <field name="operation_strategy"/>
-                    <field name="partner_id"/>
-                    <field name="contract_id"/>
-                    <field name="settlement_id"/>
-                    <field name="direction"/>
                     <field name="source_kind"/>
+                    <field name="direction"/>
+                    <field name="state"/>
+                    <field name="invoice_date"/>
                     <field name="invoice_no"/>
                     <field name="invoice_code"/>
                     <field name="invoice_type"/>
                     <field name="tax_rate"/>
                     <field name="invoice_content"/>
-                    <field name="cost_category_name"/>
                     <field name="amount_no_tax" sum="不含税金额"/>
                     <field name="tax_amount" sum="税额"/>
                     <field name="amount_total" sum="价税合计"/>
+                    <field name="project_id"/>
+                    <field name="operation_strategy"/>
+                    <field name="partner_id"/>
+                    <field name="contract_id" optional="show"/>
+                    <field name="settlement_id" optional="hide"/>
+                    <field name="cost_category_name" optional="show"/>
+                    <field name="document_no" optional="show"/>
+                    <field name="document_date" optional="show"/>
                     <field name="handler_name"/>
                     <field name="invoice_holder"/>
                     <field name="accounting_state"/>
                     <field name="voucher_no"/>
+                    <field name="legacy_source_model" optional="show"/>
+                    <field name="legacy_source_table" optional="show"/>
                     <field name="creator_name" optional="show"/>
                     <field name="created_time" optional="show"/>
-                    <field name="state"/>
                 </tree>
             </field>
         </record>
@@ -147,11 +154,11 @@
         </record>
 
         <record id="action_sc_invoice_registration" model="ir.actions.act_window">
-            <field name="name">发票登记</field>
+            <field name="name">发票总台账</field>
             <field name="res_model">sc.invoice.registration</field>
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_sc_invoice_registration_search"/>
-            <field name="context">{'search_default_group_project': 1}</field>
+            <field name="context">{'search_default_group_source_kind': 1}</field>
             <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')),
                                            (4, ref('smart_construction_core.group_sc_cap_finance_read')),
                                            (4, ref('smart_construction_core.group_sc_cap_finance_user')),
@@ -159,7 +166,7 @@
         </record>
 
         <menuitem id="menu_sc_invoice_registration"
-                  name="发票登记"
+                  name="发票总台账"
                   parent="smart_construction_core.menu_sc_finance_center"
                   action="action_sc_invoice_registration"
                   sequence="37"

--- a/addons/smart_construction_core/views/core/payment_request_views.xml
+++ b/addons/smart_construction_core/views/core/payment_request_views.xml
@@ -9,6 +9,7 @@
                 <tree string="付款/收款申请" decoration-danger="is_overpay_risk">
                     <field name="name"/>
                     <field name="type"/>
+                    <field name="receipt_type" optional="show"/>
                     <field name="project_id"/>
                     <field name="operation_strategy"/>
                     <field name="contract_id"/>
@@ -61,6 +62,7 @@
                             <group>
                                 <field name="name" readonly="1"/>
                                 <field name="type"/>
+                                <field name="receipt_type" invisible="type != 'receive'"/>
                                 <field name="project_id" options="{'no_create': True}"/>
                                 <field name="operation_strategy" readonly="1"/>
                                 <field name="contract_id" domain="[('project_id', '=', project_id)]"/>
@@ -181,6 +183,7 @@
                 <search string="付款/收款申请">
                     <field name="name"/>
                     <field name="project_id"/>
+                    <field name="receipt_type"/>
                     <field name="operation_strategy"/>
                     <field name="partner_id"/>
                     <field name="contract_id"/>
@@ -190,6 +193,8 @@
                     <field name="partner_bank_account"/>
                     <filter string="付款" name="type_pay" domain="[('type', '=', 'pay')]"/>
                     <filter string="收款" name="type_receive" domain="[('type', '=', 'receive')]"/>
+                    <filter string="正常类型收款" name="receipt_type_normal" domain="[('type', '=', 'receive'), ('receipt_type', '=', '正常类型收款')]"/>
+                    <filter string="其他类型收款" name="receipt_type_other" domain="[('type', '=', 'receive'), ('receipt_type', '=', '其他类型收款')]"/>
                     <filter string="公司直营" name="operation_direct" domain="[('operation_strategy', '=', 'direct')]"/>
                     <filter string="联营项目" name="operation_joint" domain="[('operation_strategy', '=', 'joint')]"/>
                     <separator/>
@@ -202,6 +207,7 @@
                     <filter string="按经营策略" name="group_by_operation_strategy" context="{'group_by': 'operation_strategy'}"/>
                     <filter string="按单位" name="group_by_partner_id" context="{'group_by': 'partner_id'}"/>
                     <filter string="按类型" name="group_by_type" context="{'group_by': 'type'}"/>
+                    <filter string="按登记类型" name="group_by_receipt_type" context="{'group_by': 'receipt_type'}"/>
                     <filter string="按成本分类" name="group_by_cost_category_name" context="{'group_by': 'cost_category_name'}"/>
                     <filter string="按状态" name="group_by_state" context="{'group_by': 'state'}"/>
                     <filter string="按申请日期" name="group_by_date_request" context="{'group_by': 'date_request'}"/>
@@ -244,7 +250,7 @@
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_payment_request_search"/>
             <field name="domain">[('type', '=', 'receive')]</field>
-            <field name="context">{'default_type': 'receive', 'search_default_type_receive': 1, 'search_default_group_by_project_id': 1}</field>
+            <field name="context">{'default_type': 'receive', 'search_default_type_receive': 1, 'search_default_group_by_receipt_type': 1, 'search_default_group_by_project_id': 1}</field>
             <field name="groups_id" eval="[(6, 0, [
                 ref('smart_construction_core.group_sc_cap_finance_read'),
                 ref('smart_construction_core.group_sc_cap_finance_user'),

--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -181,16 +181,16 @@
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_invoice_registration_search"/>
         <field name="domain">[('direction', '=', 'input')]</field>
-        <field name="context">{'default_direction': 'input', 'default_source_kind': 'input_invoice_tax', 'search_default_group_project': 1}</field>
+        <field name="context">{'default_direction': 'input', 'default_source_kind': 'input_invoice_tax', 'search_default_group_source_kind': 1}</field>
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_finance_read'))]"/>
     </record>
     <record id="action_sc_invoice_application_user" model="ir.actions.act_window">
-        <field name="name">开票申请</field>
+        <field name="name">销项开票申请</field>
         <field name="res_model">sc.invoice.registration</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_invoice_registration_search"/>
         <field name="domain">[('source_kind', '=', 'output_invoice_tax'), ('direction', '=', 'output')]</field>
-        <field name="context">{'default_source_kind': 'output_invoice_tax', 'default_direction': 'output', 'default_invoice_content': '开票申请', 'search_default_group_project': 1}</field>
+        <field name="context">{'default_source_kind': 'output_invoice_tax', 'default_direction': 'output', 'default_invoice_content': '销项开票申请', 'search_default_group_project': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),
             ref('smart_construction_core.group_sc_cap_finance_read'),
@@ -199,12 +199,12 @@
         ])]"/>
     </record>
     <record id="action_sc_invoice_registration_user" model="ir.actions.act_window">
-        <field name="name">开票登记</field>
+        <field name="name">进项发票登记</field>
         <field name="res_model">sc.invoice.registration</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_invoice_registration_search"/>
         <field name="domain">[('source_kind', '=', 'invoice_registration'), ('direction', '=', 'input')]</field>
-        <field name="context">{'default_source_kind': 'invoice_registration', 'default_direction': 'input', 'default_invoice_content': '开票登记', 'search_default_group_project': 1}</field>
+        <field name="context">{'default_source_kind': 'invoice_registration', 'default_direction': 'input', 'default_invoice_content': '进项发票登记', 'search_default_group_project': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),
             ref('smart_construction_core.group_sc_cap_finance_read'),
@@ -227,12 +227,12 @@
         ])]"/>
     </record>
     <record id="action_sc_invoice_input_report_user" model="ir.actions.act_window">
-        <field name="name">进项上报</field>
+        <field name="name">进项税额上报</field>
         <field name="res_model">sc.invoice.registration</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_invoice_registration_search"/>
         <field name="domain">[('source_kind', '=', 'input_invoice_tax'), ('direction', '=', 'input')]</field>
-        <field name="context">{'default_source_kind': 'input_invoice_tax', 'default_direction': 'input', 'default_invoice_content': '进项上报', 'search_default_group_project': 1}</field>
+        <field name="context">{'default_source_kind': 'input_invoice_tax', 'default_direction': 'input', 'default_invoice_content': '进项税额上报', 'search_default_group_project': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),
             ref('smart_construction_core.group_sc_cap_finance_read'),
@@ -1336,13 +1336,13 @@
               parent="smart_construction_core.menu_sc_finance_center"
               sequence="33"/>
     <menuitem id="menu_sc_invoice_application_user"
-              name="开票申请"
+              name="销项开票申请"
               parent="smart_construction_core.menu_sc_invoice_tax_user_group"
               action="smart_construction_core.action_sc_invoice_application_user"
               sequence="10"
               groups="smart_construction_core.group_sc_cap_business_initiator,smart_construction_core.group_sc_cap_finance_read,smart_construction_core.group_sc_cap_finance_user,smart_construction_core.group_sc_cap_finance_manager"/>
     <menuitem id="menu_sc_invoice_registration_user"
-              name="开票登记"
+              name="进项发票登记"
               parent="smart_construction_core.menu_sc_invoice_tax_user_group"
               action="smart_construction_core.action_sc_invoice_registration_user"
               sequence="20"
@@ -1354,7 +1354,7 @@
               sequence="30"
               groups="smart_construction_core.group_sc_cap_business_initiator,smart_construction_core.group_sc_cap_finance_read,smart_construction_core.group_sc_cap_finance_user,smart_construction_core.group_sc_cap_finance_manager"/>
     <menuitem id="menu_sc_invoice_input_report_user"
-              name="进项上报"
+              name="进项税额上报"
               parent="smart_construction_core.menu_sc_invoice_tax_user_group"
               action="smart_construction_core.action_sc_invoice_input_report_user"
               sequence="40"

--- a/addons/smart_core/app_config_engine/models/app_search_config.py
+++ b/addons/smart_core/app_config_engine/models/app_search_config.py
@@ -488,10 +488,10 @@ class AppSearchConfig(models.Model):
                 filter_fields.append(row)
                 seen_filter.add(fname)
 
-        def add_group(fname, meta):
+        def add_group(fname, meta, *, explicit=False):
             if fname in seen_group:
                 return
-            row = self._normalize_custom_field(fname, meta, mode="group")
+            row = self._normalize_custom_field(fname, meta, mode="group", explicit=explicit)
             if row:
                 group_fields.append(row)
                 seen_group.add(fname)
@@ -500,7 +500,7 @@ class AppSearchConfig(models.Model):
             fname = str((gb or {}).get("field") or gb or '').split(':', 1)[0].strip()
             meta = fields_meta.get(fname)
             if meta:
-                add_group(fname, meta)
+                add_group(fname, meta, explicit=True)
                 add_filter(fname, meta)
 
         for fname, meta in fields_meta.items():
@@ -526,7 +526,7 @@ class AppSearchConfig(models.Model):
             },
         }
 
-    def _normalize_custom_field(self, fname, meta, mode="filter"):
+    def _normalize_custom_field(self, fname, meta, mode="filter", explicit=False):
         field_name = str(fname or '').strip()
         if not field_name or not isinstance(meta, dict):
             return None
@@ -534,7 +534,10 @@ class AppSearchConfig(models.Model):
             return None
         field_type = meta.get('type')
         if mode == "group":
-            if field_type not in ('many2one', 'many2many', 'selection', 'date', 'datetime', 'boolean'):
+            allowed_group_types = ('many2one', 'many2many', 'selection', 'date', 'datetime', 'boolean')
+            if explicit:
+                allowed_group_types = allowed_group_types + ('char',)
+            if field_type not in allowed_group_types:
                 return None
             if field_type == 'many2many' and not meta.get('store', True):
                 return None

--- a/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
+++ b/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
@@ -1341,39 +1341,39 @@ class PageAssembler:
         context = action_context if isinstance(action_context, dict) else {}
         if not context:
             return
-        default_tokens = {
+        default_tokens = [
             str(key).strip()
             for key, value in context.items()
             if str(key).strip().startswith("search_default_") and value
-        }
+        ]
         if not default_tokens:
             return
 
         group_rows = search.get("group_by") if isinstance(search.get("group_by"), list) else []
-        matched = set()
-        for row in group_rows:
-            if not isinstance(row, dict):
-                continue
-            field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
-            key = str(row.get("key") or row.get("name") or field).strip()
-            base_field = field.split(":", 1)[0]
-            candidates = {
-                f"search_default_{key}",
-                f"search_default_group_{field}",
-                f"search_default_group_{base_field}",
-            }
-            if default_tokens & candidates:
-                row["default"] = True
-                matched.add(field or key)
-        if not matched:
+        matched_row = None
+        for token in default_tokens:
+            for row in group_rows:
+                if not isinstance(row, dict):
+                    continue
+                field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
+                key = str(row.get("key") or row.get("name") or field).strip()
+                base_field = field.split(":", 1)[0]
+                candidates = {
+                    f"search_default_{key}",
+                    f"search_default_group_{field}",
+                    f"search_default_group_{base_field}",
+                }
+                if token in candidates:
+                    matched_row = row
+                    break
+            if matched_row is not None:
+                break
+        if matched_row is None:
             return
         for row in group_rows:
             if not isinstance(row, dict):
                 continue
-            field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
-            key = str(row.get("key") or row.get("name") or field).strip()
-            if (field or key) not in matched:
-                row["default"] = False
+            row["default"] = row is matched_row
 
     def _inject_relation_entry_contract(self, data, model_name=""):
         fields = data.get("fields") if isinstance(data, dict) else None

--- a/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
+++ b/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
@@ -315,6 +315,7 @@ class PageAssembler:
             data["search"] = {}
             versions["search"] = 0
         self._inject_search_view_orchestration(data, env=env, model=model, view_context=view_context, versions=versions)
+        self._apply_action_search_defaults(data, effective_context)
         self._inject_view_orchestration_summary(data)
 
         # 4.x) 关系字段维护入口（many2one/many2many/one2many）
@@ -1332,6 +1333,47 @@ class PageAssembler:
             if value:
                 merged[key] = value
         data["search"] = merged
+
+    def _apply_action_search_defaults(self, data, action_context):
+        search = data.get("search") if isinstance(data, dict) else {}
+        if not isinstance(search, dict):
+            return
+        context = action_context if isinstance(action_context, dict) else {}
+        if not context:
+            return
+        default_tokens = {
+            str(key).strip()
+            for key, value in context.items()
+            if str(key).strip().startswith("search_default_") and value
+        }
+        if not default_tokens:
+            return
+
+        group_rows = search.get("group_by") if isinstance(search.get("group_by"), list) else []
+        matched = set()
+        for row in group_rows:
+            if not isinstance(row, dict):
+                continue
+            field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
+            key = str(row.get("key") or row.get("name") or field).strip()
+            base_field = field.split(":", 1)[0]
+            candidates = {
+                f"search_default_{key}",
+                f"search_default_group_{field}",
+                f"search_default_group_{base_field}",
+            }
+            if default_tokens & candidates:
+                row["default"] = True
+                matched.add(field or key)
+        if not matched:
+            return
+        for row in group_rows:
+            if not isinstance(row, dict):
+                continue
+            field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
+            key = str(row.get("key") or row.get("name") or field).strip()
+            if (field or key) not in matched:
+                row["default"] = False
 
     def _inject_relation_entry_contract(self, data, model_name=""):
         fields = data.get("fields") if isinstance(data, dict) else None

--- a/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
+++ b/addons/smart_core/app_config_engine/services/assemblers/page_assembler.py
@@ -1358,10 +1358,15 @@ class PageAssembler:
                 field = str(row.get("field") or row.get("group_by") or row.get("key") or "").strip()
                 key = str(row.get("key") or row.get("name") or field).strip()
                 base_field = field.split(":", 1)[0]
+                semantic_field = base_field[:-3] if base_field.endswith("_id") else base_field
                 candidates = {
                     f"search_default_{key}",
                     f"search_default_group_{field}",
                     f"search_default_group_{base_field}",
+                    f"search_default_group_{semantic_field}",
+                    f"search_default_group_by_{field}",
+                    f"search_default_group_by_{base_field}",
+                    f"search_default_group_by_{semantic_field}",
                 }
                 if token in candidates:
                     matched_row = row

--- a/addons/smart_core/delivery/menu_delivery_convergence_service.py
+++ b/addons/smart_core/delivery/menu_delivery_convergence_service.py
@@ -269,6 +269,9 @@ class MenuDeliveryConvergenceService:
     }
     RENAME_LABELS = {
         "项目台账（试点）": "项目台账",
+        "开票申请": "销项开票申请",
+        "开票登记": "进项发票登记",
+        "进项上报": "进项税额上报",
     }
 
     @classmethod

--- a/addons/smart_core/delivery/menu_service.py
+++ b/addons/smart_core/delivery/menu_service.py
@@ -402,10 +402,14 @@ class MenuService:
             }
             group_order.append(fallback_key)
 
+        convergence_service = MenuDeliveryConvergenceService()
         for menu in self._flatten_policy_menus(policy):
             if not self._policy_menu_user_authorized(menu, native_index, is_admin=is_admin):
                 continue
             converged_menu = dict(menu)
+            renamed = convergence_service.RENAME_LABELS.get(str(converged_menu.get("label") or "").strip())
+            if renamed:
+                converged_menu["label"] = renamed
             converged_menu["delivery_bucket"] = "released_product_policy"
             converged_menu["source_authority"] = self.source_authority_contract()
             menu_id = menu.get("menu_id")

--- a/addons/smart_core/handlers/api_data_unlink.py
+++ b/addons/smart_core/handlers/api_data_unlink.py
@@ -60,6 +60,33 @@ class ApiDataUnlinkHandler(BaseIntentHandler):
     def _delete_policy(self, model: str) -> Dict[str, Any]:
         return resolve_unlink_policy(self.env, model, default_allowed_models=self.ALLOWED_MODELS)
 
+    def _check_record_delete_policy(self, recs, delete_policy: Dict[str, Any]):
+        state_field = str(delete_policy.get("state_field") or "").strip()
+        allowed_states = {
+            str(item or "").strip()
+            for item in (delete_policy.get("allowed_states") or [])
+            if str(item or "").strip()
+        }
+        if not state_field and not allowed_states:
+            return None
+        if not state_field or not allowed_states:
+            return self._err(403, "删除策略缺少状态字段或允许状态配置", REASON_DELETE_POLICY_DENIED)
+        if state_field not in getattr(recs, "_fields", {}):
+            return self._err(403, f"当前模型缺少删除策略要求的状态字段: {state_field}", REASON_DELETE_POLICY_DENIED)
+        invalid_ids = []
+        for rec in recs:
+            value = str(getattr(rec, state_field, "") or "").strip()
+            if value not in allowed_states:
+                invalid_ids.append(rec.id)
+        if invalid_ids:
+            allowed_text = "、".join(sorted(allowed_states))
+            return self._err(
+                400,
+                f"仅允许删除 {state_field} 为 {allowed_text} 的草稿/取消态数据",
+                REASON_BUSINESS_RULE_FAILED,
+            )
+        return None
+
     def _err(self, code: int, message: str, reason_code: str):
         return {
             "ok": False,
@@ -281,8 +308,14 @@ class ApiDataUnlinkHandler(BaseIntentHandler):
                 return {"ok": True, "data": data, "meta": meta}
 
         recs = env_model.browse(ids).exists()
-        if not recs:
+        found_ids = set(recs.ids)
+        missing_ids = [rec_id for rec_id in ids if rec_id not in found_ids]
+        if missing_ids:
             return self._err(404, "记录不存在", REASON_NOT_FOUND)
+
+        policy_error = self._check_record_delete_policy(recs, delete_policy)
+        if policy_error:
+            return policy_error
 
         try:
             env_model.check_access_rights("unlink")
@@ -301,6 +334,7 @@ class ApiDataUnlinkHandler(BaseIntentHandler):
 
         data = {
             "ids": ids,
+            "deleted_count": 0 if dry_run else len(set(ids)),
             "model": model,
             "dry_run": dry_run,
             "delete_policy": delete_policy,

--- a/addons/smart_core/tests/test_api_data_unlink_id_boundaries.py
+++ b/addons/smart_core/tests/test_api_data_unlink_id_boundaries.py
@@ -60,7 +60,10 @@ def _load_handler():
     )
     _install_module(
         "odoo.addons.smart_core.utils.delete_policy",
-        resolve_unlink_policy=lambda env, model, default_allowed_models=None: {"allowed": True, "delete_mode": "unlink"},
+        resolve_unlink_policy=lambda env, model, default_allowed_models=None: env.get(
+            "__delete_policy__",
+            {"allowed": True, "delete_mode": "unlink"},
+        ),
     )
 
     reason_name = "odoo.addons.smart_core.utils.reason_codes"
@@ -100,6 +103,118 @@ class TestApiDataUnlinkIdBoundaries(unittest.TestCase):
         self.assertFalse(result["ok"])
         self.assertEqual(result["code"], 400)
         self.assertEqual(result["error"]["reason_code"], "INVALID_ID")
+
+    def test_partial_missing_ids_rejects_without_unlink(self):
+        model = _FakeModel(existing_ids={1})
+        handler = self.module.ApiDataUnlinkHandler(
+            env={"x.model": model},
+            params={"model": "x.model", "ids": [1, 2]},
+        )
+
+        result = handler.handle()
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], 404)
+        self.assertEqual(result["error"]["reason_code"], "NOT_FOUND")
+        self.assertFalse(model.unlinked)
+
+    def test_dry_run_checks_access_but_does_not_unlink(self):
+        model = _FakeModel(existing_ids={1, 2})
+        handler = self.module.ApiDataUnlinkHandler(
+            env={"x.model": model},
+            params={"model": "x.model", "ids": [1, 2], "dry_run": True},
+        )
+
+        result = handler.handle()
+
+        self.assertTrue(result["ok"])
+        self.assertTrue(result["data"]["dry_run"])
+        self.assertEqual(result["data"]["deleted_count"], 0)
+        self.assertFalse(model.unlinked)
+
+    def test_state_policy_allows_draft_record(self):
+        model = _FakeModel(existing_ids={1}, states={1: "draft"})
+        handler = self.module.ApiDataUnlinkHandler(
+            env={
+                "x.model": model,
+                "__delete_policy__": {
+                    "allowed": True,
+                    "delete_mode": "unlink",
+                    "state_field": "state",
+                    "allowed_states": ["draft", "cancel"],
+                },
+            },
+            params={"model": "x.model", "ids": [1], "dry_run": True},
+        )
+
+        result = handler.handle()
+
+        self.assertTrue(result["ok"])
+        self.assertFalse(model.unlinked)
+
+    def test_state_policy_rejects_submitted_record_without_unlink(self):
+        model = _FakeModel(existing_ids={1}, states={1: "submitted"})
+        handler = self.module.ApiDataUnlinkHandler(
+            env={
+                "x.model": model,
+                "__delete_policy__": {
+                    "allowed": True,
+                    "delete_mode": "unlink",
+                    "state_field": "state",
+                    "allowed_states": ["draft", "cancel"],
+                },
+            },
+            params={"model": "x.model", "ids": [1]},
+        )
+
+        result = handler.handle()
+
+        self.assertFalse(result["ok"])
+        self.assertEqual(result["code"], 400)
+        self.assertEqual(result["error"]["reason_code"], "BUSINESS_RULE_FAILED")
+        self.assertFalse(model.unlinked)
+
+
+class _FakeModel:
+    _fields = {"state": object()}
+
+    def __init__(self, existing_ids, states=None):
+        self.existing_ids = set(existing_ids)
+        self.states = dict(states or {})
+        self.unlinked = False
+
+    def browse(self, ids):
+        return _FakeRecords(self, ids)
+
+    def check_access_rights(self, operation):
+        self.access_operation = operation
+
+
+class _FakeRecords:
+    def __init__(self, model, ids):
+        self.model = model
+        self._fields = model._fields
+        self.requested_ids = list(ids or [])
+        self.ids = [rec_id for rec_id in self.requested_ids if rec_id in model.existing_ids]
+
+    def exists(self):
+        return self
+
+    def __iter__(self):
+        for rec_id in self.ids:
+            yield _FakeRecord(rec_id, self.model.states.get(rec_id, "draft"))
+
+    def check_access_rule(self, operation):
+        self.access_rule_operation = operation
+
+    def unlink(self):
+        self.model.unlinked = True
+
+
+class _FakeRecord:
+    def __init__(self, rec_id, state):
+        self.id = rec_id
+        self.state = state
 
 
 if __name__ == "__main__":

--- a/addons/smart_core/utils/delete_policy.py
+++ b/addons/smart_core/utils/delete_policy.py
@@ -42,7 +42,7 @@ def _normalize_policy(model: str, raw: Any, *, source: str) -> Dict[str, Any]:
     message = str(row.get("message") or "").strip()
     if not message:
         message = "允许删除" if allowed else "当前模型未开放删除"
-    return {
+    normalized = {
         "model": model,
         "allowed": allowed,
         "delete_mode": delete_mode if allowed else "none",
@@ -54,6 +54,20 @@ def _normalize_policy(model: str, raw: Any, *, source: str) -> Dict[str, Any]:
         "requires_record_rule": bool(row.get("requires_record_rule", True)),
         "dry_run_supported": True,
     }
+    for key in (
+        "policy_kind",
+        "state_field",
+        "requires_group",
+        "dependency_guard",
+    ):
+        value = str(row.get(key) or "").strip()
+        if value:
+            normalized[key] = value
+    for key in ("allowed_states", "blocked_states"):
+        values = sorted(_as_model_set(row.get(key)))
+        if values:
+            normalized[key] = values
+    return normalized
 
 
 def _normalize_policy_payload(payload: Any, *, default_allowed_models: Iterable[str] | None = None) -> Dict[str, Dict[str, Any]]:

--- a/frontend/apps/web/src/api/data.ts
+++ b/frontend/apps/web/src/api/data.ts
@@ -189,6 +189,7 @@ export async function unlinkRecord(params: {
   context?: Record<string, unknown>;
   requestId?: string;
   idempotencyKey?: string;
+  dryRun?: boolean;
 }) {
   return intentRequest<ApiDataUnlinkContract>({
     intent: 'api.data.unlink',
@@ -198,6 +199,7 @@ export async function unlinkRecord(params: {
       context: params.context ?? {},
       request_id: params.requestId,
       idempotency_key: params.idempotencyKey,
+      dry_run: Boolean(params.dryRun),
     },
   });
 }

--- a/frontend/apps/web/src/app/runtime/actionViewBatchActionFlowRuntime.ts
+++ b/frontend/apps/web/src/app/runtime/actionViewBatchActionFlowRuntime.ts
@@ -36,11 +36,13 @@ export function resolveBatchDeleteExecutionSeed(options: {
 }): {
   requestAction: 'unlink';
   ifMatchMap: Record<number, string>;
+  dryRunIdempotencyKey: string;
   idempotencyKey: string;
 } {
   return {
     requestAction: 'unlink',
     ifMatchMap: options.buildIfMatchMap(options.selectedIds),
+    dryRunIdempotencyKey: options.buildIdempotencyKey('delete.dry_run', options.selectedIds, { delete_mode: 'unlink', dry_run: true }),
     idempotencyKey: options.buildIdempotencyKey('delete', options.selectedIds, { delete_mode: 'unlink' }),
   };
 }

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1188,8 +1188,9 @@ const selectedCount = computed(() => (props.selectedIds || []).length);
 const selectionActions = computed(() =>
   Array.isArray(props.selectionActions) ? props.selectionActions : [],
 );
+const hasSelectionActions = computed(() => selectionActions.value.length > 0);
 const selectableRows = computed(() => props.records.map((row) => rowId(row)).filter((id): id is number => typeof id === 'number'));
-const showSelectionColumn = computed(() => !!props.onToggleSelection && !!props.onToggleSelectionAll);
+const showSelectionColumn = computed(() => hasSelectionActions.value && !!props.onToggleSelection && !!props.onToggleSelectionAll);
 const showBatchBar = computed(() => showSelectionColumn.value && (selectedCount.value > 0 || Boolean(props.batchMessage)));
 const allSelected = computed(() => {
   const rows = selectableRows.value;

--- a/frontend/apps/web/src/views/ActionView.vue
+++ b/frontend/apps/web/src/views/ActionView.vue
@@ -1762,6 +1762,13 @@ async function runBatchPolicyAction(action: 'archive' | 'activate' | 'delete') {
     });
     batchBusy.value = true;
     try {
+      await unlinkActionViewRecord({
+        model: targetModel,
+        ids: selected,
+        context: resolveEffectiveRequestContext(),
+        idempotencyKey: seed.dryRunIdempotencyKey,
+        dryRun: true,
+      });
       const result = await unlinkActionViewRecord({
         model: targetModel,
         ids: selected,

--- a/scripts/migration/fresh_db_receipt_core_replay_adapter.py
+++ b/scripts/migration/fresh_db_receipt_core_replay_adapter.py
@@ -25,6 +25,7 @@ FIELDS = [
     "amount",
     "date_request",
     "type",
+    "receipt_type",
     "creator_legacy_user_id",
     "creator_name",
     "created_time",
@@ -63,8 +64,21 @@ def extract_legacy_receipt_id(note: str) -> str:
     return note.split(token, 1)[1].split(";", 1)[0].split()[0].strip()
 
 
+def raw_receipt_type_map() -> dict[str, str]:
+    path = REPO_ROOT / "tmp/raw/receipt/receipt.csv"
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return {
+            clean(row.get("Id")): clean(row.get("type"))
+            for row in csv.DictReader(handle)
+            if clean(row.get("Id"))
+        }
+
+
 def main() -> int:
     rows: list[dict[str, str]] = []
+    receipt_types = raw_receipt_type_map()
     root = ET.parse(ASSET_XML).getroot()
     for record in root.findall(".//record[@model='payment.request']"):
         values = field_map(record)
@@ -85,6 +99,7 @@ def main() -> int:
                 "amount": clean(values.get("amount")),
                 "date_request": clean(values.get("date_request")),
                 "type": clean(values.get("type")) or "receive",
+                "receipt_type": clean(values.get("receipt_type")) or receipt_types.get(legacy_receipt_id, ""),
                 "creator_legacy_user_id": clean(values.get("creator_legacy_user_id")),
                 "creator_name": clean(values.get("creator_name")),
                 "created_time": clean(values.get("created_time")),

--- a/scripts/migration/fresh_db_receipt_core_write.py
+++ b/scripts/migration/fresh_db_receipt_core_write.py
@@ -40,6 +40,7 @@ EXPECTED_ROWS = int(os.getenv("FRESH_DB_RECEIPT_CORE_EXPECTED_ROWS", "3652"))
 MIGRATION_MARKER = "[migration:receipt_core]"
 SAFE_FIELDS = {
     "type",
+    "receipt_type",
     "project_id",
     "contract_id",
     "partner_id",
@@ -54,6 +55,7 @@ SNAPSHOT_FIELDS = [
     "request_id",
     "name",
     "type",
+    "receipt_type",
     "project_id",
     "contract_id",
     "partner_id",
@@ -92,8 +94,21 @@ def ref_map(record: ET.Element) -> dict[str, str]:
     return values
 
 
+def raw_receipt_type_map() -> dict[str, str]:
+    path = REPO_ROOT / "tmp/raw/receipt/receipt.csv"
+    if not path.exists():
+        return {}
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return {
+            clean(row.get("Id")): clean(row.get("type"))
+            for row in csv.DictReader(handle)
+            if clean(row.get("Id"))
+        }
+
+
 def load_asset_rows(path: Path) -> list[dict[str, str]]:
     rows: list[dict[str, str]] = []
+    receipt_types = raw_receipt_type_map()
     root = ET.parse(path).getroot()
     for record in root.findall(".//record[@model='payment.request']"):
         values = field_map(record)
@@ -114,6 +129,7 @@ def load_asset_rows(path: Path) -> list[dict[str, str]]:
                 "amount": clean(values.get("amount")),
                 "date_request": clean(values.get("date_request")),
                 "type": clean(values.get("type")) or "receive",
+                "receipt_type": clean(values.get("receipt_type")) or receipt_types.get(legacy_receipt_id, ""),
                 "note": note,
             }
         )
@@ -323,6 +339,7 @@ for index, row in enumerate(rows, start=2):
         request_type = clean(row.get("type")) or "receive"
         vals = {
             "type": request_type,
+            "receipt_type": clean(row.get("receipt_type")) or False,
             "project_id": resolved_project_id,
             "partner_id": resolved_partner_id,
             "amount": float(clean(row.get("amount"))),
@@ -348,6 +365,7 @@ for index, row in enumerate(rows, start=2):
     request_type = "receive" if contract.type == "out" else "pay"
     vals = {
         "type": request_type,
+        "receipt_type": clean(row.get("receipt_type")) or False,
         "project_id": contract.project_id.id or resolved_project_id or 0,
         "contract_id": contract.id,
         "partner_id": contract.partner_id.id or resolved_partner_id or 0,
@@ -382,6 +400,7 @@ try:
                 "request_id": rec.id,
                 "name": rec.name or "",
                 "type": rec.type or "",
+                "receipt_type": rec.receipt_type or "",
                 "project_id": rec.project_id.id or "",
                 "contract_id": rec.contract_id.id or "",
                 "partner_id": rec.partner_id.id or "",

--- a/scripts/migration/fresh_db_receipt_income_from_payment_request_projection_write.py
+++ b/scripts/migration/fresh_db_receipt_income_from_payment_request_projection_write.py
@@ -211,7 +211,7 @@ env.cr.execute(  # noqa: F821
       source.payment_request_id,
       COALESCE(NULLIF(source.document_date, '')::date, source.date_request, CURRENT_DATE),
       NULLIF(source.document_no, ''),
-      '收款申请',
+      COALESCE(NULLIF(source.legacy_receipt_type, ''), '收款申请'),
       NULLIF(source.legacy_receipt_type, ''),
       NULLIF(source.legacy_receipt_subtype, ''),
       NULLIF(source.income_category, ''),

--- a/scripts/migration/receipt_core_asset_generator.py
+++ b/scripts/migration/receipt_core_asset_generator.py
@@ -184,6 +184,7 @@ def write_xml(path: Path, records: list[dict[str, str]]) -> None:
     for row in records:
         record = ET.SubElement(data, "record", {"id": row["external_id"], "model": "payment.request"})
         add_text_field(record, "type", "receive", required=True)
+        add_text_field(record, "receipt_type", row["receipt_type"])
         add_ref_field(record, "project_id", row["project_external_id"])
         if row["contract_external_id"]:
             add_ref_field(record, "contract_id", row["contract_external_id"])
@@ -256,6 +257,7 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
 
         receipt_ids[legacy_receipt_id] += 1
         document_no = clean(row.get("DJBH"))
+        receipt_type = clean(row.get("type"))
         receipt_date = parse_date(first_nonempty(row, ["f_RQ", "LRSJ", "f_LRSJ"]))
         created_time = parse_date(first_nonempty(row, ["LRSJ", "f_LRSJ"]))
         loadable.append(
@@ -275,6 +277,7 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
                 "partner_external_id": partner_external_id or "",
                 "amount": str(amount),
                 "date_request": receipt_date,
+                "receipt_type": receipt_type,
                 "document_no": document_no,
                 "creator_legacy_user_id": first_nonempty(row, ["LRRID", "f_LRRID"]),
                 "creator_name": first_nonempty(row, ["LRR", "f_LRR"]),

--- a/scripts/migration/visible_surface_receipt_core_creator_normalize_write.py
+++ b/scripts/migration/visible_surface_receipt_core_creator_normalize_write.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Backfill receipt request creator facts from the raw receipt source."""
+"""Backfill receipt request visible facts from the raw receipt source."""
 
 from __future__ import annotations
 
@@ -70,6 +70,7 @@ def read_receipt_facts(path: Path) -> dict[str, dict[str, str]]:
         if not legacy_id:
             continue
         facts[legacy_id] = {
+            "receipt_type": clean(row.get("type")),
             "creator_legacy_user_id": first_nonempty(row, ["LRRID", "f_LRRID"]),
             "creator_name": first_nonempty(row, ["LRR", "f_LRR"]),
             "created_time": parse_datetime(first_nonempty(row, ["LRSJ", "f_LRSJ"])),
@@ -104,6 +105,8 @@ for request in requests:
     if not fact:
         continue
     vals = {}
+    if fact["receipt_type"] and request.receipt_type != fact["receipt_type"]:
+        vals["receipt_type"] = fact["receipt_type"]
     if fact["creator_legacy_user_id"] and not request.creator_legacy_user_id:
         vals["creator_legacy_user_id"] = fact["creator_legacy_user_id"]
     if fact["creator_name"]:
@@ -129,9 +132,10 @@ payload = {
     "source_with_creator_name": with_creator_source,
     "source_with_created_time": with_created_source,
     "updated_rows": updated,
+    "receipt_requests_with_receipt_type": Request.search_count([("type", "=", "receive"), ("note", "ilike", "[migration:receipt_core]"), ("receipt_type", "!=", False)]),
     "receipt_requests_with_creator_name": Request.search_count([("type", "=", "receive"), ("note", "ilike", "[migration:receipt_core]"), ("creator_name", "!=", False)]),
     "receipt_requests_with_created_time": Request.search_count([("type", "=", "receive"), ("note", "ilike", "[migration:receipt_core]"), ("created_time", "!=", False)]),
-    "decision": "receipt_core_creator_facts_backfilled_from_raw_source",
+    "decision": "receipt_core_visible_facts_backfilled_from_raw_source",
 }
 write_json(artifact_root() / "visible_surface_receipt_core_creator_normalize_write_result_v1.json", payload)
 print("VISIBLE_SURFACE_RECEIPT_CORE_CREATOR_NORMALIZE_WRITE=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))

--- a/scripts/verify/action_default_group_contract_audit.py
+++ b/scripts/verify/action_default_group_contract_audit.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Audit action context default-group projection.
+
+Run through ``scripts/ops/odoo_shell_exec.sh`` so Odoo provides the global
+``env``.  The audit checks every ``ir.actions.act_window`` that carries a
+``search_default_group_*`` context key and verifies that the custom page
+contract projects at most one matching default group.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from odoo.addons.smart_core.app_config_engine.services.dispatchers.action_dispatcher import (
+    ActionDispatcher,
+)
+from odoo.tools.safe_eval import safe_eval
+
+
+ALLOWED_UNMATCHED = {
+    ("account.analytic.line", "search_default_group_by_analytic_account"),
+}
+KEY_ACTION_NAMES = {
+    "发票总台账",
+    "发票分类汇总表",
+    "发票分析报表",
+    "收款申请",
+    "支付申请",
+    "项目预算",
+    "施工方案",
+    "风险项",
+}
+
+
+def _context_tokens(action: Any) -> list[str]:
+    try:
+        context = safe_eval(action.context or "{}") or {}
+    except Exception:
+        context = {}
+    return [
+        str(key)
+        for key, value in context.items()
+        if str(key).startswith("search_default_group_") and value
+    ]
+
+
+def _group_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    search = payload.get("search") or {}
+    group_by = search.get("group_by") or []
+    return [row for row in group_by if isinstance(row, dict)]
+
+
+def _default_rows(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    return [row for row in _group_rows(payload) if bool(row.get("default"))]
+
+
+def _row_identity(row: dict[str, Any]) -> list[str]:
+    return [
+        str(row.get("field") or ""),
+        str(row.get("key") or ""),
+    ]
+
+
+def main() -> int:
+    dispatcher = ActionDispatcher(env, env["ir.model"].sudo().env)  # noqa: F821
+    Action = env["ir.actions.act_window"].sudo()  # noqa: F821
+    actions = Action.search([("context", "ilike", "search_default_group_")], order="id")
+
+    checked = 0
+    errors: list[dict[str, Any]] = []
+    unmatched: list[dict[str, Any]] = []
+    multi_default: list[dict[str, Any]] = []
+    defaults: list[dict[str, Any]] = []
+
+    for action in actions:
+        tokens = _context_tokens(action)
+        if not tokens:
+            continue
+        checked += 1
+        try:
+            payload, _versions = dispatcher.dispatch(
+                {
+                    "subject": "action",
+                    "action_id": action.id,
+                    "view_type": action.view_mode or "tree,form",
+                    "context": {},
+                }
+            )
+        except Exception as exc:
+            errors.append(
+                {
+                    "id": action.id,
+                    "name": action.name,
+                    "model": action.res_model,
+                    "tokens": tokens,
+                    "error": str(exc),
+                }
+            )
+            continue
+
+        default_rows = _default_rows(payload)
+        if len(default_rows) > 1:
+            multi_default.append(
+                {
+                    "id": action.id,
+                    "name": action.name,
+                    "model": action.res_model,
+                    "tokens": tokens,
+                    "defaults": [_row_identity(row) for row in default_rows],
+                }
+            )
+        elif len(default_rows) == 1:
+            row = default_rows[0]
+            defaults.append(
+                {
+                    "id": action.id,
+                    "name": action.name,
+                    "model": action.res_model,
+                    "tokens": tokens,
+                    "default": _row_identity(row),
+                }
+            )
+        else:
+            unmatched.append(
+                {
+                    "id": action.id,
+                    "name": action.name,
+                    "model": action.res_model,
+                    "tokens": tokens,
+                }
+            )
+
+    unexpected_unmatched = [
+        row
+        for row in unmatched
+        if not all((row["model"], token) in ALLOWED_UNMATCHED for token in row["tokens"])
+    ]
+    sample_defaults = [
+        row
+        for row in defaults
+        if row["name"] in KEY_ACTION_NAMES or len(row["tokens"]) > 1
+    ]
+    result = {
+        "action_count": len(actions),
+        "checked": checked,
+        "default_count": len(defaults),
+        "allowed_unmatched": unmatched,
+        "unexpected_unmatched": unexpected_unmatched,
+        "multi_default": multi_default,
+        "errors": errors,
+        "sample_defaults": sample_defaults,
+    }
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+    if errors or multi_default or unexpected_unmatched:
+        print("[verify.action_default_group.contract_audit] FAIL")
+        return 1
+    print("[verify.action_default_group.contract_audit] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/invoice_entry_fact_browser_smoke.js
+++ b/scripts/verify/invoice_entry_fact_browser_smoke.js
@@ -1,0 +1,100 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+
+const { chromium } = require(path.resolve(__dirname, '../../frontend/apps/web/node_modules/playwright'));
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:18081';
+const DB_NAME = process.env.DB_NAME || process.env.E2E_DB || 'sc_demo';
+const LOGIN = process.env.E2E_LOGIN || 'demo_role_finance';
+const PASSWORD = process.env.E2E_PASSWORD || 'demo';
+const ACTION_ID = Number(process.env.INVOICE_LEDGER_ACTION_ID || 630);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function main() {
+  if (!ACTION_ID) fail('INVOICE_LEDGER_ACTION_ID is required');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  const groupedResponses = [];
+
+  page.on('response', async (response) => {
+    if (!response.url().includes('/api/v1/intent')) return;
+    try {
+      const body = await response.json();
+      const meta = body && body.meta ? body.meta : {};
+      const data = body && body.data ? body.data : {};
+      if (meta.intent !== 'api.data' || meta.group_by_field !== 'source_kind') return;
+      groupedResponses.push({
+        status: response.status(),
+        group_count: Number(meta.group_count || 0),
+        groups: (data.group_summary || []).map((row) => ({
+          label: String(row.label || ''),
+          count: Number(row.count || 0),
+        })),
+        grouped_rows: (data.grouped_rows || []).map((row) => ({
+          label: String(row.label || ''),
+          count: Number(row.count || 0),
+          sample_count: Array.isArray(row.sample_rows) ? row.sample_rows.length : 0,
+        })),
+      });
+    } catch (_err) {
+      // Ignore unrelated non-JSON responses.
+    }
+  });
+
+  try {
+    await page.goto(`${FRONTEND_URL}/login?db=${encodeURIComponent(DB_NAME)}`, {
+      waitUntil: 'networkidle',
+      timeout: 30000,
+    });
+    await page.locator('input[placeholder="请输入账号"]').fill(LOGIN);
+    await page.locator('input[placeholder="请输入密码"]').fill(PASSWORD);
+    await page.locator('button').filter({ hasText: /登录|登陆/ }).click();
+    await page.waitForURL((url) => !String(url).includes('/login'), { timeout: 30000 });
+
+    await page.goto(`${FRONTEND_URL}/a/${ACTION_ID}?db=${encodeURIComponent(DB_NAME)}`, {
+      waitUntil: 'networkidle',
+      timeout: 30000,
+    });
+    await page.waitForTimeout(1500);
+
+    const bodyText = await page.locator('body').innerText({ timeout: 10000 });
+    for (const label of ['发票总台账', '销项开票申请', '进项发票登记', '进项税额上报', '分组结果']) {
+      if (!bodyText.includes(label)) {
+        fail(`browser invoice ledger missing label: ${label}`);
+      }
+    }
+
+    const latest = groupedResponses[groupedResponses.length - 1];
+    if (!latest) {
+      fail('api.data grouped response for source_kind was not observed');
+    }
+    const labels = new Set(latest.groups.map((row) => row.label));
+    for (const label of ['发票登记', '进项税额', '销项税额', '预缴税']) {
+      if (!labels.has(label)) {
+        fail(`api.data group_summary missing label: ${label}`);
+      }
+    }
+    if (!latest.grouped_rows.length || latest.grouped_rows.some((row) => row.sample_count <= 0)) {
+      fail('api.data grouped_rows must include visible invoice sample rows');
+    }
+
+    console.log('[invoice_entry_fact_browser_smoke] PASS');
+    console.log(JSON.stringify({
+      url: page.url(),
+      groups: latest.groups,
+      grouped_rows: latest.grouped_rows,
+    }));
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(`[invoice_entry_fact_browser_smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/verify/invoice_entry_fact_contract_guard.py
+++ b/scripts/verify/invoice_entry_fact_contract_guard.py
@@ -24,6 +24,9 @@ def main() -> int:
     taxonomy = read("addons/smart_construction_core/views/menu_business_taxonomy.xml")
     cleanup = read("addons/smart_construction_core/views/menu_user_acceptance_cleanup.xml")
     makefile = read("Makefile")
+    page_assembler = read("addons/smart_core/app_config_engine/services/assemblers/page_assembler.py")
+    menu_convergence = read("addons/smart_core/delivery/menu_delivery_convergence_service.py")
+    menu_service = read("addons/smart_core/delivery/menu_service.py")
 
     assert_ok(
         '<field name="name">发票总台账</field>' in invoice_views
@@ -67,6 +70,31 @@ def main() -> int:
         "verify.invoice_entry_fact.contract_guard" in makefile
         and "verify.invoice_entry_fact.runtime_smoke" in makefile,
         "invoice entry optimization must be wired into Makefile verification targets",
+        errors,
+    )
+    assert_ok(
+        "verify.invoice_entry_fact.browser_smoke" in makefile
+        and "invoice_entry_fact_browser_smoke.js" in makefile,
+        "invoice entry optimization must verify the custom frontend grouped browser surface",
+        errors,
+    )
+    assert_ok(
+        "_apply_action_search_defaults" in page_assembler
+        and "search_default_group_" in page_assembler,
+        "page contract assembler must project action search_default_group_* into default group chips",
+        errors,
+    )
+    assert_ok(
+        '"开票申请": "销项开票申请"' in menu_convergence
+        and '"开票登记": "进项发票登记"' in menu_convergence
+        and '"进项上报": "进项税额上报"' in menu_convergence,
+        "delivery navigation convergence must expose precise invoice handling labels",
+        errors,
+    )
+    assert_ok(
+        "convergence_service.RENAME_LABELS" in menu_service
+        and 'converged_menu["label"] = renamed' in menu_service,
+        "released product-policy navigation must consume invoice label convergence",
         errors,
     )
 

--- a/scripts/verify/invoice_entry_fact_contract_guard.py
+++ b/scripts/verify/invoice_entry_fact_contract_guard.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def read(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def assert_ok(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    invoice_views = read("addons/smart_construction_core/views/core/invoice_registration_views.xml")
+    taxonomy = read("addons/smart_construction_core/views/menu_business_taxonomy.xml")
+    cleanup = read("addons/smart_construction_core/views/menu_user_acceptance_cleanup.xml")
+    makefile = read("Makefile")
+
+    assert_ok(
+        '<field name="name">发票总台账</field>' in invoice_views
+        and "'search_default_group_source_kind': 1" in invoice_views,
+        "invoice total ledger action must be named 发票总台账 and default-group by business source kind",
+        errors,
+    )
+    assert_ok(
+        '<field name="source_kind"/>' in invoice_views
+        and '<field name="direction"/>' in invoice_views
+        and '<field name="legacy_source_model" optional="show"/>' in invoice_views
+        and '<field name="legacy_source_table" optional="show"/>' in invoice_views,
+        "invoice total ledger tree/search must expose source kind, direction, and fact source",
+        errors,
+    )
+    assert_ok(
+        'name="has_invoice_no"' in invoice_views
+        and 'name="missing_invoice_no"' in invoice_views
+        and 'name="source_origin_legacy"' in invoice_views,
+        "invoice total ledger search must let users separate real invoice-number rows from tax facts",
+        errors,
+    )
+    assert_ok(
+        "<field name=\"name\">销项开票申请</field>" in taxonomy
+        and "<field name=\"name\">进项发票登记</field>" in taxonomy
+        and "<field name=\"name\">进项税额上报</field>" in taxonomy
+        and 'name="销项开票申请"' in taxonomy
+        and 'name="进项发票登记"' in taxonomy
+        and 'name="进项税额上报"' in taxonomy,
+        "invoice business entries must use precise output/input/prepaid labels",
+        errors,
+    )
+    assert_ok(
+        "<field name=\"name\">发票总台账</field>" in cleanup
+        and "<field name=\"name\">发票台账</field>" in cleanup
+        and "<field name=\"name\">开票与税务办理</field>" in cleanup,
+        "invoice menu acceptance cleanup must keep ledger and handling groups separated",
+        errors,
+    )
+    assert_ok(
+        "verify.invoice_entry_fact.contract_guard" in makefile
+        and "verify.invoice_entry_fact.runtime_smoke" in makefile,
+        "invoice entry optimization must be wired into Makefile verification targets",
+        errors,
+    )
+
+    if errors:
+        print("[verify.invoice_entry_fact.contract_guard] FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("[verify.invoice_entry_fact.contract_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/invoice_entry_fact_runtime_smoke.js
+++ b/scripts/verify/invoice_entry_fact_runtime_smoke.js
@@ -80,6 +80,8 @@ async function main() {
   for (const field of ['source_kind', 'direction', 'invoice_type', 'tax_rate', 'cost_category_name']) {
     assert(groupFields.includes(field), `invoice contract group_by missing ${field}`);
   }
+  const sourceKindGroup = (search.group_by || []).find((row) => row && row.field === 'source_kind');
+  assert(sourceKindGroup && sourceKindGroup.default === true, 'invoice total ledger must default group by source_kind');
 
   const list = await requestJson(intentUrl, {
     intent: 'api.data',

--- a/scripts/verify/invoice_entry_fact_runtime_smoke.js
+++ b/scripts/verify/invoice_entry_fact_runtime_smoke.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+'use strict';
+
+const http = require('http');
+const https = require('https');
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:8070';
+const DB_NAME = process.env.DB_NAME || process.env.E2E_DB || 'sc_demo';
+const LOGIN = process.env.E2E_LOGIN || 'demo_role_finance';
+const PASSWORD = process.env.E2E_PASSWORD || 'demo';
+const ACTION_ID = Number(process.env.INVOICE_LEDGER_ACTION_ID || 630);
+
+function requestJson(url, payload, headers = {}) {
+  return new Promise((resolve, reject) => {
+    const u = new URL(url);
+    const body = JSON.stringify(payload);
+    const req = (u.protocol === 'https:' ? https : http).request({
+      method: 'POST',
+      hostname: u.hostname,
+      port: u.port || (u.protocol === 'https:' ? 443 : 80),
+      path: u.pathname + u.search,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        'X-Odoo-DB': DB_NAME,
+        ...headers,
+      },
+    }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => { data += chunk; });
+      res.on('end', () => {
+        try {
+          resolve({ status: res.statusCode || 0, body: JSON.parse(data || '{}') });
+        } catch (_err) {
+          resolve({ status: res.statusCode || 0, body: { raw: data } });
+        }
+      });
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+function unwrap(resp, intent) {
+  if (!resp || resp.status >= 400 || !resp.body || resp.body.ok !== true) {
+    throw new Error(`${intent} failed status=${resp && resp.status}`);
+  }
+  return resp.body.data || {};
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function main() {
+  const intentUrl = `${BASE_URL}/api/v1/intent?db=${encodeURIComponent(DB_NAME)}`;
+  const login = await requestJson(
+    intentUrl,
+    { intent: 'login', params: { db: DB_NAME, login: LOGIN, password: PASSWORD } },
+    { 'X-Anonymous-Intent': '1' },
+  );
+  const token = unwrap(login, 'login').token;
+  assert(token, 'login response missing token');
+  const auth = { Authorization: `Bearer ${token}` };
+
+  const contract = await requestJson(intentUrl, {
+    intent: 'ui.contract.v2',
+    params: {
+      client_type: 'web_pc',
+      delivery_profile: 'full',
+      op: 'action_open',
+      action_id: ACTION_ID,
+    },
+  }, auth);
+  const contractData = unwrap(contract, 'ui.contract.v2');
+  const dataContract = contractData.dataContract || {};
+  const search = dataContract.search || contractData.searchContract || {};
+  const groupFields = (search.group_by || []).map((row) => row && row.field).filter(Boolean);
+  for (const field of ['source_kind', 'direction', 'invoice_type', 'tax_rate', 'cost_category_name']) {
+    assert(groupFields.includes(field), `invoice contract group_by missing ${field}`);
+  }
+
+  const list = await requestJson(intentUrl, {
+    intent: 'api.data',
+    params: {
+      op: 'list',
+      model: 'sc.invoice.registration',
+      fields: [
+        'id',
+        'name',
+        'source_kind',
+        'direction',
+        'state',
+        'invoice_no',
+        'invoice_code',
+        'invoice_type',
+        'tax_rate',
+        'amount_total',
+        'tax_amount',
+        'project_id',
+        'partner_id',
+        'legacy_source_model',
+      ],
+      domain: [],
+      context_raw: "{'search_default_group_source_kind': 1}",
+      group_by: 'source_kind',
+      need_total: true,
+      need_group_total: true,
+      group_limit: 20,
+      group_sample_limit: 3,
+      group_page_size: 3,
+      limit: 20,
+      order: 'invoice_date desc, id desc',
+    },
+  }, auth);
+  const listData = unwrap(list, 'api.data');
+  const groups = listData.group_summary || [];
+  const labels = new Set(groups.map((row) => String(row.label || '')));
+  for (const label of ['发票登记', '进项税额', '销项税额', '预缴税']) {
+    assert(labels.has(label), `source kind group missing ${label}`);
+  }
+  assert(Number(listData.total || 0) > 0, 'invoice ledger should return records');
+  assert((listData.grouped_rows || []).every((row) => (row.sample_rows || []).length > 0), 'each invoice source group should expose sample rows');
+
+  console.log('[verify.invoice_entry_fact.runtime_smoke] PASS');
+  console.log(JSON.stringify({
+    total: listData.total,
+    groups: groups.map((row) => ({ label: row.label, count: row.count })),
+  }));
+}
+
+main().catch((err) => {
+  console.error(`[verify.invoice_entry_fact.runtime_smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/verify/payment_request_receipt_type_browser_group_smoke.js
+++ b/scripts/verify/payment_request_receipt_type_browser_group_smoke.js
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('path');
+
+const { chromium } = require(path.resolve(__dirname, '../../frontend/apps/web/node_modules/playwright'));
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:18081';
+const DB_NAME = process.env.DB_NAME || process.env.E2E_DB || 'sc_demo';
+const LOGIN = process.env.E2E_LOGIN || 'demo_role_finance';
+const PASSWORD = process.env.E2E_PASSWORD || 'demo';
+const ACTION_ID = Number(process.env.PAYMENT_REQUEST_RECEIVE_ACTION_ID || 672);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+async function main() {
+  if (!ACTION_ID) fail('PAYMENT_REQUEST_RECEIVE_ACTION_ID is required');
+  const browser = await chromium.launch({ headless: true });
+  const page = await browser.newPage({ viewport: { width: 1440, height: 1000 } });
+  const groupedResponses = [];
+
+  page.on('response', async (response) => {
+    if (!response.url().includes('/api/v1/intent')) return;
+    try {
+      const body = await response.json();
+      const meta = body && body.meta ? body.meta : {};
+      const data = body && body.data ? body.data : {};
+      if (meta.intent !== 'api.data' || meta.group_by_field !== 'receipt_type') return;
+      groupedResponses.push({
+        status: response.status(),
+        group_count: Number(meta.group_count || 0),
+        groups: (data.group_summary || []).map((row) => ({
+          label: String(row.label || ''),
+          count: Number(row.count || 0),
+        })),
+        grouped_rows: (data.grouped_rows || []).map((row) => ({
+          label: String(row.label || ''),
+          count: Number(row.count || 0),
+          sample_count: Array.isArray(row.sample_rows) ? row.sample_rows.length : 0,
+        })),
+      });
+    } catch (_err) {
+      // Non-JSON responses are unrelated to this smoke.
+    }
+  });
+
+  try {
+    await page.goto(`${FRONTEND_URL}/login?db=${encodeURIComponent(DB_NAME)}`, {
+      waitUntil: 'networkidle',
+      timeout: 30000,
+    });
+    await page.locator('input[placeholder="请输入账号"]').fill(LOGIN);
+    await page.locator('input[placeholder="请输入密码"]').fill(PASSWORD);
+    await page.locator('button').filter({ hasText: /登录|登陆/ }).click();
+    await page.waitForURL((url) => !String(url).includes('/login'), { timeout: 30000 });
+
+    const targetUrl = `${FRONTEND_URL}/a/${ACTION_ID}?db=${encodeURIComponent(DB_NAME)}&group_by=receipt_type`;
+    await page.goto(targetUrl, { waitUntil: 'networkidle', timeout: 30000 });
+    await page.waitForTimeout(1500);
+
+    const bodyText = await page.locator('body').innerText({ timeout: 10000 });
+    for (const label of ['正常类型收款', '其他类型收款']) {
+      if (!bodyText.includes(label)) {
+        fail(`browser grouped list missing label: ${label}`);
+      }
+    }
+    if (!bodyText.includes('分组结果')) {
+      fail('browser grouped list missing grouped result section');
+    }
+
+    const latest = groupedResponses[groupedResponses.length - 1];
+    if (!latest) {
+      fail('api.data grouped response for receipt_type was not observed');
+    }
+    const labels = new Set(latest.groups.map((row) => row.label));
+    for (const label of ['正常类型收款', '其他类型收款']) {
+      if (!labels.has(label)) {
+        fail(`api.data group_summary missing label: ${label}`);
+      }
+    }
+    if (!latest.grouped_rows.length || latest.grouped_rows.some((row) => row.sample_count <= 0)) {
+      fail('api.data grouped_rows must include visible sample rows');
+    }
+
+    console.log('[payment_request_receipt_type_browser_group_smoke] PASS');
+    console.log(
+      JSON.stringify({
+        url: page.url(),
+        groups: latest.groups,
+        grouped_rows: latest.grouped_rows,
+      }),
+    );
+  } finally {
+    await browser.close();
+  }
+}
+
+main().catch((err) => {
+  console.error(`[payment_request_receipt_type_browser_group_smoke] FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/scripts/verify/payment_request_receipt_type_guard.py
+++ b/scripts/verify/payment_request_receipt_type_guard.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _assert(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    model = _read("addons/smart_construction_core/models/core/payment_request.py")
+    views = _read("addons/smart_construction_core/views/core/payment_request_views.xml")
+    asset_generator = _read("scripts/migration/receipt_core_asset_generator.py")
+    replay_adapter = _read("scripts/migration/fresh_db_receipt_core_replay_adapter.py")
+    receipt_write = _read("scripts/migration/fresh_db_receipt_core_write.py")
+    normalize = _read("scripts/migration/visible_surface_receipt_core_creator_normalize_write.py")
+    search_config = _read("addons/smart_core/app_config_engine/models/app_search_config.py")
+    browser_smoke = _read("scripts/verify/payment_request_receipt_type_browser_group_smoke.js")
+    makefile = _read("Makefile")
+
+    _assert(
+        'receipt_type = fields.Char(' in model and 'string="登记类型"' in model,
+        "payment.request must carry receipt_type as 收款申请登记类型",
+        errors,
+    )
+    _assert(
+        '<field name="receipt_type" optional="show"/>' in views
+        and '<field name="receipt_type" invisible="type != \'receive\'"/>' in views,
+        "payment.request tree/form views must show receipt_type for receipt requests",
+        errors,
+    )
+    _assert(
+        "receipt_type_normal" in views
+        and "receipt_type_other" in views
+        and "group_by_receipt_type" in views
+        and "search_default_group_by_receipt_type" in views,
+        "receipt request action/search must support receipt_type filtering and grouping",
+        errors,
+    )
+    _assert(
+        "add_group(fname, meta, explicit=True)" in search_config
+        and "allowed_group_types = allowed_group_types + ('char',)" in search_config,
+        "explicit search-view char group_by fields must appear in browser custom group categories",
+        errors,
+    )
+    _assert(
+        "group_by=receipt_type" in browser_smoke
+        and "分组结果" in browser_smoke
+        and "正常类型收款" in browser_smoke
+        and "其他类型收款" in browser_smoke
+        and "verify.payment_request_receipt_type.browser_group_smoke" in makefile,
+        "receipt type grouping must have a browser-level grouped-list smoke target",
+        errors,
+    )
+    _assert(
+        'add_text_field(record, "receipt_type", row["receipt_type"])' in asset_generator
+        and 'receipt_type = clean(row.get("type"))' in asset_generator,
+        "receipt core asset must preserve C_JFHKLR.type as payment.request.receipt_type",
+        errors,
+    )
+    _assert(
+        '"receipt_type",' in replay_adapter
+        and '"receipt_type": clean(values.get("receipt_type"))' in replay_adapter,
+        "receipt core replay adapter must emit receipt_type in the payload",
+        errors,
+    )
+    _assert(
+        "def raw_receipt_type_map" in replay_adapter
+        and "receipt_types.get(legacy_receipt_id" in replay_adapter
+        and "def raw_receipt_type_map" in receipt_write
+        and "receipt_types.get(legacy_receipt_id" in receipt_write,
+        "receipt core replay/write must backfill receipt_type from raw CSV when packaged XML lacks the field",
+        errors,
+    )
+    _assert(
+        '"receipt_type"' in receipt_write
+        and '"receipt_type": clean(row.get("receipt_type")) or False' in receipt_write,
+        "receipt core write must create payment.request rows with receipt_type",
+        errors,
+    )
+    _assert(
+        '"receipt_type": clean(row.get("type"))' in normalize
+        and 'vals["receipt_type"] = fact["receipt_type"]' in normalize
+        and '"receipt_requests_with_receipt_type"' in normalize,
+        "visible surface normalize must backfill existing receipt requests with receipt_type",
+        errors,
+    )
+    if errors:
+        print("[verify.payment_request_receipt_type.guard] FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("[verify.payment_request_receipt_type.guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/receipt_income_type_mapping_guard.py
+++ b/scripts/verify/receipt_income_type_mapping_guard.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _assert(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def main() -> int:
+    errors: list[str] = []
+    script = _read("scripts/migration/fresh_db_receipt_income_from_payment_request_projection_write.py")
+    model = _read("addons/smart_construction_core/models/core/receipt_income.py")
+    menu = _read("addons/smart_construction_core/views/menu_business_taxonomy.xml")
+
+    _assert(
+        'receipt_type = fields.Char(string="登记类型"' in model,
+        "sc.receipt.income must keep receipt_type as the business registration type field",
+        errors,
+    )
+    _assert(
+        "raw.legacy_receipt_type" in script
+        and 'COALESCE(NULLIF(source.legacy_receipt_type, \'\'), \'收款申请\')' in script,
+        "receipt income projection must map C_JFHKLR.type into sc_receipt_income.receipt_type",
+        errors,
+    )
+    _assert(
+        "'收款申请',\n      NULLIF(source.legacy_receipt_type" not in script,
+        "receipt income projection must not hard-code receipt_type to 收款申请 while moving legacy type only to audit fields",
+        errors,
+    )
+    _assert(
+        "legacy_receipt_type = EXCLUDED.legacy_receipt_type" in script
+        and "legacy_receipt_subtype = EXCLUDED.legacy_receipt_subtype" in script,
+        "receipt income projection must preserve legacy type/subtype audit fields",
+        errors,
+    )
+    _assert(
+        "('receipt_type', '=', '到款确认表')" in menu,
+        "arrival confirmation menu must continue to route by runtime receipt_type",
+        errors,
+    )
+    if errors:
+        print("[verify.receipt_income_type_mapping.guard] FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("[verify.receipt_income_type_mapping.guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/user_delete_data_closure_guard.py
+++ b/scripts/verify/user_delete_data_closure_guard.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import ast
+import csv
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _read(rel_path: str) -> str:
+    return (ROOT / rel_path).read_text(encoding="utf-8")
+
+
+def _assert(condition: bool, message: str, errors: list[str]) -> None:
+    if not condition:
+        errors.append(message)
+
+
+def _action_model(xmlid: str) -> str:
+    model = ""
+    for path in sorted((ROOT / "addons" / "smart_construction_core" / "views").rglob("*.xml")):
+        try:
+            root = ET.parse(path).getroot()
+        except Exception:
+            continue
+        for record in root.iter("record"):
+            if record.attrib.get("id") != xmlid or record.attrib.get("model") != "ir.actions.act_window":
+                continue
+            for field in record.findall("field"):
+                if field.attrib.get("name") == "res_model":
+                    model = (field.text or "").strip()
+    return model
+
+
+def _probe_backend_unlink(errors: list[str]) -> None:
+    source = _read("addons/smart_core/handlers/api_data_unlink.py")
+    policy_source = _read("addons/smart_core/utils/delete_policy.py")
+    _assert("resolve_unlink_policy" in source, "api.data.unlink must be gated by delete_policy", errors)
+    _assert("dry_run = parse_bool" in source, "api.data.unlink must keep dry_run support", errors)
+    _assert("missing_ids = [rec_id for rec_id in ids if rec_id not in found_ids]" in source, "api.data.unlink must reject partial missing id sets", errors)
+    _assert("return self._err(404, \"记录不存在\", REASON_NOT_FOUND)" in source, "partial missing unlink must fail as NOT_FOUND", errors)
+    _assert("def _check_record_delete_policy" in source and "state_field" in source and "allowed_states" in source, "api.data.unlink must enforce record-state delete policy", errors)
+    _assert("policy_error = self._check_record_delete_policy(recs, delete_policy)" in source, "api.data.unlink must check state policy before ACL/unlink execution", errors)
+    _assert("if not dry_run:" in source and "recs.unlink()" in source, "dry_run must not call unlink", errors)
+    _assert("\"deleted_count\": 0 if dry_run else len(set(ids))" in source, "unlink result must expose deleted_count", errors)
+    _assert('"state_field"' in policy_source and '"allowed_states"' in policy_source, "delete_policy normalization must preserve state-limited policy metadata", errors)
+
+
+def _probe_business_delete_policy_scope(errors: list[str]) -> None:
+    source = _read("addons/smart_construction_core/core_extension.py")
+    tree = ast.parse(source)
+    policy_models: set[str] = set()
+    for node in tree.body:
+        if not isinstance(node, ast.Assign):
+            continue
+        if not any(isinstance(target, ast.Name) and target.id == "API_DATA_UNLINK_POLICIES" for target in node.targets):
+            continue
+        policies = ast.literal_eval(node.value)
+        policy_models = {str(model) for model in policies}
+    required_physical_delete_models = {
+        "construction.contract",
+        "construction.contract.income",
+        "construction.contract.expense",
+        "payment.request",
+        "payment.request.line",
+        "project.task",
+        "project.tags",
+        "res.partner",
+        "sc.approval.policy",
+        "sc.approval.step",
+        "sc.document.admin.document",
+        "sc.hr.payroll.document",
+        "sc.office.admin.document",
+        "sc.project.stage.requirement.item",
+        "sc.supplier.type",
+    }
+    missing = sorted(required_physical_delete_models - policy_models)
+    _assert(not missing, "business maintenance models missing explicit unlink policy: " + ", ".join(missing), errors)
+    required_draft_models = {
+        "payment.request",
+        "sc.general.contract",
+        "sc.expense.claim",
+        "sc.payment.execution",
+        "sc.receipt.income",
+        "sc.fund.account.operation",
+        "sc.settlement.order",
+        "sc.material.purchase.request",
+        "sc.material.acceptance",
+        "sc.material.inbound",
+        "sc.material.outbound",
+        "sc.material.rfq",
+        "sc.material.settlement",
+        "sc.labor.request",
+        "sc.equipment.request",
+        "sc.safety.plan",
+        "sc.quality.issue",
+        "project.progress.entry",
+        "tender.bid",
+        "tender.doc.purchase",
+    }
+    missing_draft = sorted(model for model in required_draft_models if f'"{model}"' not in source)
+    _assert(not missing_draft, "draft-state business documents missing unlink policy: " + ", ".join(missing_draft), errors)
+    acl_unlink_models: set[str] = set()
+    with (ROOT / "addons" / "smart_construction_core" / "security" / "ir.model.access.csv").open(encoding="utf-8", newline="") as handle:
+        for row in csv.DictReader(handle):
+            if row.get("perm_unlink") != "1":
+                continue
+            model = str(row.get("model_id:id") or "").removeprefix("model_").replace("_", ".")
+            acl_unlink_models.add(model)
+    missing_acl = sorted(required_draft_models - acl_unlink_models)
+    _assert(not missing_acl, "draft-state delete policies must remain backed by unlink ACLs: " + ", ".join(missing_acl), errors)
+    _assert(
+        "API_DATA_DRAFT_UNLINK_POLICIES" in source
+        and "DRAFT_DELETE_ALLOWED_STATES" in source
+        and '"state_field": "state"' in source
+        and '"allowed_states": list(allowed_states)' in source
+        and '"tender.bid": _state_unlink_policy("tender.bid", "投标主单", ("prepare", "estimating"))' in source,
+        "business document delete policies must be centrally state-limited, with tender pre-submit states covered",
+        errors,
+    )
+    _assert("project.project" not in policy_models, "project.project must not be in static all-user physical delete policy", errors)
+    _assert(
+        'env.user.has_group("smart_construction_core.group_sc_cap_business_config_admin")' in source,
+        "project.project physical delete policy must be gated by business config admin group",
+        errors,
+    )
+    _assert(
+        '"project.project"' in source
+        and '"requires_group": "smart_construction_core.group_sc_cap_business_config_admin"' in source
+        and '"dependency_guard": "project.project._raise_project_unlink_blockers"' in source,
+        "project.project delete policy must document group and dependency guard",
+        errors,
+    )
+    project_source = _read("addons/smart_construction_core/models/core/project_core.py")
+    _assert("def _raise_project_unlink_blockers" in project_source and "def unlink(self):" in project_source, "project.project must keep unlink dependency blockers", errors)
+    _assert("self._raise_project_unlink_blockers()" in project_source, "project.project unlink must call dependency blocker guard", errors)
+    _assert("project.cost.compare" not in policy_models and "payment.ledger" not in policy_models, "read-only ledgers/projections must not be physically deletable", errors)
+
+
+def _probe_frontend_delete_flow(errors: list[str]) -> None:
+    api = _read("frontend/apps/web/src/api/data.ts")
+    flow = _read("frontend/apps/web/src/app/runtime/actionViewBatchActionFlowRuntime.ts")
+    action_view = _read("frontend/apps/web/src/views/ActionView.vue")
+    list_page = _read("frontend/apps/web/src/pages/ListPage.vue")
+    _assert("dryRun?: boolean;" in api and "dry_run: Boolean(params.dryRun)" in api, "unlinkRecord must expose dryRun to api.data.unlink", errors)
+    _assert("dryRunIdempotencyKey" in flow and "'delete.dry_run'" in flow, "batch delete must use a distinct dry-run idempotency key", errors)
+    _assert("dryRun: true" in action_view, "ActionView batch delete must preflight with dryRun", errors)
+    _assert("const result = await unlinkActionViewRecord" in action_view, "ActionView batch delete must still execute real unlink after preflight", errors)
+    _assert("const hasSelectionActions = computed(() => selectionActions.value.length > 0);" in list_page, "ListPage must derive selection visibility from executable actions", errors)
+    _assert("const showSelectionColumn = computed(() => hasSelectionActions.value" in list_page, "ListPage must hide selection column without delete/archive actions", errors)
+
+
+def _probe_domain_action_binding(errors: list[str]) -> None:
+    model = _action_model("action_construction_contract_expense")
+    _assert(model == "construction.contract.expense", "action_construction_contract_expense must remain bound to editable expense contracts", errors)
+    ledger = _action_model("action_sc_expense_contract_ledger_alias")
+    _assert(ledger == "sc.expense.contract.ledger", "expense ledger alias action must stay separate from editable expense contract action", errors)
+
+
+def main() -> int:
+    errors: list[str] = []
+    _probe_backend_unlink(errors)
+    _probe_business_delete_policy_scope(errors)
+    _probe_frontend_delete_flow(errors)
+    _probe_domain_action_binding(errors)
+    if errors:
+        print("[verify.user_delete_data.closure_guard] FAIL")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("[verify.user_delete_data.closure_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- harden user data deletion permissions and draft-state deletion coverage
- surface receipt request registration type through migration, backend, search, and browser grouping
- clarify invoice ledger fact source and activate custom frontend grouped ledger views
- constrain action default group projection to one matching group and add full runtime audit for group aliases

## Verification
- make verify.user_delete_data.closure_guard
- make verify.payment_request_receipt_type.guard
- make verify.payment_request_receipt_type.browser_group_smoke
- make verify.invoice_entry_fact.contract_guard
- make verify.invoice_entry_fact.runtime_smoke
- make verify.invoice_entry_fact.browser_smoke
- make verify.action_default_group.contract_audit
- git diff --check