### PR TITLE
fix: use output invoice line amounts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1163,6 +1163,10 @@ fresh_db.legacy_expense_deposit.replay.adapter: guard.prod.forbid check-compose-
 fresh_db.legacy_invoice_tax.replay.adapter: guard.prod.forbid check-compose-project check-compose-env
 	@python3 scripts/migration/fresh_db_legacy_invoice_tax_replay_adapter.py
 
+.PHONY: fresh_db.legacy_invoice_tax.replay.write
+fresh_db.legacy_invoice_tax.replay.write: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_REPLAY_DB_ALLOWLIST="$(DB_NAME)" MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" bash scripts/ops/odoo_shell_exec.sh < scripts/migration/fresh_db_legacy_invoice_tax_replay_write.py
+
 fresh_db.legacy_tax_deduction.replay.adapter: guard.prod.forbid check-compose-project check-compose-env
 	@python3 scripts/migration/fresh_db_legacy_tax_deduction_replay_adapter.py
 

--- a/docs/migration_alignment/frozen/legacy_invoice_tax_fact_screen_v1.md
+++ b/docs/migration_alignment/frozen/legacy_invoice_tax_fact_screen_v1.md
@@ -7,8 +7,8 @@ This is a read-only screen for invoice and tax-related legacy facts.
 ## Result
 
 - raw rows: `21323`
-- loadable rows: `5920`
-- blocked rows: `15403`
+- loadable rows: `5959`
+- blocked rows: `15364`
 - DB writes: `0`
 - Odoo shell: `false`
 
@@ -16,17 +16,17 @@ This is a read-only screen for invoice and tax-related legacy facts.
 
 | Source table | Raw rows | Loadable candidates |
 |---|---:|---:|
-| C_JXXP_ZYFPJJD | 16616 | 1913 |
-| C_JXXP_XXKPDJ | 3157 | 2881 |
-| C_JXXP_YJSKDJ | 1290 | 904 |
-| C_JXXP_KJFPSQ | 260 | 222 |
+| C_JXXP_ZYFPJJD | 16616 | 1919 |
+| C_JXXP_XXKPDJ | 3157 | 2907 |
+| C_JXXP_YJSKDJ | 1290 | 908 |
+| C_JXXP_KJFPSQ | 260 | 225 |
 
 ## Blocked Reasons
 
 | Reason | Rows |
 |---|---:|
 | missing_counterparty_evidence | 14734 |
-| amount_and_tax_not_positive_or_missing | 2612 |
+| amount_and_tax_missing_or_zero | 1829 |
 | deleted | 623 |
 | project_not_assetized | 132 |
 | missing_project_id | 9 |
@@ -53,7 +53,7 @@ This is a read-only screen for invoice and tax-related legacy facts.
 
 - lane: `legacy_invoice_tax_fact_carrier`
 - source table priority: `C_JXXP_XXKPDJ`
-- loadable rows: `2881`
+- loadable rows: `2907`
 - reason: screen found project-anchored invoice/tax facts; design a neutral carrier before XML generation
 
 ## Boundary

--- a/scripts/migration/fresh_db_legacy_invoice_tax_replay_write.py
+++ b/scripts/migration/fresh_db_legacy_invoice_tax_replay_write.py
@@ -64,8 +64,8 @@ expected_rows = int(adapter["expected_rows"])
 Model = env["sc.legacy.invoice.tax.fact"].sudo().with_context(active_test=False)  # noqa: F821
 Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
 
-existing_keys = {
-    (clean(rec["legacy_source_table"]), clean(rec["legacy_record_id"]))
+existing_by_key = {
+    (clean(rec["legacy_source_table"]), clean(rec["legacy_record_id"])): rec["id"]
     for rec in Model.search_read([("legacy_record_id", "!=", False)], ["legacy_source_table", "legacy_record_id"])
 }
 project_ids = sorted({clean(row.get("legacy_project_id")) for row in rows if clean(row.get("legacy_project_id"))})
@@ -76,14 +76,11 @@ project_map = {
 }
 
 created = 0
-skipped = 0
+updated = 0
 buffer: list[dict[str, object]] = []
 batch_size = 500
 for row in rows:
     key = (clean(row.get("legacy_source_table")), clean(row.get("legacy_record_id")))
-    if key in existing_keys:
-        skipped += 1
-        continue
     legacy_project_id = clean(row.get("legacy_project_id"))
     project_id = project_map.get(legacy_project_id)
     if not project_id:
@@ -110,8 +107,12 @@ for row in rows:
         "note": clean(row.get("note")),
         "import_batch": clean(row.get("import_batch")) or "legacy_invoice_tax_asset_v1",
     }
+    if key in existing_by_key:
+        Model.browse(existing_by_key[key]).write(vals)
+        updated += 1
+        continue
     buffer.append(vals)
-    existing_keys.add(key)
+    existing_by_key[key] = 0
     if len(buffer) >= batch_size:
         Model.create(buffer)
         created += len(buffer)
@@ -122,15 +123,15 @@ if buffer:
     created += len(buffer)
 
 env.cr.commit()  # noqa: F821
-status = "PASS" if created + skipped == expected_rows else "FAIL"
+status = "PASS" if created + updated == expected_rows else "FAIL"
 payload = {
     "status": status,
     "mode": "fresh_db_legacy_invoice_tax_replay_write",
     "database": env.cr.dbname,  # noqa: F821
     "input_rows": len(rows),
     "created_rows": created,
-    "skipped_existing": skipped,
-    "db_writes": created,
+    "updated_existing": updated,
+    "db_writes": created + updated,
     "decision": "legacy_invoice_tax_replay_write_complete" if status == "PASS" else "STOP_REVIEW_REQUIRED",
 }
 write_json(OUTPUT_JSON, payload)

--- a/scripts/migration/legacy_invoice_tax_asset_generator.py
+++ b/scripts/migration/legacy_invoice_tax_asset_generator.py
@@ -25,7 +25,7 @@ CATALOG_REL_PATH = Path("manifest/migration_asset_catalog_v1.json")
 ASSET_PACKAGE_ID = "legacy_invoice_tax_sc_v1"
 GENERATED_AT = "2026-04-15T18:10:00+00:00"
 EXPECTED_RAW_ROWS = 21323
-EXPECTED_LOADABLE_ROWS = 5920
+EXPECTED_LOADABLE_ROWS = 5959
 
 
 class InvoiceTaxAssetError(Exception):

--- a/scripts/migration/legacy_invoice_tax_fact_screen.py
+++ b/scripts/migration/legacy_invoice_tax_fact_screen.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
+import shlex
 import subprocess
 from collections import Counter
 from decimal import Decimal, InvalidOperation
@@ -31,14 +33,25 @@ WITH src AS (
     'input_invoice_handover' AS family, 'input_invoice' AS direction, 'D_SCBSJS_ZKPJE' AS amount_field
   FROM dbo.C_JXXP_ZYFPJJD
   UNION ALL
-  SELECT 'C_JXXP_XXKPDJ', CONVERT(nvarchar(max), Id), CONVERT(nvarchar(max), DJBH),
-    CONVERT(nvarchar(max), XMID), CONVERT(nvarchar(max), XMMC), CONVERT(nvarchar(max), D_BYK_KFDWID),
-    CONVERT(nvarchar(max), SPFMC), CONVERT(nvarchar(max), D_BYK_SPF_NSSBH),
-    CONVERT(nvarchar(max), KPZJE), CONVERT(nvarchar(max), ZSE), CONVERT(nvarchar(max), SQRQ, 120),
-    CONVERT(nvarchar(max), DJZT), CONVERT(nvarchar(max), DEL), CONVERT(nvarchar(max), FPZL),
-    CONVERT(nvarchar(max), BZ), CONVERT(nvarchar(max), pid), 'output_invoice_register',
-    'output_invoice', 'KPZJE'
-  FROM dbo.C_JXXP_XXKPDJ
+  SELECT 'C_JXXP_XXKPDJ', CONVERT(nvarchar(max), h.Id), CONVERT(nvarchar(max), h.DJBH),
+    CONVERT(nvarchar(max), h.XMID), CONVERT(nvarchar(max), h.XMMC), CONVERT(nvarchar(max), h.D_BYK_KFDWID),
+    CONVERT(nvarchar(max), h.SPFMC), CONVERT(nvarchar(max), h.D_BYK_SPF_NSSBH),
+    CONVERT(nvarchar(max), CASE WHEN child.child_rows > 0 THEN child.amount_total ELSE h.KPZJE END),
+    CONVERT(nvarchar(max), CASE WHEN child.child_rows > 0 THEN child.tax_amount ELSE h.ZSE END),
+    CONVERT(nvarchar(max), h.SQRQ, 120),
+    CONVERT(nvarchar(max), h.DJZT), CONVERT(nvarchar(max), h.DEL), CONVERT(nvarchar(max), h.FPZL),
+    CONVERT(nvarchar(max), h.BZ), CONVERT(nvarchar(max), h.pid), 'output_invoice_register',
+    'output_invoice',
+    CASE WHEN child.child_rows > 0 THEN 'C_JXXP_XXKPDJ_CB.JE_SUM' ELSE 'KPZJE' END
+  FROM dbo.C_JXXP_XXKPDJ h
+  OUTER APPLY (
+    SELECT
+      COUNT(c.Id) AS child_rows,
+      SUM(ISNULL(c.JE, 0)) AS amount_total,
+      SUM(ISNULL(c.SE, 0)) AS tax_amount
+    FROM dbo.C_JXXP_XXKPDJ_CB c
+    WHERE c.ZBID = h.Id
+  ) child
   UNION ALL
   SELECT 'C_JXXP_KJFPSQ', CONVERT(nvarchar(max), Id), CONVERT(nvarchar(max), DJBH),
     CONVERT(nvarchar(max), XMID), CONVERT(nvarchar(max), XMMC), CONVERT(nvarchar(max), NULL),
@@ -139,14 +152,22 @@ def parse_amount(value: str) -> Decimal:
 
 
 def run_sql() -> str:
+    container = os.getenv("LEGACY_MSSQL_CONTAINER", "legacy-sqlserver")
+    sqlcmd = os.getenv("LEGACY_SQLCMD", "/opt/mssql-tools18/bin/sqlcmd")
+    database = os.getenv("LEGACY_MSSQL_DATABASE", "LegacyDb")
+    password = os.getenv("LEGACY_MSSQL_SA_PASSWORD")
+    password_expr = '"$SA_PASSWORD"' if password is None else shlex.quote(password)
     cmd = [
         "docker",
         "exec",
         "-i",
-        "legacy-sqlserver",
+        container,
         "bash",
         "-lc",
-        "/opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P \"$SA_PASSWORD\" -C -d LegacyDb -s '|' -y 0 -Y 0",
+        (
+            f"{shlex.quote(sqlcmd)} -S localhost -U sa -P {password_expr} "
+            f"-C -d {shlex.quote(database)} -s '|' -y 0 -Y 0"
+        ),
     ]
     completed = subprocess.run(cmd, input=SQL, text=True, capture_output=True, check=False)
     require(completed.returncode == 0, completed.stderr.strip() or completed.stdout.strip())


### PR DESCRIPTION
## Summary
- change legacy output invoice tax source amount from C_JXXP_XXKPDJ.KPZJE header value to C_JXXP_XXKPDJ_CB.JE child-line sum when child lines exist
- make legacy invoice tax replay update existing facts instead of skipping stale values
- add a Make target for the invoice tax replay write step

## Evidence
- 老系统项目 马踏洞安置房停车场相关基础设施项目: XXKPDJ-20260401-004 header KPZJE=3635000, child JE=100000
- after local replay/projection, sc_output_invoice_ledger shows invoice_amount=100000, amount_no_tax=91743.12, tax_amount=8256.88

## Verification
- python3 -m py_compile scripts/migration/legacy_invoice_tax_fact_screen.py scripts/migration/legacy_invoice_tax_asset_generator.py scripts/migration/fresh_db_legacy_invoice_tax_replay_adapter.py scripts/migration/fresh_db_legacy_invoice_tax_replay_write.py scripts/migration/fresh_db_invoice_registration_projection_write.py
- LEGACY_MSSQL_CONTAINER=legacy-mssql-restore LEGACY_MSSQL_SA_PASSWORD=*** python3 scripts/migration/legacy_invoice_tax_fact_screen.py --asset-root migration_assets --check
- LEGACY_MSSQL_CONTAINER=legacy-mssql-restore LEGACY_MSSQL_SA_PASSWORD=*** python3 scripts/migration/legacy_invoice_tax_asset_generator.py --asset-root migration_assets --check
- python3 scripts/migration/fresh_db_legacy_invoice_tax_replay_adapter.py
- DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo make fresh_db.legacy_invoice_tax.replay.write
- DB_NAME=sc_demo MIGRATION_REPLAY_DB_ALLOWLIST=sc_demo make fresh_db.invoice_registration.projection.write
- git diff --check