### PR TITLE
fix: split counterparty payments from payment requests

### DIFF
--- a/addons/smart_construction_core/views/core/payment_request_views.xml
+++ b/addons/smart_construction_core/views/core/payment_request_views.xml
@@ -220,6 +220,7 @@
             <field name="res_model">payment.request</field>
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_payment_request_search"/>
+            <field name="domain">['|', ('legacy_source_table', '=', False), ('legacy_source_table', '!=', 'T_FK_Supplier')]</field>
             <field name="context">{'search_default_group_by_project_id': 1}</field>
             <field name="groups_id" eval="[(6, 0, [
                 ref('smart_construction_core.group_sc_cap_finance_read'),
@@ -234,7 +235,7 @@
             <field name="res_model">payment.request</field>
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_payment_request_search"/>
-            <field name="domain">[('type', '=', 'pay')]</field>
+            <field name="domain">['&amp;', ('type', '=', 'pay'), '|', ('legacy_source_table', '=', False), ('legacy_source_table', '!=', 'T_FK_Supplier')]</field>
             <field name="context">{'default_type': 'pay', 'search_default_type_pay': 1, 'search_default_group_by_project_id': 1}</field>
             <field name="groups_id" eval="[(6, 0, [
                 ref('smart_construction_core.group_sc_cap_finance_read'),
@@ -263,7 +264,7 @@
             <field name="name">我的付款申请</field>
             <field name="res_model">payment.request</field>
             <field name="view_mode">tree,form</field>
-            <field name="domain">[('create_uid', '=', uid)]</field>
+            <field name="domain">['&amp;', ('create_uid', '=', uid), '|', ('legacy_source_table', '=', False), ('legacy_source_table', '!=', 'T_FK_Supplier')]</field>
             <field name="search_view_id" ref="view_payment_request_search"/>
             <field name="context">{'search_default_group_by_project_id': 1}</field>
             <field name="groups_id" eval="[(6, 0, [

--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -597,7 +597,21 @@
         <field name="res_model">payment.request</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_payment_request_search"/>
-        <field name="domain">[('type', '=', 'pay')]</field>
+        <field name="domain">['&amp;', ('type', '=', 'pay'), '|', ('legacy_source_table', '=', False), ('legacy_source_table', '!=', 'T_FK_Supplier')]</field>
+        <field name="context">{'default_type': 'pay', 'search_default_type_pay': 1, 'search_default_group_by_project_id': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_business_initiator'),
+            ref('smart_construction_core.group_sc_cap_finance_read'),
+            ref('smart_construction_core.group_sc_cap_finance_user'),
+            ref('smart_construction_core.group_sc_cap_finance_manager')
+        ])]"/>
+    </record>
+    <record id="action_payment_request_counterparty_payment" model="ir.actions.act_window">
+        <field name="name">往来单位付款</field>
+        <field name="res_model">payment.request</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="smart_construction_core.view_payment_request_search"/>
+        <field name="domain">[('type', '=', 'pay'), ('legacy_source_table', '=', 'T_FK_Supplier')]</field>
         <field name="context">{'default_type': 'pay', 'search_default_type_pay': 1, 'search_default_group_by_project_id': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),
@@ -1503,7 +1517,7 @@
     <menuitem id="menu_sc_partner_payment"
               name="往来单位付款"
               parent="smart_construction_core.menu_sc_payment_user_group"
-              action="smart_construction_core.action_sc_payment_execution_partner_payment"
+              action="smart_construction_core.action_payment_request_counterparty_payment"
               sequence="20"
               groups="smart_construction_core.group_sc_cap_business_initiator,smart_construction_core.group_sc_cap_finance_read,smart_construction_core.group_sc_cap_finance_user,smart_construction_core.group_sc_cap_finance_manager"/>
     <menuitem id="menu_sc_deduction_user_group"


### PR DESCRIPTION
## Summary
- exclude legacy T_FK_Supplier rows from payment request list actions
- add a dedicated counterparty payment action and point 往来单位付款 menu to it
- keep existing payment.execution action intact for legacy execution views

## Verification
- DB_NAME=sc_demo CODEX_NEED_UPGRADE=1 CODEX_MODULES=smart_construction_core MODULE=smart_construction_core make mod.upgrade
- git diff --check
- local sc_demo count check: 12,304 payment request pay rows visible, 13,145 counterparty payment rows split out, 25,449 total pay basis