### PR TITLE
fix: include positive legacy output invoices in ledger

### DIFF
--- a/addons/smart_construction_core/models/core/output_invoice_ledger.py
+++ b/addons/smart_construction_core/models/core/output_invoice_ledger.py
@@ -128,7 +128,15 @@ class ScOutputInvoiceLedger(models.Model):
                     'sc.invoice.registration'::varchar AS source_model,
                     ir.id::integer AS source_record_id,
                     ir.source_kind::varchar AS source_kind,
-                    'signed_adjustment'::varchar AS adjustment_kind,
+                    CASE
+                        WHEN ir.red_flush_adjustment_id IS NOT NULL
+                          OR COALESCE(ir.amount_total, 0) < 0
+                          OR COALESCE(ir.amount_no_tax, 0) < 0
+                          OR COALESCE(ir.tax_amount, 0) < 0
+                          OR COALESCE(ir.surcharge_amount, 0) < 0
+                        THEN 'signed_adjustment'
+                        ELSE 'normal'
+                    END::varchar AS adjustment_kind,
                     ir.project_id,
                     p.operation_strategy::varchar AS operation_strategy,
                     ir.partner_id,
@@ -142,7 +150,15 @@ class ScOutputInvoiceLedger(models.Model):
                     ir.legacy_document_state::varchar AS invoice_document_state,
                     ir.document_no::varchar AS source_document_no,
                     ir.legacy_source_table::varchar AS source_table_name,
-                    'invoice_registration_signed_amount'::varchar AS amount_source,
+                    CASE
+                        WHEN ir.red_flush_adjustment_id IS NOT NULL
+                          OR COALESCE(ir.amount_total, 0) < 0
+                          OR COALESCE(ir.amount_no_tax, 0) < 0
+                          OR COALESCE(ir.tax_amount, 0) < 0
+                          OR COALESCE(ir.surcharge_amount, 0) < 0
+                        THEN 'invoice_registration_signed_amount'
+                        ELSE 'legacy_output_invoice_registration'
+                    END::varchar AS amount_source,
                     0::integer AS receipt_line_count,
                     ir.amount_total::numeric AS invoice_amount,
                     ir.tax_amount::numeric AS tax_amount,
@@ -164,11 +180,22 @@ class ScOutputInvoiceLedger(models.Model):
                       AND ir.legacy_source_table = 'C_JXXP_XXKPDJ'
                     )
                   )
-                  AND (
-                    COALESCE(ir.amount_total, 0) < 0
-                    OR COALESCE(ir.amount_no_tax, 0) < 0
-                    OR COALESCE(ir.tax_amount, 0) < 0
-                    OR COALESCE(ir.surcharge_amount, 0) < 0
+                  AND NOT (
+                    ir.red_flush_adjustment_id IS NULL
+                    AND COALESCE(ir.amount_total, 0) >= 0
+                    AND COALESCE(ir.amount_no_tax, 0) >= 0
+                    AND COALESCE(ir.tax_amount, 0) >= 0
+                    AND COALESCE(ir.surcharge_amount, 0) >= 0
+                    AND EXISTS (
+                        SELECT 1
+                        FROM sc_receipt_invoice_line ril2
+                        WHERE ril2.active
+                          AND NULLIF(TRIM(ril2.invoice_no), '') = NULLIF(TRIM(ir.invoice_no), '')
+                          AND NULLIF(TRIM(ril2.invoice_no), '') IS NOT NULL
+                          AND TRIM(ril2.invoice_no) <> '0'
+                          AND (ril2.project_id = ir.project_id OR ril2.project_id IS NULL OR ir.project_id IS NULL)
+                          AND (ril2.partner_id = ir.partner_id OR ril2.partner_id IS NULL OR ir.partner_id IS NULL)
+                    )
                   )
             )
             """

--- a/addons/smart_construction_core/tests/test_user_feedback_business_views.py
+++ b/addons/smart_construction_core/tests/test_user_feedback_business_views.py
@@ -883,6 +883,38 @@ class TestUserFeedbackBusinessViews(TransactionCase):
         self.assertIn("ir.red_flush_adjustment_id IS NOT NULL", init_source)
         self.assertIn("ir.legacy_source_model = 'sc.legacy.invoice.tax.fact'", init_source)
         self.assertIn("ir.legacy_source_table = 'C_JXXP_XXKPDJ'", init_source)
+        self.assertIn("legacy_output_invoice_registration", init_source)
+        self.assertIn("sc_receipt_invoice_line ril2", init_source)
+
+    @tagged("post_install", "-at_install", "user_feedback", "output_invoice_red_flush")
+    def test_output_invoice_ledger_includes_positive_legacy_output_tax_fact_without_receipt_duplicate(self):
+        positive = self.env["sc.invoice.registration"].create(
+            {
+                "source_origin": "legacy",
+                "source_kind": "output_invoice_tax",
+                "direction": "output",
+                "state": "legacy_confirmed",
+                "project_id": self.project.id,
+                "partner_id": self.partner.id,
+                "document_no": "XXKPDJ-POSITIVE-LEGACY",
+                "invoice_no": "INV-POSITIVE-LEGACY",
+                "amount_no_tax": 100.0,
+                "tax_amount": 9.0,
+                "amount_total": 109.0,
+                "legacy_source_model": "sc.legacy.invoice.tax.fact",
+                "legacy_source_table": "C_JXXP_XXKPDJ",
+                "legacy_record_id": "positive-output-tax-fact-smoke",
+            }
+        )
+
+        ledger = self.env["sc.output.invoice.ledger"].search(
+            [("source_model", "=", "sc.invoice.registration"), ("source_record_id", "=", positive.id)],
+            limit=1,
+        )
+        self.assertTrue(ledger)
+        self.assertEqual(ledger.adjustment_kind, "normal")
+        self.assertEqual(ledger.amount_source, "legacy_output_invoice_registration")
+        self.assertEqual(ledger.invoice_amount, 109.0)
 
     @tagged("post_install", "-at_install", "user_feedback", "output_invoice_red_flush")
     def test_output_invoice_ledger_exposes_signed_adjustment_filters(self):


### PR DESCRIPTION
## Summary
- include positive historical output invoice registrations from C_JXXP_XXKPDJ in the output invoice ledger
- keep red-flush and signed adjustment rows marked as signed adjustments
- avoid duplicating positive registration rows when an active receipt invoice line already carries the same invoice

## Verification
- python3 -m compileall addons/smart_construction_core/models/core/output_invoice_ledger.py addons/smart_construction_core/tests/test_user_feedback_business_views.py
- git diff --check
- CODEX_NEED_UPGRADE=1 CODEX_MODULES=smart_construction_core MODULE=smart_construction_core DB_NAME=sc_demo make mod.upgrade
- local sc_demo project_id=664 output ledger now returns 3 rows: 2 positive legacy output invoices and 1 signed adjustment