### PR TITLE
fix: move list totals to footer

### DIFF
--- a/frontend/apps/web/src/app/action_runtime/useActionViewDisplayComputedRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewDisplayComputedRuntime.ts
@@ -19,10 +19,7 @@ export function useActionViewDisplayComputedRuntime(options: UseActionViewDispla
     );
   });
 
-  const subtitle = computed(
-    () =>
-      `${options.records.value.length}${options.pageText('subtitle_records_suffix', ' 条记录')}`,
-  );
+  const subtitle = computed(() => '');
 
   const statusLabel = computed(() => {
     if (options.status.value === 'loading') return options.pageText('status_loading', '加载中');

--- a/frontend/apps/web/src/pages/KanbanPage.vue
+++ b/frontend/apps/web/src/pages/KanbanPage.vue
@@ -78,7 +78,6 @@
             跳转
           </button>
         </div>
-        <span v-else class="kanban-count">{{ records.length }} 条记录</span>
       </section>
 
       <slot name="toolbar"></slot>
@@ -113,8 +112,8 @@
       </section>
 
       <section v-if="showPagination" class="pagination-bar">
-        <span>{{ paginationSummary }}</span>
         <div class="pagination-actions">
+          <span class="pagination-total">{{ paginationTotalText }}</span>
           <button
             type="button"
             class="pagination-btn"
@@ -150,6 +149,9 @@
             跳转
           </button>
         </div>
+      </section>
+      <section v-else class="pagination-bar pagination-bar--count-only">
+        <span class="pagination-total">{{ paginationTotalText }}</span>
       </section>
     </template>
   </section>
@@ -248,33 +250,19 @@ const totalPages = computed(() => {
   return Math.max(1, Math.ceil(total / listLimit.value));
 });
 const currentPage = computed(() => Math.min(totalPages.value, Math.floor(listOffset.value / listLimit.value) + 1));
-const rangeStart = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return 0;
-  return Math.min(total, listOffset.value + 1);
-});
-const rangeEnd = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return 0;
-  return Math.min(total, listOffset.value + props.records.length);
-});
 const showPagination = computed(() => listTotal.value !== null && props.status === 'ok');
 const canPagePrev = computed(() => listOffset.value > 0);
 const canPageNext = computed(() => {
   const total = listTotal.value || 0;
   return listOffset.value + listLimit.value < total;
 });
-const paginationSummary = computed(() => {
-  const total = listTotal.value || 0;
-  if (!total) return '共 0 条';
-  return `共 ${total} 条，当前 ${rangeStart.value}-${rangeEnd.value} 条`;
-});
+const paginationTotalText = computed(() => `共 ${listTotal.value ?? props.records.length} 条`);
 const compactSubtitle = computed(() => {
-  const summary = showPagination.value ? paginationSummary.value : `${props.records.length} 条记录`;
   const source = String(props.subtitle || '').trim();
-  if (!source) return summary;
-  const normalized = source.replace(/^\d+\s*条记录\s*·?\s*/, '').trim();
-  return normalized ? `${summary} · ${normalized}` : summary;
+  return source
+    .replace(/^共\s*\d+\s*条(?:，当前\s*\d+\s*-\s*\d+\s*条)?\s*·?\s*/, '')
+    .replace(/^\d+\s*条记录\s*·?\s*/, '')
+    .trim();
 });
 
 function semanticCell(field: string, value: unknown) {
@@ -415,12 +403,6 @@ function formatValue(value: unknown) {
   line-height: 1.35;
 }
 
-.kanban-count {
-  color: var(--sc-app-text-secondary);
-  font-size: 13px;
-  white-space: nowrap;
-}
-
 .card {
   background: var(--sc-app-panel);
   border: 1px solid var(--sc-app-border);
@@ -494,7 +476,7 @@ function formatValue(value: unknown) {
 .pagination-bar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: flex-end;
   gap: 12px;
   border: 1px solid var(--sc-app-border);
   border-radius: 10px;
@@ -504,10 +486,21 @@ function formatValue(value: unknown) {
   font-size: 13px;
 }
 
+.pagination-bar--count-only {
+  justify-content: flex-end;
+}
+
 .pagination-actions {
   display: inline-flex;
   align-items: center;
   gap: 8px;
+}
+
+.pagination-total {
+  color: var(--sc-app-text-secondary);
+  font-size: 13px;
+  font-weight: 600;
+  white-space: nowrap;
 }
 
 .pagination-actions--top {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -47,7 +47,6 @@
             {{ uiLabel('search_submit', '搜索') }}
           </button>
         </div>
-        <span v-else-if="!showPagination" class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
       </section>
       <section class="list-empty-state">
         <div class="list-empty-copy">
@@ -67,6 +66,11 @@
           <button type="button" class="list-empty-secondary" :disabled="loading" @click="onReload">
             {{ uiLabel('empty_retry', '刷新') }}
           </button>
+        </div>
+      </section>
+      <section class="pagination-footer pagination-footer--count-only">
+        <div class="pagination-actions pagination-actions--bottom">
+          <span class="pagination-total">{{ listRecordCountText }}</span>
         </div>
       </section>
     </template>
@@ -95,7 +99,6 @@
             {{ uiLabel('search_submit', '搜索') }}
           </button>
         </div>
-        <span v-else-if="!showPagination" class="list-count">{{ uiLabel('record_count', '{count} 条记录', { count: records.length }) }}</span>
       </section>
 
       <section v-if="enableSummaryStrip && summaryItems.length" class="summary-strip">
@@ -526,6 +529,7 @@
 
       <section v-if="showGroupedWindowPagination" class="pagination-footer">
         <div class="pagination-actions pagination-actions--bottom">
+          <span class="pagination-total">{{ listRecordCountText }}</span>
           <button
             type="button"
             class="pagination-btn"
@@ -608,6 +612,11 @@
               </select>
             </span>
           </label>
+        </div>
+      </section>
+      <section v-else class="pagination-footer pagination-footer--count-only">
+        <div class="pagination-actions pagination-actions--bottom">
+          <span class="pagination-total">{{ listRecordCountText }}</span>
         </div>
       </section>
 
@@ -1251,8 +1260,19 @@ const totalPages = computed(() => {
 });
 const currentPage = computed(() => Math.min(totalPages.value, Math.floor(listOffset.value / listLimit.value) + 1));
 const showPagination = computed(() => listTotal.value !== null && props.status === 'ok' && !showGroupedRows.value);
+const groupedRecordTotal = computed(() => {
+  if (!showGroupedRows.value) return null;
+  const total = sortedGroupedRows.value.reduce((sum, group) => {
+    const count = Number(group.count);
+    return Number.isFinite(count) && count > 0 ? sum + Math.trunc(count) : sum;
+  }, 0);
+  return total > 0 ? total : null;
+});
+const listRecordTotal = computed(() =>
+  listTotal.value ?? groupedRecordTotal.value ?? pageVisibleRows.value.length ?? props.records.length,
+);
 const listRecordCountText = computed(() =>
-  uiLabel('record_count', '{count} 条记录', { count: listTotal.value ?? props.records.length }),
+  uiLabel('record_count', '共 {count} 条', { count: listRecordTotal.value }),
 );
 const toolbarSubtitle = computed(() => props.subtitle || '');
 const canPagePrev = computed(() => listOffset.value > 0);
@@ -1887,12 +1907,6 @@ onBeforeUnmount(() => {
   white-space: nowrap;
 }
 
-.list-count {
-  color: var(--sc-app-text-secondary);
-  font-size: 13px;
-  white-space: nowrap;
-}
-
 .list-header-toolbar {
   display: flex;
   justify-content: flex-start;
@@ -2290,6 +2304,10 @@ onBeforeUnmount(() => {
   z-index: 24;
   background: var(--sc-app-bg);
   padding-top: 6px;
+}
+
+.pagination-footer--count-only {
+  position: static;
 }
 
 .pagination-actions--bottom {


### PR DESCRIPTION
## Summary
- remove record-count subtitles from the shared ActionView model so list totals do not appear in the header
- move ListPage totals to the footer for paginated, grouped, unpaginated, and empty states with the text format 共 {count} 条
- align KanbanPage totals with the same footer-only display and remove top count text

## Validation
- pnpm run typecheck
- pnpm run build