### PR TITLE
fix: allow clearing default list grouping

### DIFF
--- a/frontend/apps/web/src/app/action_runtime/useActionViewLoadPreflightRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewLoadPreflightRuntime.ts
@@ -13,6 +13,7 @@ type ExecuteLoadPreflightOptions = {
   routeFilterRaw: unknown;
   routeSavedFilterRaw: unknown;
   routeGroupByRaw: unknown;
+  routeGroupClearedRaw?: unknown;
   routeGroupValueRaw?: unknown;
   sceneReadyDefaultSortRaw: unknown;
   sceneDefaultSortRaw: unknown;
@@ -205,6 +206,7 @@ export function useActionViewLoadPreflightRuntime() {
       routeFilterRaw: options.routeFilterRaw,
       routeSavedFilterRaw: options.routeSavedFilterRaw,
       routeGroupByRaw: options.routeGroupByRaw,
+      routeGroupClearedRaw: options.routeGroupClearedRaw,
       routeGroupValueRaw: options.routeGroupValueRaw,
       activeContractFilterKey: options.activeContractFilterKey,
       activeSavedFilterKey: options.activeSavedFilterKey,

--- a/frontend/apps/web/src/app/navigationContext.ts
+++ b/frontend/apps/web/src/app/navigationContext.ts
@@ -12,6 +12,7 @@ export const CONTRACT_NAV_QUERY_KEYS = [
   'preset_filter',
   'search',
   'ctx_source',
+  'group_by_cleared',
 ] as const;
 
 export function pickContractNavQuery(

--- a/frontend/apps/web/src/app/runtime/actionViewContractLoadRuntime.ts
+++ b/frontend/apps/web/src/app/runtime/actionViewContractLoadRuntime.ts
@@ -34,6 +34,7 @@ export function resolveRouteSelectionState(options: {
   routeFilterRaw: unknown;
   routeSavedFilterRaw: unknown;
   routeGroupByRaw: unknown;
+  routeGroupClearedRaw?: unknown;
   routeGroupValueRaw?: unknown;
   activeContractFilterKey: string;
   activeSavedFilterKey: string;
@@ -49,6 +50,8 @@ export function resolveRouteSelectionState(options: {
   const routeFilter = String(options.routeFilterRaw || '').trim();
   const routeSavedFilter = String(options.routeSavedFilterRaw || '').trim();
   const routeGroupBy = String(options.routeGroupByRaw || '').trim();
+  const routeGroupCleared = String(options.routeGroupClearedRaw || '').trim() === '1'
+    || options.routeGroupClearedRaw === true;
   const routeGroupValue = String(options.routeGroupValueRaw || '').trim();
 
   let activeContractFilterKey = String(options.activeContractFilterKey || '').trim();
@@ -81,7 +84,7 @@ export function resolveRouteSelectionState(options: {
   if (activeGroupByField) {
     const hasGroupBy = options.groupByChips.some((item) => item.field === activeGroupByField);
     if (!hasGroupBy) activeGroupByField = '';
-  } else if (!routeGroupValue) {
+  } else if (!routeGroupValue && !routeGroupCleared) {
     const defaultGroupBy = options.groupByChips.find((item) => item.isDefault);
     if (defaultGroupBy) activeGroupByField = defaultGroupBy.field;
   }

--- a/frontend/apps/web/src/app/runtime/actionViewRouteRuntime.ts
+++ b/frontend/apps/web/src/app/runtime/actionViewRouteRuntime.ts
@@ -173,6 +173,7 @@ export function buildSavedFilterPatch(key?: string): Dict {
 export function buildGroupByPatch(field?: string): Dict {
   return {
     group_by: field || undefined,
+    group_by_cleared: field ? undefined : true,
     group_value: undefined,
     group_page: undefined,
     group_offset: undefined,

--- a/frontend/apps/web/src/views/ActionView.vue
+++ b/frontend/apps/web/src/views/ActionView.vue
@@ -2450,6 +2450,7 @@ const {
     routeFilterRaw: route.query.preset_filter,
     routeSavedFilterRaw: route.query.saved_filter,
     routeGroupByRaw: route.query.group_by,
+    routeGroupClearedRaw: route.query.group_by_cleared,
     routeGroupValueRaw: route.query.group_value,
     sceneReadyDefaultSortRaw: '',
     sceneDefaultSortRaw: '',


### PR DESCRIPTION
## Summary
- preserve an explicit user-cleared grouping state with group_by_cleared=1
- prevent contract default group_by from being re-applied after the user clears grouping
- clear the marker when a user selects a group again

## Validation
- pnpm run typecheck
- pnpm run build