### PR TITLE
完善产品交付控制台

### DIFF
--- a/addons/smart_construction_bundle/__init__.py
+++ b/addons/smart_construction_bundle/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401
+from .core_extension import (  # noqa: F401
+    get_intent_handler_contributions,
+    get_system_init_fact_contributions,
+    smart_core_extend_system_init,
+)

--- a/addons/smart_construction_bundle/__manifest__.py
+++ b/addons/smart_construction_bundle/__manifest__.py
@@ -8,6 +8,7 @@
     "depends": ["smart_core"],
     "data": [
         "data/construction_bundle_product_profile.xml",
+        "data/product_delivery_extension_modules.xml",
     ],
     "application": False,
     "installable": True

--- a/addons/smart_construction_bundle/core_extension.py
+++ b/addons/smart_construction_bundle/core_extension.py
@@ -18,6 +18,30 @@ def get_intent_handler_contributions():
     return []
 
 
+def _build_bundle_product_fact() -> dict:
+    return {
+        "profile": product_profile(),
+        "name": "smart_construction_bundle",
+        "scenes": list_bundle_scenes(),
+        "capabilities": list_bundle_capabilities(),
+        "recommended_roles": recommended_roles(),
+        "default_dashboard": default_dashboard(),
+    }
+
+
+def get_system_init_fact_contributions(env, user, context=None):
+    context = context if isinstance(context, dict) else {}
+    bundle = str((context.get("sc.bundle") or (env.context or {}).get("sc.bundle") or "")).strip().lower()
+    if bundle not in {"", "construction"}:
+        return None
+    return {
+        "module": "product",
+        "facts": {
+            "bundle": _build_bundle_product_fact(),
+        },
+    }
+
+
 def smart_core_extend_system_init(data, env, user):
     try:
         bundle = str((env.context or {}).get("sc.bundle") or "").strip().lower()
@@ -25,14 +49,7 @@ def smart_core_extend_system_init(data, env, user):
             return
         ext_facts = data.get("ext_facts") if isinstance(data.get("ext_facts"), dict) else {}
         product = ext_facts.get("product") if isinstance(ext_facts.get("product"), dict) else {}
-        product["bundle"] = {
-            "profile": product_profile(),
-            "name": "smart_construction_bundle",
-            "scenes": list_bundle_scenes(),
-            "capabilities": list_bundle_capabilities(),
-            "recommended_roles": recommended_roles(),
-            "default_dashboard": default_dashboard(),
-        }
+        product["bundle"] = _build_bundle_product_fact()
         ext_facts["product"] = product
         data["ext_facts"] = ext_facts
     except Exception as exc:

--- a/addons/smart_construction_bundle/data/product_delivery_extension_modules.xml
+++ b/addons/smart_construction_bundle/data/product_delivery_extension_modules.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <function model="ir.config_parameter" name="set_param">
+        <value>sc.core.extension_modules</value>
+        <value>smart_construction_core,smart_construction_portal,smart_construction_bundle,smart_license_core</value>
+    </function>
+</odoo>

--- a/addons/smart_core/core/system_init_payload_builder.py
+++ b/addons/smart_core/core/system_init_payload_builder.py
@@ -50,6 +50,7 @@ class SystemInitPayloadBuilder:
     }
     MINIMAL_EXT_FACT_KEYS = {
         "enterprise_enablement",
+        "product",
     }
     DEFAULT_STARTUP_PAGE_KEYS = ("home", "my_work", "workbench")
 

--- a/addons/smart_core/delivery/release_operator_read_model_service.py
+++ b/addons/smart_core/delivery/release_operator_read_model_service.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+import importlib
 from copy import deepcopy
 from typing import Any
 
 from odoo.addons.smart_core.core.source_authority import build_source_authority_contract
+from odoo.addons.smart_core.utils.extension_hooks import iter_extension_modules
 
 from .release_approval_policy_service import ReleaseApprovalPolicyService
 from .release_audit_trail_service import ReleaseAuditTrailService
@@ -140,6 +142,7 @@ class ReleaseOperatorReadModelService:
             "action_retry": "重试",
             "action_refresh": "刷新",
             "section_release_state": "当前发布状态",
+            "section_product_delivery_console": "产品交付控制台",
             "section_control_scope": "受控内容",
             "section_policy_control": "产品策略管控",
             "section_candidate": "可 Promote 候选",
@@ -172,6 +175,79 @@ class ReleaseOperatorReadModelService:
             "history_actions_title": "Actions",
             "history_snapshots_title": "Snapshots",
             "approve_action_label": "审批并执行",
+        }
+
+    def _load_product_ext_facts(self) -> dict[str, Any]:
+        product: dict[str, Any] = {}
+        for module_name in iter_extension_modules(self.env):
+            try:
+                module = importlib.import_module(f"odoo.addons.{module_name}")
+            except Exception:
+                continue
+            hook = getattr(module, "get_system_init_fact_contributions", None)
+            if not callable(hook):
+                continue
+            try:
+                payload = hook(self.env, self.env.user, context={})
+            except Exception:
+                continue
+            rows = payload if isinstance(payload, list) else [payload]
+            for row in rows:
+                if not isinstance(row, dict) or _text(row.get("module")) != "product":
+                    continue
+                facts = row.get("facts")
+                if isinstance(facts, dict):
+                    product.update(facts)
+        return product
+
+    def _build_product_delivery_console(
+        self,
+        *,
+        identity: dict[str, Any],
+        control_scope: dict[str, Any],
+        release_pipeline: dict[str, Any],
+        current_release_state: dict[str, Any],
+    ) -> dict[str, Any]:
+        product_facts = self._load_product_ext_facts()
+        bundle = _dict(product_facts.get("bundle"))
+        license_payload = _dict(product_facts.get("license"))
+        profile = _dict(bundle.get("profile"))
+        capabilities = [row for row in _list(bundle.get("capabilities")) if isinstance(row, dict)]
+        scenes = [row for row in _list(bundle.get("scenes")) if isinstance(row, dict)]
+        checks = [row for row in _list(release_pipeline.get("preflight_checks")) if isinstance(row, dict)]
+        blocking_count = len([row for row in checks if _text(row.get("status")) == "fail"])
+        warn_count = len([row for row in checks if _text(row.get("status")) == "warn"])
+        return {
+            "product_key": identity.get("product_key") or profile.get("product_key") or "",
+            "base_product_key": identity.get("base_product_key") or "",
+            "edition_key": identity.get("edition_key") or "",
+            "profile": profile,
+            "bundle": {
+                "name": bundle.get("name") or "",
+                "default_dashboard": bundle.get("default_dashboard") or "",
+                "recommended_roles": _list(bundle.get("recommended_roles")),
+                "scene_count": len(scenes),
+                "capability_count": len(capabilities),
+                "scenes": scenes,
+                "capabilities": capabilities,
+            },
+            "license": license_payload,
+            "readiness": {
+                "status": "blocked" if blocking_count else ("warn" if warn_count else "ready"),
+                "blocking_count": blocking_count,
+                "warn_count": warn_count,
+                "controlled_page_count": int(control_scope.get("page_count") or 0),
+                "released_page_count": int(control_scope.get("released_page_count") or 0),
+                "candidate_snapshot_count": int(_dict(release_pipeline.get("change_summary")).get("candidate_snapshot_count") or 0),
+                "active_snapshot": _dict(current_release_state.get("active_snapshot")),
+            },
+            "acceptance_assets": _list(profile.get("acceptance_assets")),
+            "source_authority": {
+                "kind": "release_operator_product_delivery_console_projection",
+                "authorities": ["system_init_extension_fact_contributions", "release_operator_read_model_projection"],
+                "projection_only": True,
+                "no_business_fact_authority": True,
+            },
         }
 
     def _build_control_scope(self, *, product_key: str) -> dict[str, Any]:
@@ -596,6 +672,12 @@ class ReleaseOperatorReadModelService:
             pending_approval_queue=pending_approval_queue,
             candidate_snapshots=candidate_snapshots,
         )
+        product_delivery_console = self._build_product_delivery_console(
+            identity=identity,
+            control_scope=control_scope,
+            release_pipeline=release_pipeline,
+            current_release_state=current_release_state,
+        )
         role_context = self.approval_policy_service.resolve_actor_role_context(self.env.user)
         available_operator_actions = {
             "write_model_contract_version": RELEASE_OPERATOR_WRITE_MODEL_CONTRACT_VERSION,
@@ -696,6 +778,7 @@ class ReleaseOperatorReadModelService:
             "products": self._products(identity["product_key"]),
             "actor_role_context": role_context,
             "control_scope": control_scope,
+            "product_delivery_console": product_delivery_console,
             "release_pipeline": release_pipeline,
             "current_release_state": current_release_state,
             "pending_approval_queue": pending_approval_queue,

--- a/addons/smart_core/delivery/release_operator_surface_service.py
+++ b/addons/smart_core/delivery/release_operator_surface_service.py
@@ -40,6 +40,7 @@ class ReleaseOperatorSurfaceService:
             "copy": dict(read_model.get("copy") or {}),
             "identity": dict(read_model.get("identity") or {}),
             "products": list(read_model.get("products") or []),
+            "product_delivery_console": dict(read_model.get("product_delivery_console") or {}),
             "control_scope": dict(read_model.get("control_scope") or {}),
             "release_pipeline": dict(read_model.get("release_pipeline") or {}),
             "release_state": dict(read_model.get("current_release_state") or {}),

--- a/addons/smart_core/tests/test_release_operator_surface_copy_backend.py
+++ b/addons/smart_core/tests/test_release_operator_surface_copy_backend.py
@@ -152,13 +152,16 @@ class _Env(dict):
 
 
 class _ConfigParameter:
-    def __init__(self, default_base):
+    def __init__(self, default_base, params=None):
         self.default_base = default_base
+        self.params = dict(params or {})
 
     def sudo(self):
         return self
 
     def get_param(self, key, default=""):
+        if key in self.params:
+            return self.params[key]
         if key == "smart_core.release_operator.default_base_product_key":
             return self.default_base
         return default
@@ -224,6 +227,45 @@ class TestReleaseOperatorSurfaceCopyBackend(unittest.TestCase):
 
         self.assertEqual((read_model.get("identity") or {}).get("product_key"), "platform.standard")
         self.assertEqual((read_model.get("identity") or {}).get("default_base_source"), "config")
+
+    def test_product_delivery_console_merges_product_extension_facts(self):
+        module = types.ModuleType("odoo.addons.test_product_delivery_extension")
+        module.get_system_init_fact_contributions = lambda env, user, context=None: {
+            "module": "product",
+            "facts": {
+                "bundle": {
+                    "name": "test_bundle",
+                    "profile": {"product_key": "construction.standard", "label": "测试交付包"},
+                    "capabilities": [{"key": "product.project.delivery", "label": "项目交付"}],
+                    "scenes": [{"code": "projects.dashboard", "name": "项目驾驶舱"}],
+                    "recommended_roles": ["pm"],
+                    "default_dashboard": "projects.dashboard",
+                },
+                "license": {
+                    "level": "enterprise",
+                    "tiers": ["community", "pro", "enterprise"],
+                    "customer_visible": True,
+                    "upgrade_hint": "联系管理员升级",
+                },
+            },
+        }
+        sys.modules["odoo.addons.test_product_delivery_extension"] = module
+        env = _Env()
+        env["ir.config_parameter"] = _ConfigParameter(
+            "",
+            params={"sc.core.extension_modules": "test_product_delivery_extension"},
+        )
+        service = TARGET.ReleaseOperatorSurfaceService(env)
+        service.read_model_service.audit_service = _AuditTrailService()
+        service.read_model_service.approval_policy_service = _ApprovalPolicyService()
+
+        payload = service.build_surface(product_key="construction.standard", action_limit=5)
+        console = payload.get("product_delivery_console") or {}
+
+        self.assertEqual((console.get("profile") or {}).get("label"), "测试交付包")
+        self.assertEqual(((console.get("license") or {}).get("level")), "enterprise")
+        self.assertEqual(((console.get("bundle") or {}).get("capability_count")), 1)
+        self.assertEqual(((console.get("source_authority") or {}).get("kind")), "release_operator_product_delivery_console_projection")
 
 
 if __name__ == "__main__":

--- a/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
+++ b/addons/smart_core/tests/test_system_init_payload_builder_semantics.py
@@ -74,6 +74,32 @@ class TestSystemInitPayloadBuilderSemantics(unittest.TestCase):
 
         self.assertNotIn("workspace_home", payload)
 
+    def test_build_startup_surface_keeps_product_extension_facts(self):
+        payload = target.SystemInitPayloadBuilder.build_startup_surface(
+            {
+                "user": {"id": 1},
+                "nav": [],
+                "nav_meta": {},
+                "default_route": {"scene_key": "workspace.home"},
+                "intents": [],
+                "feature_flags": {},
+                "role_surface": {"landing_scene_key": "workspace.home"},
+                "ext_facts": {
+                    "product": {
+                        "bundle": {"profile": {"product_key": "construction.standard"}},
+                        "license": {"level": "enterprise"},
+                    },
+                    "internal_noise": {"hidden": True},
+                },
+            },
+            params={"contract_mode": "user"},
+        )
+
+        product = ((payload.get("ext_facts") or {}).get("product") or {})
+        self.assertEqual((((product.get("bundle") or {}).get("profile") or {}).get("product_key")), "construction.standard")
+        self.assertEqual(((product.get("license") or {}).get("level")), "enterprise")
+        self.assertNotIn("internal_noise", payload.get("ext_facts") or {})
+
     def test_build_startup_surface_keeps_workspace_home_ref(self):
         payload = target.SystemInitPayloadBuilder.build_startup_surface(
             {

--- a/addons/smart_license_core/__init__.py
+++ b/addons/smart_license_core/__init__.py
@@ -1,4 +1,8 @@
 # -*- coding: utf-8 -*-
 
 from . import core_extension  # noqa: F401
-from .core_extension import get_intent_handler_contributions, smart_core_extend_system_init  # noqa: F401
+from .core_extension import (  # noqa: F401
+    get_intent_handler_contributions,
+    get_system_init_fact_contributions,
+    smart_core_extend_system_init,
+)

--- a/addons/smart_license_core/core_extension.py
+++ b/addons/smart_license_core/core_extension.py
@@ -18,6 +18,39 @@ def get_intent_handler_contributions():
     return []
 
 
+def _build_license_product_fact(env) -> dict:
+    level = _load_license_level(env)
+    upgrade_hint = ""
+    reason_codes: list[str] = []
+    try:
+        ICP = env["ir.config_parameter"].sudo()
+        upgrade_hint = str(ICP.get_param("smart_license_core.upgrade_hint") or "").strip()
+        reason_codes = [
+            item.strip()
+            for item in str(ICP.get_param("smart_license_core.reason_codes") or "").split(",")
+            if item.strip()
+        ]
+    except Exception:
+        upgrade_hint = ""
+        reason_codes = []
+    return {
+        "level": level,
+        "tiers": ["community", "pro", "enterprise"],
+        "customer_visible": True,
+        "upgrade_hint": upgrade_hint,
+        "reason_codes": reason_codes,
+    }
+
+
+def get_system_init_fact_contributions(env, user, context=None):
+    return {
+        "module": "product",
+        "facts": {
+            "license": _build_license_product_fact(env),
+        },
+    }
+
+
 def _min_tier_for_key(cap_key: str) -> str:
     key = str(cap_key or "").strip().lower()
     for prefix, tier in PREFIX_MIN_TIER.items():
@@ -44,19 +77,6 @@ def _load_license_level(env) -> str:
 def smart_core_extend_system_init(data, env, user):
     try:
         level = _load_license_level(env)
-        upgrade_hint = ""
-        reason_codes: list[str] = []
-        try:
-            ICP = env["ir.config_parameter"].sudo()
-            upgrade_hint = str(ICP.get_param("smart_license_core.upgrade_hint") or "").strip()
-            reason_codes = [
-                item.strip()
-                for item in str(ICP.get_param("smart_license_core.reason_codes") or "").split(",")
-                if item.strip()
-            ]
-        except Exception:
-            upgrade_hint = ""
-            reason_codes = []
         caps = data.get("capabilities") if isinstance(data.get("capabilities"), list) else []
         filtered = [cap for cap in caps if isinstance(cap, dict) and _allow(cap.get("key"), level)]
         if caps:
@@ -74,13 +94,7 @@ def smart_core_extend_system_init(data, env, user):
 
         ext_facts = data.get("ext_facts") if isinstance(data.get("ext_facts"), dict) else {}
         product = ext_facts.get("product") if isinstance(ext_facts.get("product"), dict) else {}
-        product["license"] = {
-            "level": level,
-            "tiers": ["community", "pro", "enterprise"],
-            "customer_visible": True,
-            "upgrade_hint": upgrade_hint,
-            "reason_codes": reason_codes,
-        }
+        product["license"] = _build_license_product_fact(env)
         ext_facts["product"] = product
         data["ext_facts"] = ext_facts
     except Exception as exc:

--- a/frontend/apps/web/src/stores/session.ts
+++ b/frontend/apps/web/src/stores/session.ts
@@ -59,11 +59,15 @@ export interface ProductFacts {
   license: {
     level: string;
     tiers: string[];
+    customer_visible?: boolean;
+    upgrade_hint?: string;
+    reason_codes?: string[];
   } | null;
   bundle: {
     name: string;
-    scenes: string[];
-    capabilities: string[];
+    profile?: Record<string, unknown>;
+    scenes: Array<Record<string, unknown>>;
+    capabilities: Array<Record<string, unknown>>;
     recommended_roles: string[];
     default_dashboard: string;
   } | null;
@@ -1187,13 +1191,25 @@ export const useSessionStore = defineStore('session', {
           ? {
               level: String(rawLicense.level || ''),
               tiers: Array.isArray(rawLicense.tiers) ? rawLicense.tiers.map((item) => String(item || '')).filter(Boolean) : [],
+              customer_visible: rawLicense.customer_visible !== false,
+              upgrade_hint: String(rawLicense.upgrade_hint || ''),
+              reason_codes: Array.isArray(rawLicense.reason_codes)
+                ? rawLicense.reason_codes.map((item) => String(item || '')).filter(Boolean)
+                : [],
             }
           : null,
         bundle: Object.keys(rawBundle).length
           ? {
               name: String(rawBundle.name || ''),
-              scenes: Array.isArray(rawBundle.scenes) ? rawBundle.scenes.map((item) => String(item || '')).filter(Boolean) : [],
-              capabilities: Array.isArray(rawBundle.capabilities) ? rawBundle.capabilities.map((item) => String(item || '')).filter(Boolean) : [],
+              profile: rawBundle.profile && typeof rawBundle.profile === 'object'
+                ? rawBundle.profile as Record<string, unknown>
+                : {},
+              scenes: Array.isArray(rawBundle.scenes)
+                ? rawBundle.scenes.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && !Array.isArray(item)))
+                : [],
+              capabilities: Array.isArray(rawBundle.capabilities)
+                ? rawBundle.capabilities.filter((item): item is Record<string, unknown> => Boolean(item && typeof item === 'object' && !Array.isArray(item)))
+                : [],
               recommended_roles: Array.isArray(rawBundle.recommended_roles)
                 ? rawBundle.recommended_roles.map((item) => String(item || '')).filter(Boolean)
                 : [],

--- a/frontend/apps/web/src/views/ReleaseOperatorView.vue
+++ b/frontend/apps/web/src/views/ReleaseOperatorView.vue
@@ -69,6 +69,62 @@
 
       <section class="release-operator__section">
         <div class="release-operator__section-head">
+          <h2>{{ copy.section_product_delivery_console || '产品交付控制台' }}</h2>
+          <p>{{ productProfile.label || productConsole.product_key || '-' }}</p>
+        </div>
+        <div class="release-operator__product-grid">
+          <article>
+            <span>产品包</span>
+            <strong>{{ productBundle.name || '-' }}</strong>
+            <small>{{ productBundle.default_dashboard || '-' }}</small>
+          </article>
+          <article>
+            <span>授权层级</span>
+            <strong>{{ productLicense.level || '-' }}</strong>
+            <small>{{ productLicense.customer_visible === false ? '内部可见' : '客户可见' }}</small>
+          </article>
+          <article>
+            <span>交付就绪</span>
+            <strong>{{ readinessLabel(productReadiness.status) }}</strong>
+            <small>阻断 {{ productReadiness.blocking_count ?? 0 }} / 警告 {{ productReadiness.warn_count ?? 0 }}</small>
+          </article>
+          <article>
+            <span>受控页面</span>
+            <strong>{{ productReadiness.controlled_page_count ?? 0 }}</strong>
+            <small>已发布 {{ productReadiness.released_page_count ?? 0 }}</small>
+          </article>
+        </div>
+        <div class="release-operator__delivery-lists">
+          <article>
+            <h3>能力包</h3>
+            <div class="release-operator__tag-list">
+              <span v-for="capability in productCapabilities" :key="productItemKey(capability)">
+                {{ capability.label || capability.key || '-' }}
+              </span>
+            </div>
+          </article>
+          <article>
+            <h3>场景包</h3>
+            <div class="release-operator__tag-list">
+              <span v-for="scene in productScenes" :key="productItemKey(scene)">
+                {{ scene.name || scene.code || '-' }}
+              </span>
+            </div>
+          </article>
+          <article>
+            <h3>交付资产</h3>
+            <div class="release-operator__asset-list">
+              <span v-for="asset in acceptanceAssets" :key="asset">{{ asset }}</span>
+            </div>
+          </article>
+        </div>
+        <p v-if="productLicense.upgrade_hint" class="release-operator__upgrade-hint">
+          {{ productLicense.upgrade_hint }}
+        </p>
+      </section>
+
+      <section class="release-operator__section">
+        <div class="release-operator__section-head">
           <h2>产品配置发布线</h2>
           <p>草案、检查、候选、发布、生效</p>
         </div>
@@ -399,6 +455,7 @@ interface ReleaseOperatorSurface {
   copy?: AnyRecord;
   identity?: AnyRecord;
   products?: ProductRow[];
+  product_delivery_console?: AnyRecord;
   control_scope?: AnyRecord;
   release_pipeline?: AnyRecord;
   release_state?: AnyRecord;
@@ -426,6 +483,23 @@ const copy = computed<Record<string, string>>(() => {
 });
 const identity = computed(() => surface.value?.identity || {});
 const products = computed(() => surface.value?.products || []);
+const productConsole = computed(() => surface.value?.product_delivery_console || {});
+const productProfile = computed(() => (productConsole.value.profile || {}) as AnyRecord);
+const productBundle = computed(() => (productConsole.value.bundle || {}) as AnyRecord);
+const productLicense = computed(() => (productConsole.value.license || {}) as AnyRecord);
+const productReadiness = computed(() => (productConsole.value.readiness || {}) as AnyRecord);
+const productCapabilities = computed(() => {
+  const items = productBundle.value.capabilities;
+  return Array.isArray(items) ? items as AnyRecord[] : [];
+});
+const productScenes = computed(() => {
+  const items = productBundle.value.scenes;
+  return Array.isArray(items) ? items as AnyRecord[] : [];
+});
+const acceptanceAssets = computed(() => {
+  const items = productConsole.value.acceptance_assets;
+  return Array.isArray(items) ? items.map((item) => String(item || '')).filter(Boolean) : [];
+});
 const controlScope = computed(() => surface.value?.control_scope || {});
 const releasePipeline = computed(() => surface.value?.release_pipeline || {});
 const pipelineStages = computed(() => {
@@ -482,6 +556,18 @@ function definitionKey(item: AnyRecord) {
 }
 function pipelineKey(item: AnyRecord) {
   return String(item.key || item.label || '').trim();
+}
+function productItemKey(item: AnyRecord) {
+  return String(item.key || item.code || item.name || item.label || '').trim();
+}
+function readinessLabel(value: unknown) {
+  const status = String(value || '').trim();
+  const labels: Record<string, string> = {
+    ready: '可交付',
+    warn: '需关注',
+    blocked: '有阻断',
+  };
+  return labels[status] || status || '-';
 }
 function releaseStateLabel(page: AnyRecord) {
   const state = String(page.release_state || (page.enabled === false ? 'hidden' : 'released'));
@@ -728,6 +814,77 @@ onMounted(() => {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
   gap: 12px;
+}
+
+.release-operator__product-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.release-operator__product-grid article {
+  border: 1px solid var(--sc-app-border);
+  border-radius: var(--sc-component-panel-radius);
+  padding: 12px;
+}
+
+.release-operator__product-grid span,
+.release-operator__product-grid small {
+  display: block;
+  color: var(--sc-semantic-text-muted);
+  font-size: 12px;
+}
+
+.release-operator__product-grid strong {
+  display: block;
+  margin: 7px 0;
+  overflow-wrap: anywhere;
+  color: var(--sc-app-text-primary);
+  font-size: 18px;
+}
+
+.release-operator__delivery-lists {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 12px;
+}
+
+.release-operator__delivery-lists article {
+  border: 1px solid var(--sc-app-border);
+  border-radius: var(--sc-component-panel-radius);
+  padding: 12px;
+}
+
+.release-operator__delivery-lists h3 {
+  margin: 0 0 10px;
+  font-size: 14px;
+}
+
+.release-operator__tag-list,
+.release-operator__asset-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.release-operator__tag-list span,
+.release-operator__asset-list span {
+  border: 1px solid var(--sc-app-border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  color: var(--sc-app-text-primary);
+  font-size: 12px;
+  overflow-wrap: anywhere;
+}
+
+.release-operator__asset-list span {
+  max-width: 100%;
+}
+
+.release-operator__upgrade-hint {
+  margin-top: 12px;
+  color: var(--sc-semantic-text-muted);
 }
 
 .release-operator__pipeline,
@@ -1029,6 +1186,8 @@ onMounted(() => {
 
   .release-operator__metrics,
   .release-operator__scope-grid,
+  .release-operator__product-grid,
+  .release-operator__delivery-lists,
   .release-operator__pipeline,
   .release-operator__summary-grid,
   .release-operator__checks,

--- a/frontend/packages/schema/src/index.ts
+++ b/frontend/packages/schema/src/index.ts
@@ -150,11 +150,15 @@ export interface AppInitResponse {
       license?: {
         level?: string;
         tiers?: string[];
+        customer_visible?: boolean;
+        upgrade_hint?: string;
+        reason_codes?: string[];
       };
       bundle?: {
         name?: string;
-        scenes?: string[];
-        capabilities?: string[];
+        profile?: Record<string, unknown>;
+        scenes?: Array<Record<string, unknown>>;
+        capabilities?: Array<Record<string, unknown>>;
         recommended_roles?: string[];
         default_dashboard?: string;
       };


### PR DESCRIPTION
## Summary
- 接入施工产品包和 license 到当前 system.init 扩展事实贡献机制
- 在发布控制台增加产品交付控制台视图，展示产品包、授权层级、就绪状态、能力包、场景包和交付资产
- 增加模块升级补丁，确保 sc.core.extension_modules 自动包含产品交付扩展，避免手工配置漂移

## Verification
- python3 addons/smart_core/tests/test_release_operator_surface_copy_backend.py
- python3 addons/smart_core/tests/test_system_init_payload_builder_semantics.py
- python3 -m py_compile addons/smart_construction_bundle/core_extension.py addons/smart_license_core/core_extension.py addons/smart_core/delivery/release_operator_read_model_service.py addons/smart_core/delivery/release_operator_surface_service.py addons/smart_core/core/system_init_payload_builder.py
- make verify.frontend.build
- make verify.product.delivery.ready
- make verify.semantic.behavior.guard.report
- git diff --check

## Runtime Probe
- 本地 sc_demo admin/admin 验证 system.init 返回 construction.standard 与客户可见 license
- 本地 release.operator.surface 返回 product_delivery_console，能力数量 6，license enterprise/customer_visible true