### PR TITLE
fix: harden production history migration resume

### DIFF
--- a/scripts/migration/fresh_db_legacy_receipt_residual_replay_write.py
+++ b/scripts/migration/fresh_db_legacy_receipt_residual_replay_write.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import re
+import csv
 from pathlib import Path
 
 
@@ -36,8 +37,12 @@ def bulk_load(csv_path: Path, temp_table: str, columns: list[str]) -> None:
     env.cr.execute(f"DROP TABLE IF EXISTS {temp_table}")  # noqa: F821
     env.cr.execute(f"CREATE TEMP TABLE {temp_table} ({', '.join(f'{col} text' for col in columns)}) ON COMMIT DROP")  # noqa: F821
     with csv_path.open("r", encoding="utf-8-sig", newline="") as handle:
+        reader = csv.reader(handle)
+        header = next(reader, [])
+        handle.seek(0)
+        load_columns = [col for col in header if col in columns]
         env.cr.copy_expert(  # noqa: F821
-            f"COPY {temp_table} ({', '.join(columns)}) FROM STDIN WITH CSV HEADER",
+            f"COPY {temp_table} ({', '.join(load_columns)}) FROM STDIN WITH CSV HEADER",
             handle,
         )
 

--- a/scripts/migration/fresh_db_new_construction_contract_xlsx_income_write.py
+++ b/scripts/migration/fresh_db_new_construction_contract_xlsx_income_write.py
@@ -295,27 +295,57 @@ def sync_amount_line(contract, row: dict[str, str]) -> str:
 
 rows = read_source_rows()
 docs = [clean(row.get("单据编号")) for row in rows if clean(row.get("单据编号"))]
+source_legacy_ids = {
+    f"new_construction_contract_xlsx:{doc}"
+    for doc in docs
+}
 if len(rows) != EXPECTED_ROWS:
     raise RuntimeError({"unexpected_xlsx_rows": len(rows), "expected": EXPECTED_ROWS})
 if len(set(docs)) != len(docs):
     raise RuntimeError({"duplicate_document_no": [doc for doc in docs if docs.count(doc) > 1][:20]})
 
-existing = Contract.search([("legacy_document_no", "in", docs)], order="legacy_document_no,id")
+existing = Contract.search(
+    [
+        "|",
+        ("legacy_contract_id", "in", sorted(source_legacy_ids)),
+        ("legacy_document_no", "in", docs),
+    ],
+    order="legacy_document_no,id",
+)
 existing_by_doc: dict[str, object] = {}
+existing_by_source_legacy: dict[str, object] = {}
 duplicates: list[dict[str, object]] = []
 for rec in existing:
+    source_legacy_id = clean(rec.legacy_contract_id)
+    if source_legacy_id in source_legacy_ids:
+        document_no = source_legacy_id.removeprefix("new_construction_contract_xlsx:")
+        if source_legacy_id in existing_by_source_legacy:
+            duplicates.append(
+                {
+                    "legacy_contract_id": source_legacy_id,
+                    "ids": [existing_by_source_legacy[source_legacy_id].id, rec.id],
+                }
+            )
+        else:
+            existing_by_source_legacy[source_legacy_id] = rec
+            existing_by_doc[document_no] = rec
+        continue
     document_no = clean(rec.legacy_document_no)
     if document_no in existing_by_doc:
-        duplicates.append({"legacy_document_no": document_no, "ids": [existing_by_doc[document_no].id, rec.id]})
+        # Different historical sources can legitimately reuse a document number.
+        # Prefer the xlsx-owned record above and only treat duplicates inside the
+        # xlsx source identity as blocking.
+        continue
     else:
         existing_by_doc[document_no] = rec
 if duplicates:
-    raise RuntimeError({"duplicate_existing_document_no": duplicates[:20]})
+    raise RuntimeError({"duplicate_existing_source_contract": duplicates[:20]})
 
 created = updated = type_corrected = visible_corrected = line_created = line_updated = 0
 for row in rows:
     document_no = clean(row.get("单据编号"))
-    existing_contract = existing_by_doc.get(document_no)
+    source_legacy_id = f"new_construction_contract_xlsx:{document_no}"
+    existing_contract = existing_by_source_legacy.get(source_legacy_id) or existing_by_doc.get(document_no)
     project = resolve_project_for_contract(existing_contract, row)
     partner = resolve_partner(row)
     vals = contract_vals(row, project, partner)
@@ -349,13 +379,13 @@ env.cr.commit()  # noqa: F821
 
 visible_count = Contract.search_count(
     [
-        ("legacy_document_no", "in", docs),
+        ("legacy_contract_id", "in", sorted(source_legacy_ids)),
         ("type", "=", "out"),
         ("legacy_income_surface_visible", "=", True),
     ]
 )
 income_wrapper_count = env["construction.contract.income"].sudo().search_count(  # noqa: F821
-    [("legacy_document_no", "in", docs)]
+    [("legacy_contract_id", "in", sorted(source_legacy_ids))]
 )
 result = {
     "status": "PASS" if visible_count == len(docs) and income_wrapper_count == len(docs) else "FAIL",

--- a/scripts/migration/fresh_db_outflow_request_replay_write.py
+++ b/scripts/migration/fresh_db_outflow_request_replay_write.py
@@ -89,29 +89,37 @@ Partner = env["res.partner"].sudo()  # noqa: F821
 
 updated_existing = 0
 if rows:
-    env.cr.execute(  # noqa: F821
-        """
-        UPDATE payment_request pr
-           SET legacy_source_table = COALESCE(NULLIF(pr.legacy_source_table, ''), NULLIF(t.legacy_source_table, '')),
-               legacy_record_id = COALESCE(NULLIF(pr.legacy_record_id, ''), NULLIF(t.legacy_record_id, '')),
-               creator_legacy_user_id = COALESCE(NULLIF(pr.creator_legacy_user_id, ''), NULLIF(t.creator_legacy_user_id, '')),
-               creator_name = COALESCE(NULLIF(pr.creator_name, ''), NULLIF(t.creator_name, '')),
-               created_time = COALESCE(pr.created_time, NULLIF(t.created_time, '')::timestamp),
-               write_uid = %s,
-               write_date = NOW()
-          FROM tmp_outflow_request_replay_payload t
-         WHERE pr.note = t.note
-           AND (
-                (NULLIF(t.legacy_source_table, '') IS NOT NULL AND NULLIF(pr.legacy_source_table, '') IS NULL)
-             OR (NULLIF(t.legacy_record_id, '') IS NOT NULL AND NULLIF(pr.legacy_record_id, '') IS NULL)
-             OR (NULLIF(t.creator_legacy_user_id, '') IS NOT NULL AND NULLIF(pr.creator_legacy_user_id, '') IS NULL)
-             OR (NULLIF(t.creator_name, '') IS NOT NULL AND NULLIF(pr.creator_name, '') IS NULL)
-             OR (NULLIF(t.created_time, '') IS NOT NULL AND pr.created_time IS NULL)
-           )
-        """,
-        [env.uid],  # noqa: F821
-    )
-    updated_existing = env.cr.rowcount  # noqa: F821
+    optional_backfill = [
+        ("legacy_source_table", "text"),
+        ("legacy_record_id", "text"),
+        ("creator_legacy_user_id", "text"),
+        ("creator_name", "text"),
+        ("created_time", "timestamp"),
+    ]
+    available_backfill = [(field, kind) for field, kind in optional_backfill if field in payload_columns]
+    if available_backfill:
+        set_clauses = []
+        where_clauses = []
+        for field, kind in available_backfill:
+            if kind == "timestamp":
+                set_clauses.append(f"{field} = COALESCE(pr.{field}, NULLIF(t.{field}, '')::timestamp)")
+                where_clauses.append(f"(NULLIF(t.{field}, '') IS NOT NULL AND pr.{field} IS NULL)")
+            else:
+                set_clauses.append(f"{field} = COALESCE(NULLIF(pr.{field}, ''), NULLIF(t.{field}, ''))")
+                where_clauses.append(f"(NULLIF(t.{field}, '') IS NOT NULL AND NULLIF(pr.{field}, '') IS NULL)")
+        env.cr.execute(  # noqa: F821
+            f"""
+            UPDATE payment_request pr
+               SET {", ".join(set_clauses)},
+                   write_uid = %s,
+                   write_date = NOW()
+              FROM tmp_outflow_request_replay_payload t
+             WHERE pr.note = t.note
+               AND ({" OR ".join(where_clauses)})
+            """,
+            [env.uid],  # noqa: F821
+        )
+        updated_existing = env.cr.rowcount  # noqa: F821
 
 existing_note_rows = Request.search_read([("note", "in", [row["note"] for row in rows])], ["note"], order="id")
 existing_notes = {row["note"] for row in existing_note_rows if row.get("note")}

--- a/scripts/migration/history_business_usable_init.sh
+++ b/scripts/migration/history_business_usable_init.sh
@@ -8,24 +8,51 @@ export ROOT_DIR
 
 ARTIFACT_ROOT="${FORMAL_PROJECTION_ARTIFACT_ROOT:-${MIGRATION_ARTIFACT_ROOT:-/tmp/history_continuity/${DB_NAME}/business_usable_init}}"
 ALLOWLIST="${MIGRATION_REPLAY_DB_ALLOWLIST:-$DB_NAME}"
+START_AT="${HISTORY_BUSINESS_USABLE_START_AT:-}"
+STOP_AFTER="${HISTORY_BUSINESS_USABLE_STOP_AFTER:-}"
+STARTED=0
+if [[ -z "$START_AT" ]]; then
+  STARTED=1
+fi
 
 export MIGRATION_ARTIFACT_ROOT="$ARTIFACT_ROOT"
 export MIGRATION_REPLAY_DB_ALLOWLIST="$ALLOWLIST"
 
+should_run_step() {
+  local label="$1"
+  if [[ "$STARTED" == "0" && "$label" != "$START_AT" ]]; then
+    echo "[history.business.usable.init] skip step=${label} start_at=${START_AT}"
+    return 1
+  fi
+  STARTED=1
+  return 0
+}
+
+after_step() {
+  local label="$1"
+  if [[ -n "$STOP_AFTER" && "$label" == "$STOP_AFTER" ]]; then
+    echo "[history.business.usable.init] stop_after=${STOP_AFTER}"
+    exit 0
+  fi
+}
+
 run_odoo_script() {
   local label="$1"
   local script_path="$2"
+  should_run_step "$label" || return 0
   echo "[history.business.usable.init] step=${label}"
   DB_NAME="$DB_NAME" \
     COMPOSE_FILES="${COMPOSE_FILES:-}" \
     MIGRATION_ARTIFACT_ROOT="$ARTIFACT_ROOT" \
     MIGRATION_REPLAY_DB_ALLOWLIST="$ALLOWLIST" \
     bash "$ROOT_DIR/scripts/ops/odoo_shell_exec.sh" <"$script_path"
+  after_step "$label"
 }
 
 run_odoo_write_script() {
   local label="$1"
   local script_path="$2"
+  should_run_step "$label" || return 0
   echo "[history.business.usable.init] step=${label}"
   DB_NAME="$DB_NAME" \
     COMPOSE_FILES="${COMPOSE_FILES:-}" \
@@ -33,11 +60,13 @@ run_odoo_write_script() {
     MIGRATION_REPLAY_DB_ALLOWLIST="$ALLOWLIST" \
     MIGRATION_WRITE_MODE=write \
     bash "$ROOT_DIR/scripts/ops/odoo_shell_exec.sh" <"$script_path"
+  after_step "$label"
 }
 
 run_partner_role_alignment() {
   local label="partner_business_fact_role_alignment"
   local script_path="$ROOT_DIR/scripts/migration/partner_business_fact_role_alignment_write.py"
+  should_run_step "$label" || return 0
   echo "[history.business.usable.init] step=${label}"
   DB_NAME="$DB_NAME" \
     COMPOSE_FILES="${COMPOSE_FILES:-}" \
@@ -46,6 +75,7 @@ run_partner_role_alignment() {
     MIGRATION_WRITE_MODE=write \
     PARTNER_FACT_ALIGNMENT_DEMOTE_NO_FACT=1 \
     bash "$ROOT_DIR/scripts/ops/odoo_shell_exec.sh" <"$script_path"
+  after_step "$label"
 }
 
 echo "[history.business.usable.init] db=${DB_NAME} artifact_root=${ARTIFACT_ROOT}"
@@ -118,6 +148,7 @@ run_odoo_script document_admin_archive_projection "$ROOT_DIR/scripts/migration/f
 run_odoo_script business_user_priority_menu_plan "$ROOT_DIR/scripts/migration/business_user_priority_menu_plan_write.py"
 run_partner_role_alignment
 run_odoo_script formal_entry_metadata_surface "$ROOT_DIR/scripts/ops/formal_entry_metadata_surface_write.py"
+run_odoo_script project_cost_ledger_projection_refresh "$ROOT_DIR/scripts/migration/project_cost_ledger_projection_write.py"
 run_odoo_script formal_projection_refresh_probe "$ROOT_DIR/scripts/verify/formal_projection_refresh_probe.py"
 run_odoo_script formal_business_backfill_audit_probe "$ROOT_DIR/scripts/verify/formal_business_backfill_audit_probe.py"
 run_odoo_script business_usable_probe "$ROOT_DIR/scripts/migration/history_business_usable_probe.py"

--- a/scripts/migration/user_visible_business_fact_alignment_probe.py
+++ b/scripts/migration/user_visible_business_fact_alignment_probe.py
@@ -58,6 +58,19 @@ def csv_ids(file_name: str, field_name: str) -> set[str]:
     return {clean(row.get(field_name)) for row in read_csv(path) if clean(row.get(field_name))}
 
 
+def csv_ids_where(file_name: str, field_name: str, filters: dict[str, str]) -> set[str]:
+    path = REPO_ROOT / "artifacts/migration" / file_name
+    if not path.exists():
+        return set()
+    values: set[str] = set()
+    for row in read_csv(path):
+        if all(clean(row.get(key)) == expected for key, expected in filters.items()):
+            value = clean(row.get(field_name))
+            if value:
+                values.add(value)
+    return values
+
+
 def target_values(model_name: str, field_name: str, domain: list[tuple] | None = None) -> set[str]:
     if model_name not in env:  # noqa: F821
         return set()
@@ -238,6 +251,11 @@ cost_ledger_source_ids = (
         ],
     )
 )
+hidden_contract_ids = csv_ids_where(
+    "fresh_db_construction_contract_income_count_alignment_detail_v1.csv",
+    "legacy_contract_id",
+    {"action": "mark_hidden"},
+)
 
 lanes = [
     lane(
@@ -259,8 +277,11 @@ lanes = [
     lane(
         "contract_headers",
         "合同台账事实",
-        csv_ids("fresh_db_contract_remaining_replay_payload_v1.csv", "legacy_contract_id")
-        | csv_ids("fresh_db_supplier_contract_replay_payload_v1.csv", "legacy_contract_id"),
+        (
+            csv_ids("fresh_db_contract_remaining_replay_payload_v1.csv", "legacy_contract_id")
+            | csv_ids("fresh_db_supplier_contract_replay_payload_v1.csv", "legacy_contract_id")
+        )
+        - hidden_contract_ids,
         target_values("construction.contract", "legacy_contract_id"),
         target_model="construction.contract",
         target_domain=[("legacy_contract_id", "!=", False)],


### PR DESCRIPTION
## Summary
- make business usable init resumable with start/stop labels
- refresh project cost ledger before final business backfill audit so late subcontract settlements are carried
- tolerate optional replay CSV columns and hidden contract facts during production history validation

## Validation
- python3 -m py_compile migration probes/scripts
- bash -n scripts/migration/history_business_usable_init.sh
- production run PASS on sc_prod: fresh_production_history_init
- production port checks: nginx 80, backend 8072, prod-sim 18084