### PR TITLE
完善销项发票字段投影

### DIFF
--- a/addons/smart_construction_core/models/core/invoice_registration.py
+++ b/addons/smart_construction_core/models/core/invoice_registration.py
@@ -83,9 +83,18 @@ class ScInvoiceRegistration(models.Model):
     tax_rate = fields.Char(string="税率", index=True)
     invoice_content = fields.Char(string="开票内容", index=True)
     cost_category_name = fields.Char(string="成本类别", index=True)
+    invoice_issue_company = fields.Char(string="开票单位", index=True)
+    push_result = fields.Char(string="推送结果", index=True)
+    kingdee_document_no = fields.Char(string="金蝶单据编号", index=True)
+    expected_receipt_date = fields.Date(string="预计回款日期", index=True)
+    applicant_name = fields.Char(string="申请人", index=True)
+    invoice_count = fields.Integer(string="开票张数", default=0)
+    contract_amount = fields.Monetary(string="合同额", currency_field="currency_id")
     amount_no_tax = fields.Monetary(string="不含税金额", currency_field="currency_id")
     tax_amount = fields.Monetary(string="税额", currency_field="currency_id")
     amount_total = fields.Monetary(string="价税合计", currency_field="currency_id")
+    surcharge_amount = fields.Monetary(string="附加税", currency_field="currency_id")
+    related_receipt_amount = fields.Monetary(string="关联回款金额", currency_field="currency_id")
     currency_id = fields.Many2one(
         "res.currency",
         string="币种",

--- a/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
+++ b/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
@@ -718,8 +718,26 @@ LABEL_SOURCE_OVERRIDES = {
 
 MODEL_LABEL_SOURCE_OVERRIDES = {
     'sc.invoice.registration': {
+        '推送结果': ['push_result', 'legacy_document_state', 'state'],
+        '金蝶单据编号': ['kingdee_document_no', 'document_no', 'name'],
+        '预计回款日期': ['expected_receipt_date'],
+        '申请人': ['applicant_name', 'creator_name', 'source_created_by'],
+        '受票方名称': ['partner_id', 'legacy_partner_name'],
+        '含税金额': ['amount_total'],
+        '不含税金额': ['amount_no_tax'],
+        '税额': ['tax_amount'],
+        '附加税': ['surcharge_amount'],
+        '税率': ['tax_rate'],
+        '关联回款金额': ['related_receipt_amount'],
         '累计开票金额': ['amount_total'],
         '本次开票金额': ['amount_total'],
+        '合同额': ['contract_amount'],
+        '本次开票张数': ['invoice_count'],
+        '开票张数': ['invoice_count'],
+        '发票号': ['invoice_no'],
+        '发票种类': ['invoice_type'],
+        '开票单位': ['invoice_issue_company', 'company_id'],
+        '开票日期': ['invoice_date'],
     },
     'sc.material.inbound': {
         '数量': ['total_qty'],
@@ -783,7 +801,9 @@ def _alias_value(record, label):
 
 
 def _compute_p1_daily_business_visible_aliases(self):
-    labels = P1_ALIAS_LABELS.get(self._name, ())
+    labels = list(dict.fromkeys(
+        list(P1_ALIAS_LABELS.get(self._name, ())) + P1_ALIAS_COMPAT_LABELS.get(self._name, [])
+    ))
     field_pairs = [(_alias_field_name(label), label) for label in labels]
     for record in self:
         for field_name, label in field_pairs:

--- a/addons/smart_construction_core/views/core/invoice_registration_views.xml
+++ b/addons/smart_construction_core/views/core/invoice_registration_views.xml
@@ -17,6 +17,9 @@
                     <field name="partner_id"/>
                     <field name="contract_id"/>
                     <field name="invoice_type"/>
+                    <field name="invoice_issue_company"/>
+                    <field name="kingdee_document_no"/>
+                    <field name="push_result"/>
                     <filter string="发票登记" name="source_kind_invoice_registration" domain="[('source_kind', '=', 'invoice_registration')]"/>
                     <filter string="进项税额" name="source_kind_input_invoice_tax" domain="[('source_kind', '=', 'input_invoice_tax')]"/>
                     <filter string="销项税额" name="source_kind_output_invoice_tax" domain="[('source_kind', '=', 'output_invoice_tax')]"/>
@@ -35,6 +38,8 @@
                     <filter string="按类型" name="group_source_kind" context="{'group_by': 'source_kind'}"/>
                     <filter string="按发票类型" name="group_invoice_type" context="{'group_by': 'invoice_type'}"/>
                     <filter string="按税率" name="group_tax_rate" context="{'group_by': 'tax_rate'}"/>
+                    <filter string="按开票单位" name="group_invoice_issue_company" context="{'group_by': 'invoice_issue_company'}"/>
+                    <filter string="按推送结果" name="group_push_result" context="{'group_by': 'push_result'}"/>
                     <filter string="按成本类别" name="group_cost_category" context="{'group_by': 'cost_category_name'}"/>
                     <filter string="按状态" name="group_state" context="{'group_by': 'state'}"/>
                     <filter string="按发票日期" name="group_invoice_date" context="{'group_by': 'invoice_date'}"/>
@@ -56,18 +61,27 @@
                     <field name="invoice_code"/>
                     <field name="invoice_type"/>
                     <field name="tax_rate"/>
+                    <field name="invoice_issue_company"/>
                     <field name="invoice_content"/>
                     <field name="amount_no_tax" sum="不含税金额"/>
                     <field name="tax_amount" sum="税额"/>
                     <field name="amount_total" sum="价税合计"/>
+                    <field name="surcharge_amount" optional="show" sum="附加税"/>
+                    <field name="invoice_count" optional="show" sum="开票张数"/>
+                    <field name="related_receipt_amount" optional="show" sum="关联回款金额"/>
                     <field name="project_id"/>
                     <field name="operation_strategy"/>
                     <field name="partner_id"/>
                     <field name="contract_id" optional="show"/>
+                    <field name="contract_amount" optional="show" sum="合同额"/>
                     <field name="settlement_id" optional="hide"/>
                     <field name="cost_category_name" optional="show"/>
                     <field name="document_no" optional="show"/>
                     <field name="document_date" optional="show"/>
+                    <field name="kingdee_document_no" optional="show"/>
+                    <field name="push_result" optional="show"/>
+                    <field name="expected_receipt_date" optional="show"/>
+                    <field name="applicant_name" optional="show"/>
                     <field name="handler_name"/>
                     <field name="invoice_holder"/>
                     <field name="accounting_state"/>
@@ -125,14 +139,25 @@
                             <field name="invoice_code" readonly="state == 'legacy_confirmed'"/>
                             <field name="invoice_type" readonly="state == 'legacy_confirmed'"/>
                             <field name="tax_rate" readonly="state == 'legacy_confirmed'"/>
+                            <field name="invoice_issue_company" readonly="state == 'legacy_confirmed'"/>
                             <field name="invoice_content" readonly="state == 'legacy_confirmed'"/>
                             <field name="cost_category_name" readonly="state == 'legacy_confirmed'"/>
+                            <field name="invoice_count" readonly="state == 'legacy_confirmed'"/>
                         </group>
                         <group string="金额">
                             <field name="amount_no_tax" readonly="state == 'legacy_confirmed'"/>
                             <field name="tax_amount" readonly="state == 'legacy_confirmed'"/>
                             <field name="amount_total" readonly="state == 'legacy_confirmed'"/>
+                            <field name="surcharge_amount" readonly="state == 'legacy_confirmed'"/>
+                            <field name="related_receipt_amount" readonly="state == 'legacy_confirmed'"/>
+                            <field name="contract_amount" readonly="state == 'legacy_confirmed'"/>
                             <field name="currency_id" invisible="1"/>
+                        </group>
+                        <group string="销项业务信息">
+                            <field name="push_result" readonly="state == 'legacy_confirmed'"/>
+                            <field name="kingdee_document_no" readonly="state == 'legacy_confirmed'"/>
+                            <field name="expected_receipt_date" readonly="state == 'legacy_confirmed'"/>
+                            <field name="applicant_name" readonly="state == 'legacy_confirmed'"/>
                         </group>
                         <group string="办理信息">
                             <field name="handler_name" readonly="state == 'legacy_confirmed'"/>

--- a/scripts/migration/fresh_db_invoice_registration_projection_write.py
+++ b/scripts/migration/fresh_db_invoice_registration_projection_write.py
@@ -173,7 +173,9 @@ env.cr.execute(  # noqa: F821
     INSERT INTO sc_invoice_registration (
       name, source_origin, source_kind, direction, state, project_id, partner_id,
       document_no, document_date, invoice_date, invoice_type,
-      amount_no_tax, tax_amount, amount_total, currency_id,
+      tax_rate, invoice_no, invoice_issue_company, push_result, kingdee_document_no,
+      invoice_count, contract_amount, amount_no_tax, tax_amount, amount_total,
+      surcharge_amount, related_receipt_amount, currency_id,
       legacy_source_model, legacy_source_table, legacy_record_id,
       legacy_document_state, legacy_partner_id, legacy_partner_name,
       legacy_partner_tax_no, note, active, create_uid, write_uid, create_date, write_date
@@ -199,9 +201,30 @@ env.cr.execute(  # noqa: F821
       f.document_date,
       COALESCE(f.document_date, CURRENT_DATE),
       NULLIF(f.invoice_type, ''),
+      CASE
+        WHEN COALESCE(f.source_tax_amount, 0) > 0
+         AND GREATEST(COALESCE(f.source_amount, 0) - COALESCE(f.source_tax_amount, 0), 0) > 0
+        THEN RTRIM(RTRIM(TO_CHAR(ROUND(
+          (
+            COALESCE(f.source_tax_amount, 0)
+            / NULLIF(GREATEST(COALESCE(f.source_amount, 0) - COALESCE(f.source_tax_amount, 0), 0), 0)
+            * 100
+          )::numeric,
+          2
+        ), 'FM999999990.00'), '0'), '.') || '%%'
+        ELSE NULL
+      END,
+      NULLIF(surcharge.invoice_no, ''),
+      COALESCE(NULLIF(company.name, ''), NULLIF(f.legacy_project_name, '')),
+      NULLIF(f.legacy_state, ''),
+      NULLIF(f.document_no, ''),
+      COALESCE(surcharge.invoice_count, 0),
+      0,
       GREATEST(COALESCE(f.source_amount, 0) - COALESCE(f.source_tax_amount, 0), 0),
       GREATEST(COALESCE(f.source_tax_amount, 0), 0),
       GREATEST(COALESCE(f.source_amount, 0), 0),
+      GREATEST(COALESCE(surcharge.surcharge_amount, 0), 0),
+      0,
       %s,
       'sc.legacy.invoice.tax.fact',
       f.legacy_source_table,
@@ -224,6 +247,22 @@ env.cr.execute(  # noqa: F821
       NOW(),
       NOW()
     FROM sc_legacy_invoice_tax_fact f
+    LEFT JOIN project_project pp ON pp.id = f.project_id
+    LEFT JOIN res_company company ON company.id = pp.company_id
+    LEFT JOIN LATERAL (
+      SELECT
+        MIN(NULLIF(s.invoice_no, '')) AS invoice_no,
+        COUNT(DISTINCT NULLIF(s.invoice_no, ''))::integer AS invoice_count,
+        COALESCE(SUM(s.surcharge_amount), 0) AS surcharge_amount
+      FROM sc_legacy_invoice_surcharge_fact s
+      WHERE s.active
+        AND (
+          (f.direction = 'output_invoice' AND s.direction = 'output')
+          OR (f.direction = 'input_invoice' AND s.direction = 'input')
+        )
+        AND s.document_no = f.document_no
+        AND (s.project_id = f.project_id OR s.project_id IS NULL OR f.project_id IS NULL)
+    ) surcharge ON TRUE
     LEFT JOIN LATERAL (
       SELECT rp.id
         FROM res_partner rp
@@ -250,13 +289,179 @@ env.cr.execute(  # noqa: F821
       document_date = EXCLUDED.document_date,
       invoice_date = EXCLUDED.invoice_date,
       invoice_type = EXCLUDED.invoice_type,
+      tax_rate = EXCLUDED.tax_rate,
+      invoice_no = EXCLUDED.invoice_no,
+      invoice_issue_company = EXCLUDED.invoice_issue_company,
+      push_result = EXCLUDED.push_result,
+      kingdee_document_no = EXCLUDED.kingdee_document_no,
+      invoice_count = EXCLUDED.invoice_count,
+      contract_amount = EXCLUDED.contract_amount,
       amount_no_tax = EXCLUDED.amount_no_tax,
       tax_amount = EXCLUDED.tax_amount,
       amount_total = EXCLUDED.amount_total,
+      surcharge_amount = EXCLUDED.surcharge_amount,
+      related_receipt_amount = EXCLUDED.related_receipt_amount,
       legacy_document_state = EXCLUDED.legacy_document_state,
       legacy_partner_id = EXCLUDED.legacy_partner_id,
       legacy_partner_name = EXCLUDED.legacy_partner_name,
       legacy_partner_tax_no = EXCLUDED.legacy_partner_tax_no,
+      note = EXCLUDED.note,
+      active = EXCLUDED.active,
+      write_uid = 1,
+      write_date = NOW()
+    """,
+    [currency_id],
+)
+
+env.cr.execute(  # noqa: F821
+    """
+    INSERT INTO sc_invoice_registration (
+      name, source_origin, source_kind, direction, state, project_id, partner_id,
+      contract_id, document_no, document_date, invoice_date, expected_receipt_date,
+      invoice_no, invoice_code, invoice_type, tax_rate, invoice_content,
+      invoice_issue_company, push_result, kingdee_document_no, applicant_name,
+      invoice_count, contract_amount, amount_no_tax, tax_amount, amount_total,
+      surcharge_amount, related_receipt_amount, currency_id,
+      legacy_source_model, legacy_source_table, legacy_record_id,
+      legacy_document_state, legacy_partner_id, legacy_partner_name,
+      legacy_partner_tax_no, legacy_attachment_ref, creator_legacy_user_id,
+      creator_name, created_time, note, active, create_uid, write_uid, create_date, write_date
+    )
+    SELECT
+      COALESCE(NULLIF(f.invoice_no, ''), NULLIF(f.document_no, ''), 'LEGACY-INCOME-INVOICE-' || f.legacy_record_id),
+      'legacy',
+      'output_invoice_tax',
+      'output',
+      CASE WHEN COALESCE(f.document_state, '') = '2' THEN 'legacy_confirmed' ELSE 'draft' END,
+      f.project_id,
+      partner_match.id,
+      contract_match.id,
+      NULLIF(f.document_no, ''),
+      f.document_date::date,
+      COALESCE(f.invoice_date::date, f.document_date::date, f.created_time::date, CURRENT_DATE),
+      f.expected_receipt_date::date,
+      NULLIF(f.invoice_no, ''),
+      NULLIF(f.invoice_code, ''),
+      NULLIF(f.invoice_type, ''),
+      CASE
+        WHEN COALESCE(f.tax_rate, 0) > 0
+        THEN RTRIM(RTRIM(TO_CHAR(ROUND(f.tax_rate::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
+        WHEN COALESCE(f.tax_amount, 0) > 0 AND GREATEST(COALESCE(f.amount_no_tax, 0), 0) > 0
+        THEN RTRIM(RTRIM(TO_CHAR(ROUND((f.tax_amount / NULLIF(f.amount_no_tax, 0) * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
+        ELSE NULL
+      END,
+      NULLIF(f.invoice_content, ''),
+      COALESCE(NULLIF(company.name, ''), NULLIF(f.project_name, '')),
+      NULLIF(f.document_state, ''),
+      NULLIF(f.document_no, ''),
+      NULLIF(f.creator_name, ''),
+      CASE
+        WHEN COALESCE(f.qty, 0) > 0 THEN GREATEST(ROUND(f.qty)::integer, 1)
+        WHEN NULLIF(f.invoice_no, '') IS NOT NULL THEN 1
+        ELSE 0
+      END,
+      GREATEST(COALESCE(f.amount_contract, 0), 0),
+      GREATEST(COALESCE(f.amount_no_tax, 0), 0),
+      GREATEST(COALESCE(f.tax_amount, 0), 0),
+      GREATEST(COALESCE(f.amount_total, COALESCE(f.amount_no_tax, 0) + COALESCE(f.tax_amount, 0)), 0),
+      0,
+      GREATEST(COALESCE(f.amount_received, 0), 0),
+      %s,
+      'sc.legacy.income.invoice.fact',
+      f.source_table,
+      f.legacy_record_id,
+      NULLIF(f.document_state, ''),
+      NULLIF(f.partner_legacy_id, ''),
+      NULLIF(f.partner_name, ''),
+      NULLIF(f.partner_tax_no, ''),
+      NULLIF(f.attachment_ref, ''),
+      NULLIF(f.creator_legacy_user_id, ''),
+      NULLIF(f.creator_name, ''),
+      f.created_time,
+      CONCAT_WS(E'\n',
+        '[migration:income_invoice] legacy_record_id=' || f.legacy_record_id,
+        NULLIF(f.fact_type, ''),
+        NULLIF(f.source_table, ''),
+        NULLIF(f.project_name, ''),
+        NULLIF(f.partner_name, ''),
+        NULLIF(f.contract_no, ''),
+        NULLIF(f.note, '')
+      ),
+      f.active,
+      1,
+      1,
+      NOW(),
+      NOW()
+    FROM sc_legacy_income_invoice_fact f
+    LEFT JOIN project_project pp ON pp.id = f.project_id
+    LEFT JOIN res_company company ON company.id = pp.company_id
+    LEFT JOIN LATERAL (
+      SELECT rp.id
+        FROM res_partner rp
+       WHERE rp.active
+         AND (
+           (f.partner_name IS NOT NULL AND rp.name = f.partner_name)
+           OR (f.partner_tax_no IS NOT NULL AND rp.vat = f.partner_tax_no)
+         )
+       ORDER BY
+         CASE WHEN f.partner_tax_no IS NOT NULL AND rp.vat = f.partner_tax_no THEN 0 ELSE 1 END,
+         rp.id
+       LIMIT 1
+    ) partner_match ON TRUE
+    LEFT JOIN LATERAL (
+      SELECT c.id
+        FROM construction_contract c
+       WHERE (
+           (f.contract_legacy_id IS NOT NULL AND c.legacy_contract_id = f.contract_legacy_id)
+           OR (f.contract_no IS NOT NULL AND c.name = f.contract_no)
+       )
+       ORDER BY c.id
+       LIMIT 1
+    ) contract_match ON TRUE
+    WHERE f.active
+      AND f.project_id IS NOT NULL
+      AND f.fact_type IN ('invoice_application', 'invoice_application_line', 'invoice_issue', 'invoice_issue_line')
+      AND (
+        GREATEST(COALESCE(f.amount_total, 0), 0) > 0
+        OR GREATEST(COALESCE(f.amount_no_tax, 0), 0) > 0
+        OR GREATEST(COALESCE(f.tax_amount, 0), 0) > 0
+      )
+    ON CONFLICT (legacy_source_model, legacy_record_id)
+    DO UPDATE SET
+      source_kind = EXCLUDED.source_kind,
+      direction = EXCLUDED.direction,
+      state = EXCLUDED.state,
+      project_id = EXCLUDED.project_id,
+      partner_id = EXCLUDED.partner_id,
+      contract_id = EXCLUDED.contract_id,
+      document_no = EXCLUDED.document_no,
+      document_date = EXCLUDED.document_date,
+      invoice_date = EXCLUDED.invoice_date,
+      expected_receipt_date = EXCLUDED.expected_receipt_date,
+      invoice_no = EXCLUDED.invoice_no,
+      invoice_code = EXCLUDED.invoice_code,
+      invoice_type = EXCLUDED.invoice_type,
+      tax_rate = EXCLUDED.tax_rate,
+      invoice_content = EXCLUDED.invoice_content,
+      invoice_issue_company = EXCLUDED.invoice_issue_company,
+      push_result = EXCLUDED.push_result,
+      kingdee_document_no = EXCLUDED.kingdee_document_no,
+      applicant_name = EXCLUDED.applicant_name,
+      invoice_count = EXCLUDED.invoice_count,
+      contract_amount = EXCLUDED.contract_amount,
+      amount_no_tax = EXCLUDED.amount_no_tax,
+      tax_amount = EXCLUDED.tax_amount,
+      amount_total = EXCLUDED.amount_total,
+      surcharge_amount = EXCLUDED.surcharge_amount,
+      related_receipt_amount = EXCLUDED.related_receipt_amount,
+      legacy_document_state = EXCLUDED.legacy_document_state,
+      legacy_partner_id = EXCLUDED.legacy_partner_id,
+      legacy_partner_name = EXCLUDED.legacy_partner_name,
+      legacy_partner_tax_no = EXCLUDED.legacy_partner_tax_no,
+      legacy_attachment_ref = EXCLUDED.legacy_attachment_ref,
+      creator_legacy_user_id = EXCLUDED.creator_legacy_user_id,
+      creator_name = EXCLUDED.creator_name,
+      created_time = EXCLUDED.created_time,
       note = EXCLUDED.note,
       active = EXCLUDED.active,
       write_uid = 1,


### PR DESCRIPTION
## Summary
- add outgoing invoice business fields to invoice registration model and views
- backfill outgoing invoice number, tax rate, issue company, push result, Kingdee document number, invoice count, surcharge, and receipt-related amounts from legacy invoice facts
- bind P1 visible aliases to the new invoice fields and compute compatibility aliases consistently

## Verification
- python3 -m py_compile addons/smart_construction_core/models/core/invoice_registration.py addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py scripts/migration/fresh_db_invoice_registration_projection_write.py
- python3 -m xml.etree.ElementTree addons/smart_construction_core/views/core/invoice_registration_views.xml
- git diff --check
- ENV=dev ENV_FILE=.env.dev CODEX_NEED_UPGRADE=1 CODEX_MODULES=smart_construction_core make mod.upgrade
- ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo make odoo.shell.exec < scripts/migration/fresh_db_invoice_registration_projection_write.py
- ENV=dev ENV_FILE=.env.dev make verify.invoice_entry_fact.contract_guard
- ENV=dev ENV_FILE=.env.dev make verify.invoice_entry_fact.runtime_smoke
- ENV=dev ENV_FILE=.env.dev make verify.invoice_entry_fact.browser_smoke

## Runtime evidence
- output invoices: 3103
- issue company / push result / Kingdee document no: 3103 populated
- invoice no / invoice count: 2876 populated
- tax rate: 2499 populated
- surcharge: 2604 rows, sum 20888476.9972
