### PR TITLE
fix: prefer invoice registration facts in output ledger

### DIFF
--- a/addons/smart_construction_core/models/core/output_invoice_ledger.py
+++ b/addons/smart_construction_core/models/core/output_invoice_ledger.py
@@ -11,7 +11,7 @@ class ScOutputInvoiceLedger(models.Model):
     source_model = fields.Selection(
         [
             ("sc.receipt.invoice.line", "收款发票明细"),
-            ("sc.invoice.registration", "销项冲抵/红冲"),
+            ("sc.invoice.registration", "开票登记"),
         ],
         string="来源模型",
         readonly=True,
@@ -120,6 +120,17 @@ class ScOutputInvoiceLedger(models.Model):
                 FROM receipt_invoice_dedup ril
                 LEFT JOIN project_project p ON p.id = ril.project_id
                 WHERE ril.receipt_rank = 1
+                  AND NOT EXISTS (
+                    SELECT 1
+                    FROM sc_invoice_registration ir2
+                    WHERE ir2.active
+                      AND ir2.direction = 'output'
+                      AND ir2.legacy_source_model = 'sc.legacy.invoice.tax.fact'
+                      AND ir2.legacy_source_table = 'C_JXXP_XXKPDJ'
+                      AND NULLIF(TRIM(ir2.invoice_no), '') = ril.normalized_invoice_no
+                      AND (ir2.project_id = ril.project_id OR ir2.project_id IS NULL OR ril.project_id IS NULL)
+                      AND (ir2.partner_id = ril.partner_id OR ir2.partner_id IS NULL OR ril.partner_id IS NULL)
+                  )
 
                 UNION ALL
 
@@ -178,23 +189,6 @@ class ScOutputInvoiceLedger(models.Model):
                     OR (
                       ir.legacy_source_model = 'sc.legacy.invoice.tax.fact'
                       AND ir.legacy_source_table = 'C_JXXP_XXKPDJ'
-                    )
-                  )
-                  AND NOT (
-                    ir.red_flush_adjustment_id IS NULL
-                    AND COALESCE(ir.amount_total, 0) >= 0
-                    AND COALESCE(ir.amount_no_tax, 0) >= 0
-                    AND COALESCE(ir.tax_amount, 0) >= 0
-                    AND COALESCE(ir.surcharge_amount, 0) >= 0
-                    AND EXISTS (
-                        SELECT 1
-                        FROM sc_receipt_invoice_line ril2
-                        WHERE ril2.active
-                          AND NULLIF(TRIM(ril2.invoice_no), '') = NULLIF(TRIM(ir.invoice_no), '')
-                          AND NULLIF(TRIM(ril2.invoice_no), '') IS NOT NULL
-                          AND TRIM(ril2.invoice_no) <> '0'
-                          AND (ril2.project_id = ir.project_id OR ril2.project_id IS NULL OR ir.project_id IS NULL)
-                          AND (ril2.partner_id = ir.partner_id OR ril2.partner_id IS NULL OR ir.partner_id IS NULL)
                     )
                   )
             )

--- a/addons/smart_construction_core/tests/test_user_feedback_business_views.py
+++ b/addons/smart_construction_core/tests/test_user_feedback_business_views.py
@@ -884,7 +884,7 @@ class TestUserFeedbackBusinessViews(TransactionCase):
         self.assertIn("ir.legacy_source_model = 'sc.legacy.invoice.tax.fact'", init_source)
         self.assertIn("ir.legacy_source_table = 'C_JXXP_XXKPDJ'", init_source)
         self.assertIn("legacy_output_invoice_registration", init_source)
-        self.assertIn("sc_receipt_invoice_line ril2", init_source)
+        self.assertIn("FROM sc_invoice_registration ir2", init_source)
 
     @tagged("post_install", "-at_install", "user_feedback", "output_invoice_red_flush")
     def test_output_invoice_ledger_includes_positive_legacy_output_tax_fact_without_receipt_duplicate(self):
@@ -915,6 +915,63 @@ class TestUserFeedbackBusinessViews(TransactionCase):
         self.assertEqual(ledger.adjustment_kind, "normal")
         self.assertEqual(ledger.amount_source, "legacy_output_invoice_registration")
         self.assertEqual(ledger.invoice_amount, 109.0)
+
+    @tagged("post_install", "-at_install", "user_feedback", "output_invoice_red_flush")
+    def test_output_invoice_ledger_prefers_registration_fact_over_receipt_invoice_line(self):
+        request = self.env["payment.request"].create(
+            {
+                "name": "FB-RECEIPT-WITH-OUTPUT-REGISTRATION",
+                "type": "receive",
+                "project_id": self.project.id,
+                "partner_id": self.partner.id,
+                "amount": 50.0,
+            }
+        )
+        receipt_line = self.env["sc.receipt.invoice.line"].create(
+            {
+                "request_id": request.id,
+                "project_id": self.project.id,
+                "partner_id": self.partner.id,
+                "legacy_invoice_line_id": "registration-first-line",
+                "legacy_receipt_id": "registration-first-receipt",
+                "invoice_no": "INV-REGISTRATION-FIRST",
+                "invoice_issue_company": "Feedback Issue Company",
+                "invoice_party_name": "Feedback Party",
+                "invoice_amount": 50.0,
+                "surcharge_amount": 0.5,
+            }
+        )
+        registration = self.env["sc.invoice.registration"].create(
+            {
+                "source_origin": "legacy",
+                "source_kind": "output_invoice_tax",
+                "direction": "output",
+                "state": "legacy_confirmed",
+                "project_id": self.project.id,
+                "partner_id": self.partner.id,
+                "document_no": "XXKPDJ-REGISTRATION-FIRST",
+                "invoice_no": "INV-REGISTRATION-FIRST",
+                "amount_no_tax": 90.0,
+                "tax_amount": 9.0,
+                "amount_total": 99.0,
+                "legacy_source_model": "sc.legacy.invoice.tax.fact",
+                "legacy_source_table": "C_JXXP_XXKPDJ",
+                "legacy_record_id": "registration-first-output-tax-fact",
+            }
+        )
+
+        receipt_ledger = self.env["sc.output.invoice.ledger"].search(
+            [("source_model", "=", "sc.receipt.invoice.line"), ("source_record_id", "=", receipt_line.id)],
+            limit=1,
+        )
+        registration_ledger = self.env["sc.output.invoice.ledger"].search(
+            [("source_model", "=", "sc.invoice.registration"), ("source_record_id", "=", registration.id)],
+            limit=1,
+        )
+        self.assertFalse(receipt_ledger)
+        self.assertTrue(registration_ledger)
+        self.assertEqual(registration_ledger.invoice_document_no, "XXKPDJ-REGISTRATION-FIRST")
+        self.assertEqual(registration_ledger.invoice_amount, 99.0)
 
     @tagged("post_install", "-at_install", "user_feedback", "output_invoice_red_flush")
     def test_output_invoice_ledger_exposes_signed_adjustment_filters(self):


### PR DESCRIPTION
## Summary
- make output invoice ledger prefer historical output invoice registration facts over receipt invoice lines for the same invoice number
- keep receipt invoice lines as fallback only when no output invoice registration exists
- update source labels and tests so invoice aggregation details match user-visible invoice registration facts

## Verification
- python3 -m compileall addons/smart_construction_core/models/core/output_invoice_ledger.py addons/smart_construction_core/tests/test_user_feedback_business_views.py
- git diff --check
- CODEX_NEED_UPGRADE=1 CODEX_MODULES=smart_construction_core MODULE=smart_construction_core DB_NAME=sc_demo make mod.upgrade
- local SQL: project 马踏洞安置房停车场相关基础设施项目 now shows 12 output ledger rows all from sc.invoice.registration, including XXKPDJ-20260401-004 amount 3635000

## Note
- TEST_TAGS=output_invoice_red_flush MODULE=smart_construction_core DB_NAME=sc_demo make test.safe ran successfully but Odoo reported 0 selected tests, so it is not counted as a functional test pass.