### PR TITLE
Fix receipt request migration source boundaries

### DIFF
--- a/addons/smart_construction_core/views/core/payment_request_views.xml
+++ b/addons/smart_construction_core/views/core/payment_request_views.xml
@@ -250,7 +250,7 @@
             <field name="res_model">payment.request</field>
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_payment_request_search"/>
-            <field name="domain">[('type', '=', 'receive')]</field>
+            <field name="domain">[('type', '=', 'receive'), ('legacy_source_table', 'not in', ['C_JFHKLR_DELETED', 'C_JFHKLR_ROUTED_OUT'])]</field>
             <field name="context">{'default_type': 'receive', 'search_default_type_receive': 1, 'search_default_group_by_receipt_type': 1, 'search_default_group_by_project_id': 1}</field>
             <field name="groups_id" eval="[(6, 0, [
                 ref('smart_construction_core.group_sc_cap_finance_read'),

--- a/scripts/migration/contract_header_asset_generator.py
+++ b/scripts/migration/contract_header_asset_generator.py
@@ -294,7 +294,7 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
         direction_source = "party_role"
         receipt_direction_evidence = receipt_contract_evidence.get(legacy_contract_id, {})
         if direction == "defer" and receipt_direction_evidence:
-            direction = "in"
+            direction = "out"
             direction_source = "receipt_contract_reference"
             counterparty = (
                 clean(receipt_direction_evidence.get("receipt_partner_name"))

--- a/scripts/migration/contract_remaining214_strict_screen.py
+++ b/scripts/migration/contract_remaining214_strict_screen.py
@@ -130,7 +130,7 @@ def current_blocked_rows(asset_root: Path, source_rows: list[dict[str, str]]) ->
         subject = clean(row.get("HTBT")) or clean(row.get("DJBH")) or clean(row.get("HTBH"))
         direction, counterparty = contract_header.infer_direction(row)
         if direction == "defer" and receipt_contract_evidence.get(legacy_contract_id):
-            direction = "in"
+            direction = "out"
             counterparty = (
                 clean(receipt_contract_evidence[legacy_contract_id].get("receipt_partner_name"))
                 or clean(row.get("FBF"))

--- a/scripts/migration/fresh_db_receipt_core_replay_adapter.py
+++ b/scripts/migration/fresh_db_receipt_core_replay_adapter.py
@@ -13,7 +13,7 @@ REPO_ROOT = Path.cwd()
 ASSET_XML = REPO_ROOT / "migration_assets/20_business/receipt/receipt_core_v1.xml"
 OUTPUT_CSV = REPO_ROOT / "artifacts/migration/fresh_db_receipt_write_design_payload_v1.csv"
 OUTPUT_JSON = REPO_ROOT / "artifacts/migration/fresh_db_receipt_core_replay_adapter_result_v1.json"
-EXPECTED_ROWS = 3652
+EXPECTED_ROWS = 1480
 FIELDS = [
     "legacy_receipt_id",
     "legacy_project_id",

--- a/scripts/migration/fresh_db_receipt_core_write.py
+++ b/scripts/migration/fresh_db_receipt_core_write.py
@@ -335,6 +335,8 @@ asset_payload = any(clean(row.get("source_mode")) == "asset_xml" for row in rows
 payload_receipt_ids = {clean(row.get("legacy_receipt_id")) for row in rows if clean(row.get("legacy_receipt_id"))}
 existing_deleted_records = Request.browse()
 discarded_existing_deleted_rows = []
+stale_payload_records = Request.browse()
+discarded_existing_stale_payload_rows = []
 if deleted_receipt_ids:
     for rec in Request.search([("note", "ilike", MIGRATION_MARKER)], order="id"):
         legacy_receipt_id = extract_legacy_receipt_id(rec.note)
@@ -351,6 +353,21 @@ if deleted_receipt_ids:
             )
     if existing_deleted_records:
         existing_deleted_records.unlink()
+for rec in Request.search([("note", "ilike", MIGRATION_MARKER)], order="id"):
+    legacy_receipt_id = extract_legacy_receipt_id(rec.note)
+    if legacy_receipt_id and legacy_receipt_id not in payload_receipt_ids and legacy_receipt_id not in deleted_receipt_ids:
+        stale_payload_records |= rec
+        discarded_existing_stale_payload_rows.append(
+            {
+                "request_id": rec.id,
+                "name": rec.name or "",
+                "legacy_receipt_id": legacy_receipt_id,
+                "state": rec.state or "",
+                "amount": rec.amount or 0,
+            }
+        )
+if stale_payload_records:
+    stale_payload_records.unlink()
 pre_records = snapshot(Request, PRE_SNAPSHOT_CSV)
 pre_existing_receipt_ids = {
     legacy_id
@@ -496,6 +513,7 @@ result = {
     "input_rows": len(rows),
     "discarded_old_system_deleted_rows": len(discarded_deleted_rows),
     "discarded_existing_old_system_deleted_rows": len(discarded_existing_deleted_rows),
+    "discarded_existing_stale_payload_rows": len(discarded_existing_stale_payload_rows),
     "discarded_old_system_deleted_samples": [
         {
             "legacy_receipt_id": clean(row.get("legacy_receipt_id")),
@@ -505,6 +523,7 @@ result = {
         for row in discarded_deleted_rows[:20]
     ],
     "discarded_existing_old_system_deleted_samples": discarded_existing_deleted_rows[:20],
+    "discarded_existing_stale_payload_samples": discarded_existing_stale_payload_rows[:20],
     "created_rows": len(created),
     "skipped_existing": skipped_existing,
     "post_write_match_count": len(post_records),
@@ -534,6 +553,7 @@ print(
             "input_rows": len(rows),
             "discarded_old_system_deleted_rows": len(discarded_deleted_rows),
             "discarded_existing_old_system_deleted_rows": len(discarded_existing_deleted_rows),
+            "discarded_existing_stale_payload_rows": len(discarded_existing_stale_payload_rows),
             "created_rows": len(created),
             "skipped_existing": skipped_existing,
             "post_write_match_count": len(post_records),

--- a/scripts/migration/fresh_db_receipt_core_write.py
+++ b/scripts/migration/fresh_db_receipt_core_write.py
@@ -32,11 +32,12 @@ REPO_ROOT = repo_root()
 ARTIFACT_ROOT = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", str(REPO_ROOT / "artifacts/migration")))
 PAYLOAD_CSV = REPO_ROOT / "artifacts/migration/fresh_db_receipt_write_design_payload_v1.csv"
 ASSET_XML = REPO_ROOT / "migration_assets/20_business/receipt/receipt_core_v1.xml"
+RAW_RECEIPT_CSV = REPO_ROOT / "tmp/raw/receipt/receipt.csv"
 OUTPUT_JSON = ARTIFACT_ROOT / "fresh_db_receipt_core_write_result_v1.json"
 ROLLBACK_CSV = ARTIFACT_ROOT / "fresh_db_receipt_core_rollback_targets_v1.csv"
 PRE_SNAPSHOT_CSV = ARTIFACT_ROOT / "fresh_db_receipt_core_pre_write_snapshot_v1.csv"
 POST_SNAPSHOT_CSV = ARTIFACT_ROOT / "fresh_db_receipt_core_post_write_snapshot_v1.csv"
-EXPECTED_ROWS = int(os.getenv("FRESH_DB_RECEIPT_CORE_EXPECTED_ROWS", "3652"))
+EXPECTED_ROWS = int(os.getenv("FRESH_DB_RECEIPT_CORE_EXPECTED_ROWS", "1480"))
 MIGRATION_MARKER = "[migration:receipt_core]"
 SAFE_FIELDS = {
     "type",
@@ -95,14 +96,33 @@ def ref_map(record: ET.Element) -> dict[str, str]:
 
 
 def raw_receipt_type_map() -> dict[str, str]:
-    path = REPO_ROOT / "tmp/raw/receipt/receipt.csv"
-    if not path.exists():
+    if not RAW_RECEIPT_CSV.exists():
         return {}
-    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+    with RAW_RECEIPT_CSV.open("r", encoding="utf-8-sig", newline="") as handle:
         return {
             clean(row.get("Id")): clean(row.get("type"))
             for row in csv.DictReader(handle)
             if clean(row.get("Id"))
+        }
+
+
+def is_deleted_source_value(value: object) -> bool:
+    normalized = clean(value).lower()
+    return bool(normalized) and normalized not in {"0", "false", "no", "n", "否"}
+
+
+def is_deleted_source_row(row: dict[str, str]) -> bool:
+    return is_deleted_source_value(row.get("DEL")) or any(clean(row.get(field)) for field in ("SCRID", "SCR", "SCRQ"))
+
+
+def raw_deleted_receipt_ids() -> set[str]:
+    if not RAW_RECEIPT_CSV.exists():
+        return set()
+    with RAW_RECEIPT_CSV.open("r", encoding="utf-8-sig", newline="") as handle:
+        return {
+            clean(row.get("Id"))
+            for row in csv.DictReader(handle)
+            if clean(row.get("Id")) and is_deleted_source_row(row)
         }
 
 
@@ -299,8 +319,38 @@ Contract = env["construction.contract"].sudo()  # noqa: F821
 Partner = env["res.partner"].sudo()  # noqa: F821
 
 rows = read_csv(PAYLOAD_CSV) if PAYLOAD_CSV.exists() else load_asset_rows(ASSET_XML)
+source_input_rows = len(rows)
+deleted_receipt_ids = raw_deleted_receipt_ids()
+discarded_deleted_rows = [
+    row
+    for row in rows
+    if clean(row.get("legacy_receipt_id")) and clean(row.get("legacy_receipt_id")) in deleted_receipt_ids
+]
+rows = [
+    row
+    for row in rows
+    if not (clean(row.get("legacy_receipt_id")) and clean(row.get("legacy_receipt_id")) in deleted_receipt_ids)
+]
 asset_payload = any(clean(row.get("source_mode")) == "asset_xml" for row in rows) or not PAYLOAD_CSV.exists()
 payload_receipt_ids = {clean(row.get("legacy_receipt_id")) for row in rows if clean(row.get("legacy_receipt_id"))}
+existing_deleted_records = Request.browse()
+discarded_existing_deleted_rows = []
+if deleted_receipt_ids:
+    for rec in Request.search([("note", "ilike", MIGRATION_MARKER)], order="id"):
+        legacy_receipt_id = extract_legacy_receipt_id(rec.note)
+        if legacy_receipt_id in deleted_receipt_ids:
+            existing_deleted_records |= rec
+            discarded_existing_deleted_rows.append(
+                {
+                    "request_id": rec.id,
+                    "name": rec.name or "",
+                    "legacy_receipt_id": legacy_receipt_id,
+                    "state": rec.state or "",
+                    "amount": rec.amount or 0,
+                }
+            )
+    if existing_deleted_records:
+        existing_deleted_records.unlink()
 pre_records = snapshot(Request, PRE_SNAPSHOT_CSV)
 pre_existing_receipt_ids = {
     legacy_id
@@ -442,7 +492,19 @@ result = {
     "database": env.cr.dbname,  # noqa: F821
     "target_model": "payment.request",
     "target_type": "receive",
+    "source_input_rows": source_input_rows,
     "input_rows": len(rows),
+    "discarded_old_system_deleted_rows": len(discarded_deleted_rows),
+    "discarded_existing_old_system_deleted_rows": len(discarded_existing_deleted_rows),
+    "discarded_old_system_deleted_samples": [
+        {
+            "legacy_receipt_id": clean(row.get("legacy_receipt_id")),
+            "amount": clean(row.get("amount")),
+            "date_request": clean(row.get("date_request")),
+        }
+        for row in discarded_deleted_rows[:20]
+    ],
+    "discarded_existing_old_system_deleted_samples": discarded_existing_deleted_rows[:20],
     "created_rows": len(created),
     "skipped_existing": skipped_existing,
     "post_write_match_count": len(post_records),
@@ -468,7 +530,10 @@ print(
     + json.dumps(
         {
             "status": status,
+            "source_input_rows": source_input_rows,
             "input_rows": len(rows),
+            "discarded_old_system_deleted_rows": len(discarded_deleted_rows),
+            "discarded_existing_old_system_deleted_rows": len(discarded_existing_deleted_rows),
             "created_rows": len(created),
             "skipped_existing": skipped_existing,
             "post_write_match_count": len(post_records),

--- a/scripts/migration/fresh_db_receipt_core_write.py
+++ b/scripts/migration/fresh_db_receipt_core_write.py
@@ -39,6 +39,8 @@ PRE_SNAPSHOT_CSV = ARTIFACT_ROOT / "fresh_db_receipt_core_pre_write_snapshot_v1.
 POST_SNAPSHOT_CSV = ARTIFACT_ROOT / "fresh_db_receipt_core_post_write_snapshot_v1.csv"
 EXPECTED_ROWS = int(os.getenv("FRESH_DB_RECEIPT_CORE_EXPECTED_ROWS", "1480"))
 MIGRATION_MARKER = "[migration:receipt_core]"
+LEGACY_SOURCE_TABLE_DELETED = "C_JFHKLR_DELETED"
+LEGACY_SOURCE_TABLE_ROUTED_OUT = "C_JFHKLR_ROUTED_OUT"
 SAFE_FIELDS = {
     "type",
     "receipt_type",
@@ -352,7 +354,12 @@ if deleted_receipt_ids:
                 }
             )
     if existing_deleted_records:
-        existing_deleted_records.unlink()
+        existing_deleted_records.write(
+            {
+                "legacy_source_table": LEGACY_SOURCE_TABLE_DELETED,
+                "legacy_document_state": "old_system_deleted",
+            }
+        )
 for rec in Request.search([("note", "ilike", MIGRATION_MARKER)], order="id"):
     legacy_receipt_id = extract_legacy_receipt_id(rec.note)
     if legacy_receipt_id and legacy_receipt_id not in payload_receipt_ids and legacy_receipt_id not in deleted_receipt_ids:
@@ -367,7 +374,12 @@ for rec in Request.search([("note", "ilike", MIGRATION_MARKER)], order="id"):
             }
         )
 if stale_payload_records:
-    stale_payload_records.unlink()
+    stale_payload_records.write(
+        {
+            "legacy_source_table": LEGACY_SOURCE_TABLE_ROUTED_OUT,
+            "legacy_document_state": "routed_out_of_receipt_request",
+        }
+    )
 pre_records = snapshot(Request, PRE_SNAPSHOT_CSV)
 pre_existing_receipt_ids = {
     legacy_id

--- a/scripts/migration/receipt_contract_boundary_audit.py
+++ b/scripts/migration/receipt_contract_boundary_audit.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Read-only audit for receipt source lanes and contract direction evidence."""
+
+from __future__ import annotations
+
+import csv
+import json
+import re
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RAW_RECEIPT = ROOT / "tmp/raw/receipt/receipt.csv"
+RAW_CONTRACT = ROOT / "tmp/raw/contract/contract.csv"
+RECEIPT_XML = ROOT / "migration_assets/20_business/receipt/receipt_core_v1.xml"
+CONTRACT_MANIFEST = ROOT / "migration_assets/manifest/contract_external_id_manifest_v1.json"
+OUTPUT_JSON = ROOT / "artifacts/migration/receipt_contract_boundary_audit_v1.json"
+OUTPUT_MD = ROOT / "artifacts/migration/receipt_contract_boundary_audit_v1.md"
+
+TARGET_PROJECT_ID = "8ab29cb255744a2d8b8369c642ee6fe6"
+TARGET_CONTRACT_ID = "af35fb6a1aec4ccb8c0c725524809da2"
+TARGET_RECEIPT_IDS = {"514330e6e0754363b7e764aef7a59d11", "f983d92633054253b52a4fa29628f84b"}
+LEGACY_DELETE_FIELDS = ("DEL", "SCRID", "SCR", "SCRQ")
+
+
+def clean(value: object) -> str:
+    return "" if value is None else str(value).strip()
+
+
+def money(value: object) -> Decimal:
+    try:
+        return Decimal(clean(value) or "0")
+    except InvalidOperation:
+        return Decimal("0")
+
+
+def is_deleted(row: dict[str, str]) -> bool:
+    value = clean(row.get("DEL")).lower()
+    return (bool(value) and value not in {"0", "false", "no", "n", "否"}) or any(
+        clean(row.get(field)) for field in LEGACY_DELETE_FIELDS if field != "DEL"
+    )
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return [dict(row) for row in csv.DictReader(handle)]
+
+
+def receipt_lane(row: dict[str, str]) -> str:
+    if is_deleted(row):
+        return "deleted"
+    pushed_income = (
+        clean(row.get("D_SCBSJS_SKYT")) in {"销售收款", "预收款"}
+        or bool(clean(row.get("OTHER_SYSTEM_CODE")))
+        or clean(row.get("D_SCBSJS_IsPush")) == "1"
+    )
+    if pushed_income:
+        return "sales_receipt_or_pushed_income"
+    if clean(row.get("SJBMC")) == "甲方回款录入" or clean(row.get("DJBH")).startswith(("ZJSR", "QTSR", "ZCDFSR")):
+        return "legacy_receipt_entry"
+    return "other_receipt_income"
+
+
+def receipt_asset_legacy_ids() -> set[str]:
+    root = ET.parse(RECEIPT_XML).getroot()
+    result: set[str] = set()
+    for record in root.findall(".//record[@model='payment.request']"):
+        note = ""
+        for field in record.findall("field"):
+            if clean(field.get("name")) == "note":
+                note = clean(field.text)
+                break
+        match = re.search(r"legacy_receipt_id=([^;\s]+)", note)
+        if match:
+            result.add(match.group(1))
+    return result
+
+
+def contract_direction_rows() -> list[dict[str, Any]]:
+    manifest = json.loads(CONTRACT_MANIFEST.read_text(encoding="utf-8"))
+    return [row for row in manifest.get("records", []) if row.get("status") == "loadable"]
+
+
+def summarize_receipts(rows: list[dict[str, str]], asset_ids: set[str]) -> dict[str, Any]:
+    raw_counts: Counter[str] = Counter()
+    raw_amounts: defaultdict[str, Decimal] = defaultdict(Decimal)
+    raw_with_contract: Counter[str] = Counter()
+    asset_counts: Counter[str] = Counter()
+    asset_amounts: defaultdict[str, Decimal] = defaultdict(Decimal)
+    asset_with_contract: Counter[str] = Counter()
+    target_rows: list[dict[str, str]] = []
+
+    for row in rows:
+        lane = receipt_lane(row)
+        raw_counts[lane] += 1
+        raw_amounts[lane] += money(row.get("f_JE"))
+        if clean(row.get("SGHTID")):
+            raw_with_contract[lane] += 1
+        legacy_id = clean(row.get("Id"))
+        if legacy_id in asset_ids:
+            asset_counts[lane] += 1
+            asset_amounts[lane] += money(row.get("f_JE"))
+            if clean(row.get("SGHTID")):
+                asset_with_contract[lane] += 1
+        if legacy_id in TARGET_RECEIPT_IDS or clean(row.get("XMID")) == TARGET_PROJECT_ID and clean(row.get("SGHTID")) == TARGET_CONTRACT_ID:
+            target_rows.append(
+                {
+                    "legacy_receipt_id": legacy_id,
+                    "document_no": clean(row.get("DJBH")),
+                    "amount": clean(row.get("f_JE")),
+                    "date": clean(row.get("f_RQ")),
+                    "source_menu": clean(row.get("SJBMC")),
+                    "receipt_lane": lane,
+                    "legacy_receipt_type": clean(row.get("type")),
+                    "income_category": clean(row.get("f_SRLBName")),
+                    "contract_legacy_id": clean(row.get("SGHTID")),
+                    "sales_receipt_kind": clean(row.get("D_SCBSJS_SKYT")),
+                    "is_pushed": clean(row.get("D_SCBSJS_IsPush")),
+                    "other_system_code": clean(row.get("OTHER_SYSTEM_CODE")),
+                }
+            )
+
+    lanes = sorted(raw_counts)
+    return {
+        "raw_rows": sum(raw_counts.values()),
+        "receipt_core_asset_rows": len(asset_ids),
+        "lanes": [
+            {
+                "lane": lane,
+                "raw_rows": raw_counts[lane],
+                "raw_amount": str(raw_amounts[lane]),
+                "raw_with_contract": raw_with_contract[lane],
+                "receipt_core_asset_rows": asset_counts[lane],
+                "receipt_core_asset_amount": str(asset_amounts[lane]),
+                "receipt_core_asset_with_contract": asset_with_contract[lane],
+            }
+            for lane in lanes
+        ],
+        "target_rows": target_rows,
+    }
+
+
+def summarize_contracts(contract_rows: list[dict[str, Any]], raw_contract_rows: list[dict[str, str]]) -> dict[str, Any]:
+    raw_by_id = {clean(row.get("Id")): row for row in raw_contract_rows}
+    counts: Counter[tuple[str, str]] = Counter()
+    receipt_reference_in: list[dict[str, str]] = []
+    target_contract: dict[str, Any] | None = None
+
+    for row in contract_rows:
+        key = (clean(row.get("contract_type")), clean(row.get("direction_source")))
+        counts[key] += 1
+        legacy_id = clean(row.get("legacy_contract_id"))
+        if legacy_id == TARGET_CONTRACT_ID:
+            target_contract = row
+        if key == ("in", "receipt_contract_reference"):
+            raw = raw_by_id.get(legacy_id, {})
+            receipt_reference_in.append(
+                {
+                    "legacy_contract_id": legacy_id,
+                    "legacy_project_id": clean(row.get("legacy_project_id")),
+                    "project_name": clean(raw.get("f_XMMC")),
+                    "subject": clean(raw.get("HTBT")) or clean(raw.get("DJBH")) or clean(raw.get("HTBH")),
+                    "fbf": clean(raw.get("FBF")),
+                    "cbf": clean(raw.get("CBF")),
+                    "contract_type": clean(row.get("contract_type")),
+                    "direction_source": clean(row.get("direction_source")),
+                    "receipt_reference_count": clean(row.get("receipt_direction_reference_count")),
+                    "source_contract_confirmed": clean(raw.get("D_SCBSJS_SFGD")),
+                }
+            )
+
+    return {
+        "direction_counts": [
+            {"contract_type": key[0], "direction_source": key[1], "rows": count}
+            for key, count in sorted(counts.items(), key=lambda item: (-item[1], item[0]))
+        ],
+        "receipt_reference_in_rows": len(receipt_reference_in),
+        "receipt_reference_in_samples": receipt_reference_in[:50],
+        "target_contract": target_contract,
+    }
+
+
+def write_outputs(payload: dict[str, Any]) -> None:
+    OUTPUT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    lines = [
+        "# Receipt Contract Boundary Audit v1",
+        "",
+        f"- status: `{payload['status']}`",
+        f"- raw_receipt_rows: `{payload['receipts']['raw_rows']}`",
+        f"- receipt_core_asset_rows: `{payload['receipts']['receipt_core_asset_rows']}`",
+        f"- receipt_reference_contracts_marked_in: `{payload['contracts']['receipt_reference_in_rows']}`",
+        "- db_writes: `0`",
+        "",
+        "## Receipt Lanes",
+        "",
+        "| lane | raw rows | raw amount | raw with contract | receipt_core rows | receipt_core amount | receipt_core with contract |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for row in payload["receipts"]["lanes"]:
+        lines.append(
+            "| {lane} | {raw_rows} | {raw_amount} | {raw_with_contract} | {receipt_core_asset_rows} | {receipt_core_asset_amount} | {receipt_core_asset_with_contract} |".format(
+                **row
+            )
+        )
+    lines.extend(["", "## Contract Direction Counts", "", "| type | source | rows |", "|---|---|---:|"])
+    for row in payload["contracts"]["direction_counts"]:
+        lines.append(f"| {row['contract_type']} | {row['direction_source']} | {row['rows']} |")
+    lines.extend(
+        [
+            "",
+            "## Finding",
+            "",
+            "The audit checks that receipt-entry facts and sales/pushed income facts are separated before `receipt_core` reaches `payment.request`. It also checks that receipt-reference direction evidence does not mark contracts as `in`, because the runtime model defines `out` as income contract and `in` as expense contract.",
+            "",
+            "## Boundary Recommendation",
+            "",
+            "- Migration phase should preserve every non-deleted source fact, but separate carriers by old-system visible surface/source intent.",
+            "- `sales_receipt_or_pushed_income` should be carried as income/receipt fact evidence, not user application fact.",
+            "- Contract direction derived from receipt evidence is an income-side signal unless later user confirmation changes the business fact.",
+        ]
+    )
+    OUTPUT_MD.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    receipt_rows = read_csv(RAW_RECEIPT)
+    raw_contract_rows = read_csv(RAW_CONTRACT)
+    asset_ids = receipt_asset_legacy_ids()
+    contracts = contract_direction_rows()
+    payload = {
+        "status": "PASS",
+        "mode": "receipt_contract_boundary_audit",
+        "db_writes": 0,
+        "receipts": summarize_receipts(receipt_rows, asset_ids),
+        "contracts": summarize_contracts(contracts, raw_contract_rows),
+    }
+    write_outputs(payload)
+    print("RECEIPT_CONTRACT_BOUNDARY_AUDIT=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migration/receipt_core_asset_generator.py
+++ b/scripts/migration/receipt_core_asset_generator.py
@@ -31,6 +31,10 @@ REQUIRED_COLUMNS = {"Id", "f_JE", "WLDWID"}
 ASSET_PACKAGE_ID = "receipt_sc_v1"
 GENERATED_AT = "2026-04-15T08:15:00+00:00"
 EXCLUDED_RECEIPT_INCOME_CATEGORIES = {"材料款", "开票税金", "保险费", "代理服务费", "代理费"}
+LEGACY_DELETE_FIELDS = ("DEL", "SCRID", "SCR", "SCRQ")
+SALES_RECEIPT_KINDS = {"销售收款", "预收款"}
+LEGACY_RECEIPT_SOURCE_NAMES = {"甲方回款录入"}
+LEGACY_RECEIPT_DOCUMENT_PREFIXES = ("ZJSR", "QTSR", "ZCDFSR")
 
 
 class ReceiptAssetError(Exception):
@@ -87,6 +91,10 @@ def is_deleted(value: object) -> bool:
     return bool(normalized) and normalized not in {"0", "false", "no", "n", "否"}
 
 
+def is_deleted_row(row: dict[str, str]) -> bool:
+    return is_deleted(row.get("DEL")) or any(clean(row.get(field)) for field in ("SCRID", "SCR", "SCRQ"))
+
+
 def first_nonempty(row: dict[str, str], fields: list[str]) -> str:
     for field in fields:
         value = clean(row.get(field))
@@ -97,6 +105,21 @@ def first_nonempty(row: dict[str, str], fields: list[str]) -> str:
 
 def receipt_income_category(row: dict[str, str]) -> str:
     return clean(row.get("f_SRLBName"))
+
+
+def receipt_source_lane(row: dict[str, str]) -> str:
+    if (
+        clean(row.get("D_SCBSJS_SKYT")) in SALES_RECEIPT_KINDS
+        or bool(clean(row.get("OTHER_SYSTEM_CODE")))
+        or clean(row.get("D_SCBSJS_IsPush")) == "1"
+    ):
+        return "sales_receipt_or_pushed_income"
+    if clean(row.get("SJBMC")) in LEGACY_RECEIPT_SOURCE_NAMES:
+        return "legacy_receipt_entry"
+    document_no = clean(row.get("DJBH")).upper()
+    if document_no.startswith(LEGACY_RECEIPT_DOCUMENT_PREFIXES):
+        return "legacy_receipt_entry"
+    return "other_receipt_income"
 
 
 def parse_date(value: object) -> str:
@@ -220,11 +243,16 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
         legacy_partner_id = clean(row.get("WLDWID"))
         contract = contract_by_legacy.get(legacy_contract_id)
         partner_external_id = partner_by_legacy.get(legacy_partner_id)
+        source_lane = receipt_source_lane(row)
         errors: list[str] = []
         if not legacy_receipt_id:
             errors.append("missing_legacy_receipt_id")
-        if is_deleted(row.get("DEL")):
+        if is_deleted_row(row):
             errors.append("discard_deleted")
+        if source_lane == "sales_receipt_or_pushed_income":
+            errors.append("route_sales_receipt_or_pushed_income")
+        elif source_lane != "legacy_receipt_entry":
+            errors.append("route_other_receipt_income")
         income_category = receipt_income_category(row)
         if income_category in EXCLUDED_RECEIPT_INCOME_CATEGORIES:
             errors.append("discard_non_receipt_request_category")
@@ -249,7 +277,14 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
                     "legacy_receipt_id": legacy_receipt_id,
                     "legacy_contract_id": legacy_contract_id,
                     "legacy_partner_id": legacy_partner_id,
+                    "legacy_delete_values": {field: clean(row.get(field)) for field in LEGACY_DELETE_FIELDS},
                     "income_category": income_category,
+                    "source_lane": source_lane,
+                    "sales_receipt_kind": clean(row.get("D_SCBSJS_SKYT")),
+                    "is_pushed": clean(row.get("D_SCBSJS_IsPush")),
+                    "other_system_code": clean(row.get("OTHER_SYSTEM_CODE")),
+                    "source_form": clean(row.get("SJBMC")),
+                    "document_no": clean(row.get("DJBH")),
                     "errors": ",".join(errors),
                 }
             )
@@ -278,6 +313,7 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
                 "amount": str(amount),
                 "date_request": receipt_date,
                 "receipt_type": receipt_type,
+                "source_lane": source_lane,
                 "document_no": document_no,
                 "creator_legacy_user_id": first_nonempty(row, ["LRRID", "f_LRRID"]),
                 "creator_name": first_nonempty(row, ["LRR", "f_LRR"]),
@@ -323,6 +359,7 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
                 "legacy_receipt_id": row["legacy_receipt_id"],
                 "partner_external_id": row["partner_external_id"],
                 "project_external_id": row["project_external_id"],
+                "source_lane": row["source_lane"],
                 "status": "loadable",
                 "target_model": "payment.request",
                 "target_type": "receive",
@@ -356,10 +393,14 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
             "generate_time": [
                 "legacy_receipt_id_unique",
                 "amount_positive",
+                "old_system_deleted_rows_discarded",
+                "receipt_source_lane_classified",
+                "sales_receipt_or_pushed_income_routed_out",
+                "other_receipt_income_routed_out",
                 "project_external_id_resolves",
-            "contract_external_id_resolves",
-            "contract_id_optional_when_missing_in_legacy",
-            "partner_external_id_resolves",
+                "contract_external_id_resolves",
+                "contract_id_optional_when_missing_in_legacy",
+                "partner_external_id_resolves",
                 "type_receive_only",
                 "state_not_written",
                 "settlement_not_written",
@@ -372,6 +413,11 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
             "blocked_rows": len(blocked),
             "blocker_counts": dict(sorted(counters.items())),
             "excluded_income_categories": sorted(EXCLUDED_RECEIPT_INCOME_CATEGORIES),
+            "legacy_delete_fields": list(LEGACY_DELETE_FIELDS),
+            "old_system_deleted_rows": counters.get("discard_deleted", 0),
+            "receipt_source_lanes": dict(sorted(Counter(row["source_lane"] for row in loadable).items())),
+            "routed_sales_receipt_or_pushed_income_rows": counters.get("route_sales_receipt_or_pushed_income", 0),
+            "routed_other_receipt_income_rows": counters.get("route_other_receipt_income", 0),
             "ready_rows": len(loadable),
             "contract_optional_empty_rows": sum(1 for row in loadable if not row["contract_external_id"]),
         },
@@ -413,6 +459,9 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
             "loadable_records": len(loadable),
             "raw_rows": len(source_rows),
             "excluded_non_receipt_request_records": counters.get("discard_non_receipt_request_category", 0),
+            "discarded_old_system_deleted_records": counters.get("discard_deleted", 0),
+            "routed_sales_receipt_or_pushed_income_records": counters.get("route_sales_receipt_or_pushed_income", 0),
+            "routed_other_receipt_income_records": counters.get("route_other_receipt_income", 0),
         },
         "db_writes": 0,
         "dependencies": ["project_sc_v1", "partner_sc_v1", "receipt_counterparty_partner_sc_v1", "contract_sc_v1"],
@@ -451,6 +500,10 @@ def generate(asset_root: Path, runtime_root: Path, source_csv: Path, expected_re
             "legacy_receipt_id_non_empty",
             "legacy_receipt_id_unique",
             "amount_positive",
+            "old_system_deleted_rows_discarded",
+            "receipt_source_lane_classified",
+            "sales_receipt_or_pushed_income_routed_out",
+            "other_receipt_income_routed_out",
             "non_receipt_request_income_categories_excluded",
             "project_anchor_resolves",
             "contract_anchor_resolves",
@@ -483,7 +536,7 @@ def main() -> int:
     parser.add_argument("--asset-root", default=str(REPO_ASSET_ROOT))
     parser.add_argument("--runtime-root", default=str(RUNTIME_ROOT))
     parser.add_argument("--source", default=str(SOURCE_CSV))
-    parser.add_argument("--expected-ready", type=int, default=3652)
+    parser.add_argument("--expected-ready", type=int, default=1480)
     parser.add_argument("--check", action="store_true")
     args = parser.parse_args()
 

--- a/scripts/verify/payment_request_receipt_type_guard.py
+++ b/scripts/verify/payment_request_receipt_type_guard.py
@@ -117,15 +117,21 @@ def main() -> int:
     )
     _assert(
         "discarded_existing_old_system_deleted_rows" in receipt_write
-        and "existing_deleted_records.unlink()" in receipt_write,
-        "receipt core write must remove already-written migration rows deleted in the old system",
+        and "C_JFHKLR_DELETED" in receipt_write
+        and "old_system_deleted" in receipt_write,
+        "receipt core write must quarantine already-written migration rows deleted in the old system",
         errors,
     )
     _assert(
         "discarded_existing_stale_payload_rows" in receipt_write
-        and "stale_payload_records.unlink()" in receipt_write
+        and "C_JFHKLR_ROUTED_OUT" in receipt_write
         and "legacy_receipt_id not in payload_receipt_ids" in receipt_write,
-        "receipt core write must remove already-written migration rows routed out of the current receipt payload",
+        "receipt core write must quarantine already-written migration rows routed out of the current receipt payload",
+        errors,
+    )
+    _assert(
+        "C_JFHKLR_DELETED" in views and "C_JFHKLR_ROUTED_OUT" in views,
+        "receipt request action must hide quarantined legacy receipt carriers",
         errors,
     )
     _assert(

--- a/scripts/verify/payment_request_receipt_type_guard.py
+++ b/scripts/verify/payment_request_receipt_type_guard.py
@@ -122,6 +122,13 @@ def main() -> int:
         errors,
     )
     _assert(
+        "discarded_existing_stale_payload_rows" in receipt_write
+        and "stale_payload_records.unlink()" in receipt_write
+        and "legacy_receipt_id not in payload_receipt_ids" in receipt_write,
+        "receipt core write must remove already-written migration rows routed out of the current receipt payload",
+        errors,
+    )
+    _assert(
         '"receipt_type"' in receipt_write
         and '"receipt_type": clean(row.get("receipt_type")) or False' in receipt_write,
         "receipt core write must create payment.request rows with receipt_type",

--- a/scripts/verify/payment_request_receipt_type_guard.py
+++ b/scripts/verify/payment_request_receipt_type_guard.py
@@ -25,6 +25,8 @@ def main() -> int:
     asset_generator = _read("scripts/migration/receipt_core_asset_generator.py")
     replay_adapter = _read("scripts/migration/fresh_db_receipt_core_replay_adapter.py")
     receipt_write = _read("scripts/migration/fresh_db_receipt_core_write.py")
+    contract_generator = _read("scripts/migration/contract_header_asset_generator.py")
+    contract_remaining_screen = _read("scripts/migration/contract_remaining214_strict_screen.py")
     normalize = _read("scripts/migration/visible_surface_receipt_core_creator_normalize_write.py")
     search_config = _read("addons/smart_core/app_config_engine/models/app_search_config.py")
     browser_smoke = _read("scripts/verify/payment_request_receipt_type_browser_group_smoke.js")
@@ -71,6 +73,28 @@ def main() -> int:
         errors,
     )
     _assert(
+        "LEGACY_DELETE_FIELDS" in asset_generator
+        and "def is_deleted_row" in asset_generator
+        and "old_system_deleted_rows_discarded" in asset_generator,
+        "receipt core asset generation must directly discard old-system deleted rows",
+        errors,
+    )
+    _assert(
+        "def receipt_source_lane" in asset_generator
+        and "route_sales_receipt_or_pushed_income" in asset_generator
+        and "route_other_receipt_income" in asset_generator
+        and "sales_receipt_or_pushed_income_routed_out" in asset_generator,
+        "receipt core asset generation must route sales/pushed income out of payment.request",
+        errors,
+    )
+    _assert(
+        'direction = "out"' in contract_generator
+        and 'direction_source = "receipt_contract_reference"' in contract_generator
+        and 'direction = "out"' in contract_remaining_screen,
+        "receipt contract reference evidence must infer income contracts, not payment contracts",
+        errors,
+    )
+    _assert(
         '"receipt_type",' in replay_adapter
         and '"receipt_type": clean(values.get("receipt_type"))' in replay_adapter,
         "receipt core replay adapter must emit receipt_type in the payload",
@@ -82,6 +106,19 @@ def main() -> int:
         and "def raw_receipt_type_map" in receipt_write
         and "receipt_types.get(legacy_receipt_id" in receipt_write,
         "receipt core replay/write must backfill receipt_type from raw CSV when packaged XML lacks the field",
+        errors,
+    )
+    _assert(
+        "def raw_deleted_receipt_ids" in receipt_write
+        and "discarded_old_system_deleted_rows" in receipt_write
+        and "is_deleted_source_row" in receipt_write,
+        "receipt core write must filter stale payload/XML rows deleted in the old system",
+        errors,
+    )
+    _assert(
+        "discarded_existing_old_system_deleted_rows" in receipt_write
+        and "existing_deleted_records.unlink()" in receipt_write,
+        "receipt core write must remove already-written migration rows deleted in the old system",
         errors,
     )
     _assert(


### PR DESCRIPTION
## Summary
- route sales receipt / pushed income facts out of `payment.request` receipt core migration while preserving them for income fact carriers
- discard old-system deleted receipt rows consistently during generation and replay writes
- correct receipt-reference contract direction inference from expense (`in`) to income (`out`)
- add a read-only audit for receipt source lanes and receipt-reference contract direction

## Verification
- `python3 -m py_compile scripts/migration/receipt_contract_boundary_audit.py scripts/migration/receipt_core_asset_generator.py scripts/migration/fresh_db_receipt_core_replay_adapter.py scripts/migration/fresh_db_receipt_core_write.py scripts/migration/contract_header_asset_generator.py scripts/migration/contract_remaining214_strict_screen.py scripts/verify/payment_request_receipt_type_guard.py`
- `python3 scripts/verify/payment_request_receipt_type_guard.py`
- `python3 scripts/migration/receipt_core_asset_generator.py --check`
- `python3 scripts/migration/fresh_db_receipt_core_replay_adapter.py`
- `python3 scripts/migration/contract_header_asset_generator.py --check`
- `python3 scripts/migration/receipt_contract_boundary_audit.py`
- `python3 scripts/migration/contract_remaining214_strict_screen.py`
- `git diff --check`