### PR TITLE
让业务配置管理员可见产品交付控制台

### DIFF
--- a/addons/smart_core/handlers/app_shell.py
+++ b/addons/smart_core/handlers/app_shell.py
@@ -60,10 +60,14 @@ APP_ALIASES = {
 
 HIDDEN_APP_IDS = {"default", "scene_smoke_default"}
 PLATFORM_ADMIN_SCENE_APP_IDS = {"delivery"}
+BUSINESS_CONFIG_ADMIN_GROUPS = (
+    "smart_core.group_smart_core_business_config_admin",
+    "smart_construction_core.group_sc_cap_business_config_admin",
+)
 
 ADMIN_APP_DEFS: dict[str, dict[str, Any]] = {
     "release_management": {
-        "label": "产品发布",
+        "label": "产品交付",
         "category": "platform_admin",
         "sequence": -20,
         "route": "/admin/release-operator?product_key=construction.standard",
@@ -185,6 +189,26 @@ def _is_platform_admin_user(env) -> bool:
         return False
 
 
+def _is_business_config_admin_user(env) -> bool:
+    user = getattr(env, "user", None)
+    if not user:
+        return False
+    for xmlid in BUSINESS_CONFIG_ADMIN_GROUPS:
+        try:
+            if user.has_group(xmlid):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _can_access_admin_app(env, app_id: str) -> bool:
+    token = _text(app_id)
+    if token == "release_management":
+        return _is_platform_admin_user(env) or _is_business_config_admin_user(env)
+    return _is_platform_admin_user(env)
+
+
 def _is_scene_app_visible_for_user(env, app_id: str) -> bool:
     token = _text(app_id)
     if token in PLATFORM_ADMIN_SCENE_APP_IDS:
@@ -193,10 +217,10 @@ def _is_scene_app_visible_for_user(env, app_id: str) -> bool:
 
 
 def _admin_app_rows(env) -> list[dict[str, Any]]:
-    if not _is_platform_admin_user(env):
-        return []
     rows: list[dict[str, Any]] = []
     for app_id, spec in ADMIN_APP_DEFS.items():
+        if not _can_access_admin_app(env, app_id):
+            continue
         action = _xmlid_record(env, _text(spec.get("action_xmlid")))
         if not action:
             continue
@@ -212,7 +236,8 @@ def _admin_app_rows(env) -> list[dict[str, Any]]:
                     "sequence": int(spec.get("sequence") or 0),
                     "action_xmlid": _text(spec.get("action_xmlid")),
                     "menu_xmlid": _text(spec.get("menu_xmlid")),
-                    "admin_only": True,
+                    "admin_only": not _is_business_config_admin_user(env),
+                    "business_config_visible": app_id == "release_management",
                 },
             }
         )
@@ -414,7 +439,7 @@ class AppNavHandler(_SceneDeliveryAppShellMixin, BaseIntentHandler):
         if max_depth_error:
             return self._err(400, "max_depth 无效", ts0=ts0)
         app_id = APP_ALIASES.get(_text(payload.get("app") or "workspace"), _text(payload.get("app") or "workspace"))
-        if app_id in ADMIN_APP_DEFS and _is_platform_admin_user(env):
+        if app_id in ADMIN_APP_DEFS and _can_access_admin_app(env, app_id):
             target = _admin_app_target(env, app_id)
             if target:
                 return {
@@ -515,7 +540,7 @@ class AppOpenHandler(_SceneDeliveryAppShellMixin, BaseIntentHandler):
         scene_key = feature_key
         if not scene_key:
             app_id = APP_ALIASES.get(_text(payload.get("app") or "workspace"), _text(payload.get("app") or "workspace"))
-            if app_id in ADMIN_APP_DEFS and _is_platform_admin_user(self.env):
+            if app_id in ADMIN_APP_DEFS and _can_access_admin_app(self.env, app_id):
                 target = _admin_app_target(self.env, app_id)
                 if target:
                     return {

--- a/addons/smart_core/handlers/release_operator.py
+++ b/addons/smart_core/handlers/release_operator.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import annotations
 
+from copy import deepcopy
 import time
 from typing import Any
 
@@ -31,6 +32,10 @@ SOURCE_AUTHORITIES = (
     "sc.product.policy",
 )
 NO_BUSINESS_FACT_AUTHORITY = True
+BUSINESS_CONFIG_ADMIN_GROUPS = (
+    "smart_core.group_smart_core_business_config_admin",
+    "smart_construction_core.group_sc_cap_business_config_admin",
+)
 
 
 def _text(value: Any) -> str:
@@ -66,6 +71,52 @@ def _selection(value: Any, allowed: set[str], field_name: str) -> str:
     return parsed
 
 
+def user_is_business_config_admin(user) -> bool:
+    if not user:
+        return False
+    for xmlid in BUSINESS_CONFIG_ADMIN_GROUPS:
+        try:
+            if user.has_group(xmlid):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def user_can_view_release_operator(user) -> bool:
+    return bool(user_is_platform_admin(user) or user_is_business_config_admin(user))
+
+
+def _readonly_operator_surface(surface: dict[str, Any]) -> dict[str, Any]:
+    payload = deepcopy(surface) if isinstance(surface, dict) else {}
+    actions = payload.get("available_actions")
+    if isinstance(actions, dict):
+        for key, value in list(actions.items()):
+            if isinstance(value, dict):
+                value["enabled"] = False
+                value["reason_code"] = "READ_ONLY_BUSINESS_CONFIG_ADMIN"
+                value["readonly"] = True
+                actions[key] = value
+            elif isinstance(value, list):
+                next_rows = []
+                for row in value:
+                    if isinstance(row, dict):
+                        item = dict(row)
+                        item["enabled"] = False
+                        item["reason_code"] = "READ_ONLY_BUSINESS_CONFIG_ADMIN"
+                        item["readonly"] = True
+                        next_rows.append(item)
+                    else:
+                        next_rows.append(row)
+                actions[key] = next_rows
+    payload["operator_access"] = {
+        "mode": "readonly",
+        "reason_code": "BUSINESS_CONFIG_ADMIN_SURFACE",
+        "write_enabled": False,
+    }
+    return payload
+
+
 class _ReleaseOperatorBaseHandler(BaseIntentHandler):
     REQUIRED_GROUPS = ["smart_core.group_smart_core_admin"]
     ACL_MODE = "explicit_check"
@@ -86,8 +137,8 @@ class _ReleaseOperatorBaseHandler(BaseIntentHandler):
         }
 
     def _check_permissions(self):
-        if not user_is_platform_admin(self.env.user):
-            raise AccessError("PERMISSION_DENIED: release operator requires platform administrator")
+        if not user_can_view_release_operator(self.env.user):
+            raise AccessError("PERMISSION_DENIED: release operator requires platform or business config administrator")
         return True
 
     def _params(self, payload: Any) -> dict[str, Any]:
@@ -234,6 +285,8 @@ class ReleaseOperatorSurfaceHandler(_ReleaseOperatorBaseHandler):
             product_key=product_key,
             action_limit=max(action_limit, 1),
         )
+        if not user_is_platform_admin(self.env.user):
+            surface = _readonly_operator_surface(surface)
         return self._response(ts0, surface)
 
 

--- a/addons/smart_core/tests/test_app_shell_boundaries.py
+++ b/addons/smart_core/tests/test_app_shell_boundaries.py
@@ -91,11 +91,29 @@ class _FakeAction:
         self.view_mode = view_mode
 
 
+class _FakeUser:
+    def __init__(self, *, is_platform_admin=False, business_config_admin=False):
+        self.is_platform_admin = is_platform_admin
+        self.business_config_admin = business_config_admin
+
+    def has_group(self, xmlid):
+        return bool(
+            self.business_config_admin
+            and xmlid in {
+                "smart_core.group_smart_core_business_config_admin",
+                "smart_construction_core.group_sc_cap_business_config_admin",
+            }
+        )
+
+
 class _FakeEnv:
     uid = 9
 
-    def __init__(self, *, is_platform_admin=False, has_action=True):
-        self.user = types.SimpleNamespace(is_platform_admin=is_platform_admin)
+    def __init__(self, *, is_platform_admin=False, business_config_admin=False, has_action=True):
+        self.user = _FakeUser(
+            is_platform_admin=is_platform_admin,
+            business_config_admin=business_config_admin,
+        )
         self.has_action = has_action
 
     def ref(self, xmlid, raise_if_not_found=False):
@@ -203,19 +221,25 @@ class TestAppShellBoundaries(unittest.TestCase):
         self.assertTrue(result["ok"])
         self.assertEqual(result["data"]["scene_key"], "projects.list")
 
-    def test_catalog_adds_platform_admin_apps_only_for_platform_admin(self):
+    def test_catalog_adds_admin_apps_by_role(self):
         normal_handler = self.module.AppCatalogHandler(env=_FakeEnv(is_platform_admin=False))
+        business_handler = self.module.AppCatalogHandler(env=_FakeEnv(business_config_admin=True))
         admin_handler = self.module.AppCatalogHandler(env=_FakeEnv(is_platform_admin=True))
 
         normal_result = normal_handler.handle(payload={})
+        business_result = business_handler.handle(payload={})
         admin_result = admin_handler.handle(payload={})
 
         normal_app_ids = [row["meta"]["app_id"] for row in normal_result["data"]["apps"]]
+        business_app_ids = [row["meta"]["app_id"] for row in business_result["data"]["apps"]]
         admin_app_ids = [row["meta"]["app_id"] for row in admin_result["data"]["apps"]]
         self.assertNotIn("release_management", normal_app_ids)
+        self.assertIn("release_management", business_app_ids)
+        self.assertNotIn("company_access", business_app_ids)
         self.assertIn("release_management", admin_app_ids)
         self.assertIn("company_access", admin_app_ids)
         self.assertEqual(admin_result["data"]["apps"][0]["meta"]["app_id"], "release_management")
+        self.assertEqual(business_result["data"]["apps"][0]["label"], "产品交付")
 
     def test_open_platform_admin_app_returns_release_operator_target(self):
         handler = self.module.AppOpenHandler(env=_FakeEnv(is_platform_admin=True))
@@ -236,6 +260,16 @@ class TestAppShellBoundaries(unittest.TestCase):
         child = result["data"]["sections"][0]["children"][0]
         self.assertEqual(child["meta"]["kind"], "admin")
         self.assertEqual(child["meta"]["open"]["subject"], "ui.contract")
+        self.assertEqual(child["meta"]["open"]["route"], "/admin/release-operator?product_key=construction.standard")
+
+    def test_nav_business_config_admin_can_open_release_operator(self):
+        handler = self.module.AppNavHandler(env=_FakeEnv(business_config_admin=True))
+
+        result = handler.handle(payload={"params": {"app": "release_management"}})
+
+        self.assertTrue(result["ok"])
+        child = result["data"]["sections"][0]["children"][0]
+        self.assertEqual(child["meta"]["open"]["intent"], "release.operator.surface")
         self.assertEqual(child["meta"]["open"]["route"], "/admin/release-operator?product_key=construction.standard")
 
 

--- a/frontend/apps/web/src/views/ReleaseOperatorView.vue
+++ b/frontend/apps/web/src/views/ReleaseOperatorView.vue
@@ -320,7 +320,7 @@
                   <button
                     class="sc-btn sc-btn-primary release-operator__row-action"
                     type="button"
-                    :disabled="busyKey === `promote:${snapshot.id}` || !candidateReady(snapshot)"
+                    :disabled="busyKey === `promote:${snapshot.id}` || !candidateReady(snapshot) || !promoteActionEnabled(snapshot)"
                     @click="promote(snapshot)"
                   >
                     发布
@@ -547,6 +547,11 @@ const updatePagePolicyAction = computed(() => {
   const actions = surface.value?.available_actions || {};
   return (actions.update_page_policy || {}) as { enabled?: boolean; params?: AnyRecord };
 });
+const promoteActions = computed(() => {
+  const actions = surface.value?.available_actions || {};
+  const rows = actions.promote;
+  return Array.isArray(rows) ? rows as AnyRecord[] : [];
+});
 
 function pageKey(page: AnyRecord) {
   return String(page.page_key || page.scene_key || page.menu_key || page.capability_key || '').trim();
@@ -614,6 +619,13 @@ function snapshotDiffLabel(snapshot: SnapshotRow) {
 function candidateReady(snapshot: SnapshotRow) {
   const draft = (snapshot.release_draft || {}) as AnyRecord;
   return Boolean(draft.fingerprint) && Number(draft.blocking_issue_count || 0) === 0;
+}
+function promoteActionEnabled(snapshot: SnapshotRow) {
+  const action = promoteActions.value.find((row) => {
+    const params = (row.params || {}) as AnyRecord;
+    return Number(params.snapshot_id || 0) === Number(snapshot.id || 0);
+  });
+  return Boolean(action?.enabled);
 }
 const freezeAction = computed(() => {
   const actions = surface.value?.available_actions || {};


### PR DESCRIPTION
## Summary
- app.catalog/app.nav/app.open 对业务配置管理员开放产品交付入口
- release.operator.surface 对业务配置管理员只读放行，发布/回滚等写动作仍禁用
- 发布控制台前端按 available_actions.promote 禁用 promote 按钮，避免只读用户误触写操作

## Verification
- python3 addons/smart_core/tests/test_app_shell_boundaries.py
- python3 -m py_compile addons/smart_core/handlers/app_shell.py addons/smart_core/handlers/release_operator.py
- make verify.frontend.build
- make verify.product.delivery.ready
- git diff --check

## Runtime Probe
- wutao/123456 登录后 app.catalog 返回 产品交付
- app.nav/app.open 返回 /admin/release-operator?product_key=construction.standard
- release.operator.surface 返回 operator_access.mode=readonly, write_enabled=false, console_product=construction.standard