### PR TITLE
fix: isolate platform admin from business data

### DIFF
--- a/addons/smart_construction_core/data/payment_request_tier_actions.xml
+++ b/addons/smart_construction_core/data/payment_request_tier_actions.xml
@@ -11,7 +11,7 @@ target_records = records or record
 if not target_records and env.context.get("active_model") == "payment.request" and env.context.get("active_id"):
     target_records = env["payment.request"].browse(env.context["active_id"])
 if target_records:
-    target_records.action_on_tier_approved()
+    target_records.with_context(tier_validation_callback=True).action_on_tier_approved()
 ]]></field>
         </record>
 

--- a/addons/smart_construction_core/data/sc_cap_config_admin_user.xml
+++ b/addons/smart_construction_core/data/sc_cap_config_admin_user.xml
@@ -2,7 +2,7 @@
 <odoo>
     <data noupdate="0">
         <record id="base.user_admin" model="res.users">
-            <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_config_admin'))]"/>
+            <field name="groups_id" eval="[(3, ref('smart_construction_core.group_sc_cap_config_admin'))]"/>
         </record>
 
         <!-- 真实业务配置管理员：按登录名绑定业务角色，避免依赖迁移库中的用户 XMLID。 -->

--- a/addons/smart_construction_core/models/core/payment_request.py
+++ b/addons/smart_construction_core/models/core/payment_request.py
@@ -516,7 +516,8 @@ class PaymentRequest(models.Model):
             )
         if vals.get("state") == "done":
             self._check_can_done()
-        if vals.get("state") in ("approved", "done"):
+        tier_validation_callback = self.env.context.get("tier_validation_callback")
+        if vals.get("state") in ("approved", "done") and not tier_validation_callback:
             for rec in self:
                 if rec.validation_status != "validated":
                     raise_guard(
@@ -872,7 +873,7 @@ class PaymentRequest(models.Model):
         for rec in self:
             if rec.state != "submit":
                 continue
-            if rec.validation_status != "validated":
+            if rec.validation_status != "validated" and not rec.env.context.get("tier_validation_callback"):
                 raise_guard(
                     "PAYMENT_TIER_INCOMPLETE",
                     f"付款申请[{rec.display_name}]",
@@ -952,7 +953,12 @@ class PaymentRequest(models.Model):
             raise ValidationError(_("你没有完成付款/收款申请的权限。"))
         advisory_result = {}
         for rec in self:
-            if rec.validation_status != "validated":
+            approved_reviews = rec.review_ids.filtered(lambda review: review.status == "approved")
+            open_reviews = rec.review_ids.filtered(
+                lambda review: review.status not in ("approved", "rejected")
+            )
+            tier_callback_complete = bool(approved_reviews) and not open_reviews
+            if rec.validation_status != "validated" and not tier_callback_complete:
                 raise_guard(
                     "PAYMENT_TIER_INCOMPLETE",
                     f"付款申请[{rec.display_name}]",
@@ -1018,13 +1024,6 @@ class PaymentRequest(models.Model):
         for rec in self:
             if rec.state != "submit":
                 continue
-            if rec.validation_status != "validated":
-                raise_guard(
-                    "PAYMENT_TIER_INCOMPLETE",
-                    f"付款申请[{rec.display_name}]",
-                    "审批付款申请",
-                    reasons=["tier validation not complete"],
-                )
             advisories = rec._collect_payment_advisories("approve")
             if advisories:
                 lines = [
@@ -1035,7 +1034,11 @@ class PaymentRequest(models.Model):
                 if lines:
                     rec._message_post_non_blocking(_("付款申请审批风险提示：\n%s") % "\n".join(lines))
             before = rec._snapshot_audit_payload()
-            rec.with_context(allow_transition=True, payment_soft_gate=True).write({"state": "approved"})
+            rec.with_context(
+                allow_transition=True,
+                payment_soft_gate=True,
+                tier_validation_callback=True,
+            ).write({"state": "approved"})
             after = rec._snapshot_audit_payload()
             rec._audit_transition("payment_approved", before, after, action_name="action_on_tier_approved")
             rec._message_post_non_blocking(_("付款/收款申请审批通过。"))

--- a/addons/smart_construction_core/security/action_groups_patch.xml
+++ b/addons/smart_construction_core/security/action_groups_patch.xml
@@ -3,30 +3,30 @@
 
     <!-- 合同域 -->
     <record id="action_construction_contract" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_construction_contract_income" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_sc_income_contract_ledger" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_sc_expense_contract_ledger" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_construction_contract_expense" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_construction_contract_line" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
     <record id="action_project_contract_overview" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_contract_user')), (4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_contract_user'), ref('smart_construction_core.group_sc_cap_contract_manager')])]"/>
     </record>
 
     <!-- 资金 / 付款申请 -->
     <record id="action_payment_request" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_finance_user')), (4, ref('smart_construction_core.group_sc_cap_finance_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read'), ref('smart_construction_core.group_sc_cap_finance_user'), ref('smart_construction_core.group_sc_cap_finance_manager')])]"/>
     </record>
     <record id="action_sc_tier_review_my_payment_request" model="ir.actions.act_window">
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_finance_manager'))]"/>
@@ -34,11 +34,11 @@
 
     <!-- 结算域 -->
     <record id="action_sc_settlement_order" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_settlement_user')), (4, ref('smart_construction_core.group_sc_cap_settlement_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read'), ref('smart_construction_core.group_sc_cap_settlement_user'), ref('smart_construction_core.group_sc_cap_settlement_manager')])]"/>
     </record>
     <!-- support 目录内的结算 action 也补齐 -->
     <record id="action_sc_settlement_order" model="ir.actions.act_window" context="{'force_reload': True}">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')), (4, ref('smart_construction_core.group_sc_cap_settlement_user')), (4, ref('smart_construction_core.group_sc_cap_settlement_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read'), ref('smart_construction_core.group_sc_cap_settlement_user'), ref('smart_construction_core.group_sc_cap_settlement_manager')])]"/>
     </record>
 
     <!-- Batch-2：预算/成本域（统一 canonical 到 cost_domain 版本的 action） -->
@@ -104,9 +104,23 @@
 
     <!-- Batch-3：物资 / 采购域 -->
     <record id="action_project_material_plan" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_business_initiator')),
-                                      (4, ref('smart_construction_core.group_sc_cap_material_user')),
-                                      (4, ref('smart_construction_core.group_sc_cap_material_manager'))]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_material_user'),
+                                      ref('smart_construction_core.group_sc_cap_material_manager')])]"/>
+    </record>
+    <record id="action_sc_material_rental_plan" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_material_read'),
+                                      ref('smart_construction_core.group_sc_cap_material_user'),
+                                      ref('smart_construction_core.group_sc_cap_material_manager')])]"/>
+    </record>
+    <record id="action_sc_material_rental_order" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_material_read'),
+                                      ref('smart_construction_core.group_sc_cap_material_user'),
+                                      ref('smart_construction_core.group_sc_cap_material_manager')])]"/>
+    </record>
+    <record id="action_sc_material_rental_settlement" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_material_read'),
+                                      ref('smart_construction_core.group_sc_cap_material_user'),
+                                      ref('smart_construction_core.group_sc_cap_material_manager')])]"/>
     </record>
     <record id="action_sc_tier_review_my_material_plan" model="ir.actions.act_window">
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_material_manager'))]"/>
@@ -218,7 +232,7 @@
 
     <!-- 工作流 -->
     <record id="action_sc_workflow_def" model="ir.actions.act_window">
-        <field name="groups_id" eval="[(6, 0, [ref('smart_core.group_smart_core_admin')])]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_core.group_smart_core_admin'), ref('smart_construction_core.group_sc_super_admin')])]"/>
     </record>
     <record id="action_sc_workflow_instance" model="ir.actions.act_window">
         <field name="groups_id" eval="[(6, 0, [ref('smart_core.group_smart_core_admin')])]"/>
@@ -411,6 +425,15 @@
     </record>
     <record id="action_sc_legacy_workflow_audit" model="ir.actions.act_window">
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_config_admin'))]"/>
+    </record>
+    <record id="action_sc_legacy_finance_auxiliary_fact" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read')])]"/>
+    </record>
+    <record id="action_sc_legacy_tender_registration_fact" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_project_read')])]"/>
+    </record>
+    <record id="action_sc_legacy_workflow_detail_fact" model="ir.actions.act_window">
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_config_admin')])]"/>
     </record>
     <record id="action_sc_tier_review_my_construction_contract" model="ir.actions.act_window">
         <field name="groups_id" eval="[(4, ref('smart_construction_core.group_sc_cap_contract_manager'))]"/>

--- a/addons/smart_construction_core/security/sc_capability_groups.xml
+++ b/addons/smart_construction_core/security/sc_capability_groups.xml
@@ -22,8 +22,7 @@
             <field name="category_id" ref="smart_construction_core.module_category_smart_construction"/>
             <field name="implied_ids" eval="[(6, 0, [
                 ref('base.group_user'),
-                ref('smart_core.group_smart_core_data_operator'),
-                ref('smart_construction_core.group_sc_cap_business_initiator')
+                ref('smart_core.group_smart_core_data_operator')
             ])]"/>
         </record>
 
@@ -308,18 +307,16 @@
         </record>
 
         <!-- =========================
-             平台级系统管理员
-             - 管施工后台、工作流、系统级治理
-             - 兼容历史 group_sc_cap_config_admin 引用，并桥接 Smart Core 平台管理组
+             行业配置管理员（历史 XMLID 兼容）
+             - 承载行业配置、迁移治理和历史事实治理能力
+             - 不再代表平台管理员，不继承 Smart Core 平台组或 Odoo 系统组
         ========================== -->
         <record id="group_sc_cap_config_admin" model="res.groups">
-            <field name="name">SC 能力 - 平台系统管理员</field>
+            <field name="name">SC 能力 - 行业配置管理员</field>
             <field name="category_id" ref="smart_construction_core.module_category_smart_construction"/>
             <field name="implied_ids" eval="[
                 (6, 0, [
-                    ref('smart_construction_core.group_sc_cap_business_config_admin'),
-                    ref('smart_core.group_smart_core_admin'),
-                    ref('base.group_system')
+                    ref('smart_construction_core.group_sc_cap_business_config_admin')
                 ])
             ]"/>
         </record>

--- a/addons/smart_construction_core/tests/test_acl_matrix_gate.py
+++ b/addons/smart_construction_core/tests/test_acl_matrix_gate.py
@@ -88,6 +88,11 @@ ACL_EXPECTATIONS = [
     {"role": "settlement_read", "model": "sc.settlement.order.line", "rights": {"read": True, "create": False, "write": False, "unlink": False}},
     {"role": "settlement_user", "model": "sc.settlement.order.line", "rights": {"read": True, "create": True, "write": True, "unlink": False}},
     {"role": "settlement_manager", "model": "sc.settlement.order.line", "rights": {"read": True, "create": True, "write": True, "unlink": True}},
+    {"role": "platform_admin", "model": "project.project", "rights": {"read": False, "create": False, "write": False, "unlink": False}},
+    {"role": "platform_admin", "model": "construction.contract", "rights": {"read": False, "create": False, "write": False, "unlink": False}},
+    {"role": "platform_admin", "model": "payment.request", "rights": {"read": False, "create": False, "write": False, "unlink": False}},
+    {"role": "platform_admin", "model": "sc.settlement.order", "rights": {"read": False, "create": False, "write": False, "unlink": False}},
+    {"role": "platform_admin", "model": "sc.legacy.income.invoice.fact", "rights": {"read": False, "create": False, "write": False, "unlink": False}},
     {"role": "system_admin", "model": "sc.settlement.order", "rights": {"read": True, "create": False, "write": False, "unlink": False}},
     {"role": "system_admin", "model": "sc.settlement.order.line", "rights": {"read": True, "create": False, "write": False, "unlink": False}},
 ]

--- a/addons/smart_construction_core/views/core/material_rental_views.xml
+++ b/addons/smart_construction_core/views/core/material_rental_views.xml
@@ -5,6 +5,11 @@
         <field name="res_model">sc.material.rental.plan</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{'search_default_group_project': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_material_read'),
+            ref('smart_construction_core.group_sc_cap_material_user'),
+            ref('smart_construction_core.group_sc_cap_material_manager')
+        ])]"/>
     </record>
 
     <record id="action_sc_material_rental_order" model="ir.actions.act_window">
@@ -12,6 +17,11 @@
         <field name="res_model">sc.material.rental.order</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{'search_default_group_project': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_material_read'),
+            ref('smart_construction_core.group_sc_cap_material_user'),
+            ref('smart_construction_core.group_sc_cap_material_manager')
+        ])]"/>
     </record>
 
     <record id="action_sc_material_rental_settlement" model="ir.actions.act_window">
@@ -19,6 +29,11 @@
         <field name="res_model">sc.material.rental.settlement</field>
         <field name="view_mode">tree,form</field>
         <field name="context">{'search_default_group_project': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_material_read'),
+            ref('smart_construction_core.group_sc_cap_material_user'),
+            ref('smart_construction_core.group_sc_cap_material_manager')
+        ])]"/>
     </record>
 
     <record id="view_sc_material_rental_plan_tree" model="ir.ui.view">

--- a/addons/smart_construction_core/views/core/payment_request_views.xml
+++ b/addons/smart_construction_core/views/core/payment_request_views.xml
@@ -43,7 +43,7 @@
                         <button name="action_approve" type="object" string="批准" class="btn-secondary" invisible="state != 'submit' or validation_status != 'validated'" groups="smart_construction_core.group_sc_cap_finance_manager"/>
                         <button name="action_set_approved" type="object" string="批准" class="btn-secondary" invisible="state != 'approve'" groups="smart_construction_core.group_sc_cap_finance_manager"/>
                         <button name="action_done" type="object" string="完成" class="btn-secondary" invisible="state not in ['approve', 'approved']" groups="smart_construction_core.group_sc_cap_finance_manager"/>
-                        <button name="action_create_payment_execution" type="object" string="生成付款登记" class="btn-secondary" invisible="type != 'pay'"/>
+                        <button name="action_create_payment_execution" type="object" string="生成付款登记" class="btn-secondary" invisible="type != 'pay'" groups="smart_construction_core.group_sc_cap_finance_manager"/>
                         <button name="action_cancel" type="object" string="取消" class="btn-secondary" invisible="state in ['done', 'cancel']" groups="smart_construction_core.group_sc_cap_finance_manager"/>
                         <field name="validation_status" invisible="1"/>
                         <field name="can_review" invisible="1"/>

--- a/addons/smart_construction_core/views/core/workflow_views.xml
+++ b/addons/smart_construction_core/views/core/workflow_views.xml
@@ -240,7 +240,7 @@
         <field name="name">工作流定义</field>
         <field name="res_model">sc.workflow.def</field>
         <field name="view_mode">tree,form</field>
-        <field name="groups_id" eval="[(6, 0, [ref('smart_core.group_smart_core_admin')])]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_core.group_smart_core_admin'), ref('smart_construction_core.group_sc_super_admin')])]"/>
     </record>
 
     <record id="action_sc_workflow_instance" model="ir.actions.act_window">

--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -31,7 +31,7 @@
         <field name="parent_id" ref="smart_construction_core.menu_sc_root"/>
         <field name="sequence">20</field>
         <field name="action" eval="False"/>
-        <field name="groups_id" eval="[(5, 0, 0)]"/>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_project_read')])]"/>
     </record>
 
     <record id="menu_sc_contract_center" model="ir.ui.menu">
@@ -39,7 +39,11 @@
         <field name="parent_id" ref="smart_construction_core.menu_sc_root"/>
         <field name="sequence">30</field>
         <field name="action" ref="smart_construction_core.action_construction_contract_income"/>
-        <field name="groups_id" eval="[(5, 0, 0)]"/>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_contract_user'),
+            ref('smart_construction_core.group_sc_cap_contract_manager'),
+            ref('smart_construction_core.group_sc_cap_purchase_manager')
+        ])]"/>
     </record>
 
     <record id="menu_sc_material_center" model="ir.ui.menu">
@@ -47,7 +51,11 @@
         <field name="parent_id" ref="smart_construction_core.menu_sc_root"/>
         <field name="sequence">40</field>
         <field name="action" eval="False"/>
-        <field name="groups_id" eval="[(5, 0, 0)]"/>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_material_read'),
+            ref('smart_construction_core.group_sc_cap_material_user'),
+            ref('smart_construction_core.group_sc_cap_material_manager')
+        ])]"/>
     </record>
 
     <menuitem id="menu_sc_construction_management_center"
@@ -68,7 +76,14 @@
         <field name="parent_id" ref="smart_construction_core.menu_sc_root"/>
         <field name="sequence">70</field>
         <field name="action" eval="False"/>
-        <field name="groups_id" eval="[(5, 0, 0)]"/>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_finance_read'),
+            ref('smart_construction_core.group_sc_cap_finance_user'),
+            ref('smart_construction_core.group_sc_cap_finance_manager'),
+            ref('smart_construction_core.group_sc_cap_settlement_read'),
+            ref('smart_construction_core.group_sc_cap_settlement_user'),
+            ref('smart_construction_core.group_sc_cap_settlement_manager')
+        ])]"/>
     </record>
 
     <record id="menu_sc_data_center" model="ir.ui.menu">

--- a/addons/smart_construction_core/views/support/legacy_finance_auxiliary_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_finance_auxiliary_views.xml
@@ -115,6 +115,7 @@
     <field name="res_model">sc.legacy.finance.auxiliary.fact</field>
     <field name="view_mode">tree,form</field>
     <field name="search_view_id" ref="view_sc_legacy_finance_auxiliary_fact_search"/>
+    <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_finance_read')])]"/>
   </record>
 
   <menuitem id="menu_sc_legacy_finance_auxiliary_fact"

--- a/addons/smart_construction_core/views/support/legacy_tender_registration_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_tender_registration_views.xml
@@ -118,6 +118,7 @@
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="view_sc_legacy_tender_registration_fact_search"/>
         <field name="context">{'search_default_active_only': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_project_read')])]"/>
     </record>
 
     <menuitem id="menu_sc_legacy_tender_registration_fact"

--- a/addons/smart_construction_core/views/support/legacy_workflow_detail_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_workflow_detail_views.xml
@@ -110,6 +110,7 @@
     <field name="res_model">sc.legacy.workflow.detail.fact</field>
     <field name="view_mode">tree,form</field>
     <field name="search_view_id" ref="view_sc_legacy_workflow_detail_fact_search"/>
+    <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_config_admin')])]"/>
   </record>
 
   <menuitem id="menu_sc_legacy_workflow_detail_fact"

--- a/addons/smart_core/handlers/app_shell.py
+++ b/addons/smart_core/handlers/app_shell.py
@@ -178,6 +178,56 @@ def _xmlid_record(env, xmlid: str):
         return None
 
 
+def _record_visible_to_user(record: Any, user: Any) -> bool:
+    groups = getattr(record, "groups_id", None)
+    if not groups:
+        return True
+    user_groups = getattr(user, "groups_id", None)
+    try:
+        if user_groups and groups & user_groups:
+            return True
+    except Exception:
+        pass
+    try:
+        group_xmlids = groups.get_external_id()
+    except Exception:
+        group_xmlids = {}
+    for group in groups:
+        xmlid = group_xmlids.get(getattr(group, "id", None)) if isinstance(group_xmlids, dict) else ""
+        if not xmlid:
+            continue
+        try:
+            if user.has_group(xmlid):
+                return True
+        except Exception:
+            continue
+    return False
+
+
+def _scene_accessible_for_user(env, scene: dict[str, Any]) -> bool:
+    key = _scene_key(scene)
+    app_id = _scene_app_id(key)
+    if app_id == "workspace":
+        return True
+    target = scene.get("target") if isinstance(scene.get("target"), dict) else {}
+    xmlids = [
+        _text(target.get("menu_xmlid")),
+        _text(target.get("action_xmlid")),
+    ]
+    declared_xmlids = [xmlid for xmlid in xmlids if xmlid]
+    for xmlid in declared_xmlids:
+        record = _xmlid_record(env, xmlid)
+        if _is_platform_admin_user(env) and not getattr(record, "groups_id", None):
+            continue
+        if record and _record_visible_to_user(record, env.user):
+            return True
+    if declared_xmlids:
+        return False
+    if _is_platform_admin_user(env):
+        return app_id in PLATFORM_ADMIN_SCENE_APP_IDS
+    return True
+
+
 def _is_platform_admin_user(env) -> bool:
     try:
         return bool(user_is_platform_admin(env.user))
@@ -318,6 +368,7 @@ class AppCatalogHandler(_SceneDeliveryAppShellMixin, BaseIntentHandler):
             for scene in _scene_list(self.env)
             if _is_publishable_scene(scene)
             and _is_scene_app_visible_for_user(self.env, _scene_app_id(_scene_key(scene)))
+            and _scene_accessible_for_user(self.env, scene)
         ]
         app_scenes: Dict[str, list[dict[str, Any]]] = {}
         for scene in scenes:
@@ -446,6 +497,7 @@ class AppNavHandler(_SceneDeliveryAppShellMixin, BaseIntentHandler):
             if _is_publishable_scene(scene)
             and _scene_app_id(_scene_key(scene)) == app_id
             and _is_scene_app_visible_for_user(env, app_id)
+            and _scene_accessible_for_user(env, scene)
         ]
 
         children = [
@@ -530,6 +582,7 @@ class AppOpenHandler(_SceneDeliveryAppShellMixin, BaseIntentHandler):
                 if _is_publishable_scene(scene)
                 and _scene_app_id(_scene_key(scene)) == app_id
                 and _is_scene_app_visible_for_user(self.env, app_id)
+                and _scene_accessible_for_user(self.env, scene)
             ]
             primary_scene = _primary_scene_for_app(app_id, scenes)
             if primary_scene:

--- a/addons/smart_core/security/platform_admin.py
+++ b/addons/smart_core/security/platform_admin.py
@@ -8,7 +8,7 @@ LEGACY_PLATFORM_ADMIN_GROUP = "smart_construction_core.group_sc_cap_config_admin
 SYSTEM_ADMIN_GROUP = "base.group_system"
 
 
-def platform_admin_group_xmlids(*, include_legacy: bool = True, include_system: bool = False) -> list[str]:
+def platform_admin_group_xmlids(*, include_legacy: bool = False, include_system: bool = False) -> list[str]:
     xmlids = [PLATFORM_ADMIN_GROUP]
     if include_legacy:
         xmlids.append(LEGACY_PLATFORM_ADMIN_GROUP)
@@ -17,10 +17,10 @@ def platform_admin_group_xmlids(*, include_legacy: bool = True, include_system: 
     return xmlids
 
 
-def user_is_platform_admin(user, *, include_system: bool = True) -> bool:
+def user_is_platform_admin(user, *, include_system: bool = False, include_legacy: bool = False) -> bool:
     if not user:
         return False
-    for xmlid in platform_admin_group_xmlids(include_legacy=True, include_system=include_system):
+    for xmlid in platform_admin_group_xmlids(include_legacy=include_legacy, include_system=include_system):
         try:
             if user.has_group(xmlid):
                 return True
@@ -29,7 +29,7 @@ def user_is_platform_admin(user, *, include_system: bool = True) -> bool:
     return False
 
 
-def platform_admin_groups(env, *, include_legacy: bool = True, include_system: bool = False):
+def platform_admin_groups(env, *, include_legacy: bool = False, include_system: bool = False):
     groups = []
     for xmlid in platform_admin_group_xmlids(include_legacy=include_legacy, include_system=include_system):
         group = env.ref(xmlid, raise_if_not_found=False)

--- a/addons/smart_core/tests/test_app_shell_boundaries.py
+++ b/addons/smart_core/tests/test_app_shell_boundaries.py
@@ -195,6 +195,25 @@ class TestAppShellBoundaries(unittest.TestCase):
         self.assertNotIn("delivery", normal_app_ids)
         self.assertIn("delivery", admin_app_ids)
 
+    def test_catalog_hides_business_apps_from_platform_admin_without_business_groups(self):
+        handler = self.module.AppCatalogHandler(env=_FakeEnv(is_platform_admin=True))
+
+        result = handler.handle(payload={})
+
+        app_ids = [row["meta"]["app_id"] for row in result["data"]["apps"]]
+        self.assertIn("workspace", app_ids)
+        self.assertIn("release_management", app_ids)
+        self.assertNotIn("projects", app_ids)
+        self.assertNotIn("contracts", app_ids)
+
+    def test_nav_hides_business_scene_from_platform_admin_without_business_groups(self):
+        handler = self.module.AppNavHandler(env=_FakeEnv(is_platform_admin=True))
+
+        result = handler.handle(payload={"params": {"app": "projects"}})
+
+        self.assertTrue(result["ok"])
+        self.assertEqual(result["data"]["sections"], [])
+
     def test_open_alias_app_uses_stable_primary_scene(self):
         handler = self.module.AppOpenHandler(env=types.SimpleNamespace(uid=9))
 

--- a/addons/smart_core/tests/test_platform_admin_boundary.py
+++ b/addons/smart_core/tests/test_platform_admin_boundary.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[1]
+    module_name = "platform_admin_boundary_under_test"
+    spec = importlib.util.spec_from_file_location(module_name, root / "security" / "platform_admin.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeUser:
+    def __init__(self, groups):
+        self._groups = set(groups)
+
+    def has_group(self, xmlid):
+        return xmlid in self._groups
+
+
+class TestPlatformAdminBoundary(unittest.TestCase):
+    def setUp(self):
+        self.module = _load_module()
+
+    def test_platform_admin_default_excludes_legacy_industry_config_group(self):
+        user = _FakeUser({self.module.LEGACY_PLATFORM_ADMIN_GROUP})
+
+        self.assertFalse(self.module.user_is_platform_admin(user))
+        self.assertTrue(self.module.user_is_platform_admin(user, include_legacy=True))
+
+    def test_platform_admin_default_excludes_system_admin_group(self):
+        user = _FakeUser({self.module.SYSTEM_ADMIN_GROUP})
+
+        self.assertFalse(self.module.user_is_platform_admin(user))
+        self.assertTrue(self.module.user_is_platform_admin(user, include_system=True))
+
+    def test_platform_admin_group_xmlids_are_strict_by_default(self):
+        self.assertEqual(self.module.platform_admin_group_xmlids(), [self.module.PLATFORM_ADMIN_GROUP])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- keep platform admin identity strict to the Smart Core platform admin group
- reclassify SC config admin as industry config instead of platform/system admin
- filter app shell catalog/nav/open flows by menu/action access so platform admins do not see business apps
- tighten business action/menu groups and add platform-admin no-business-data ACL coverage
- preserve payment approval closure by allowing only controlled tier callback state transition

## Validation
- python3 -m py_compile addons/smart_construction_core/models/core/payment_request.py addons/smart_core/security/platform_admin.py addons/smart_core/handlers/app_shell.py
- git diff --check
- python3 addons/smart_core/tests/test_platform_admin_boundary.py
- python3 addons/smart_core/tests/test_app_shell_boundaries.py
- make test TEST_TAGS=p0_state BD=sc_test
- make test-install-gate