### PR TITLE
fix: use footer-specific list total label

### DIFF
--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1272,7 +1272,7 @@ const listRecordTotal = computed(() =>
   listTotal.value ?? groupedRecordTotal.value ?? pageVisibleRows.value.length ?? props.records.length,
 );
 const listRecordCountText = computed(() =>
-  uiLabel('record_count', '共 {count} 条', { count: listRecordTotal.value }),
+  uiLabel('footer_record_count', '共 {count} 条', { count: listRecordTotal.value }),
 );
 const toolbarSubtitle = computed(() => props.subtitle || '');
 const canPagePrev = computed(() => listOffset.value > 0);


### PR DESCRIPTION
## Summary
- use a footer-specific i18n key for ListPage totals so existing record_count labels cannot override the required 共 {count} 条 footer text

## Validation
- pnpm run typecheck
- pnpm run build