### PR TITLE
Fix demo admin menu access and cleanup gaps

### DIFF
--- a/addons/smart_construction_core/models/core/project_core.py
+++ b/addons/smart_construction_core/models/core/project_core.py
@@ -271,41 +271,8 @@ class ProjectProjectStage(models.Model):
 class ProjectProject(models.Model):
     _inherit = 'project.project'
     _description = '项目'
-    _PROJECT_UNLINK_BLOCK_MODELS = (
-        "construction.contract",
-        "project.budget",
-        "project.cost.ledger",
-        "project.cost.period",
-        "project.progress.entry",
-        "project.material.plan",
-        "payment.request",
-        "sc.material.purchase.request",
-        "sc.material.acceptance",
-        "sc.material.inbound",
-        "sc.material.outbound",
-        "sc.material.rfq",
-        "sc.material.settlement",
-        "sc.material.rental.plan",
-        "sc.material.rental.order",
-        "sc.labor.plan",
-        "sc.labor.request",
-        "sc.attendance.checkin",
-        "sc.labor.usage",
-        "sc.labor.settlement",
-        "sc.equipment.plan",
-        "sc.equipment.request",
-        "sc.equipment.usage",
-        "sc.equipment.settlement",
-        "sc.subcontract.plan",
-        "sc.subcontract.request",
-        "sc.subcontract.register",
-        "sc.subcontract.settlement",
-        "sc.settlement.order",
-        "sc.settlement.adjustment",
-        "tender.bid",
-        "sc.project.document",
-        "sc.safety.issue",
-    )
+    # Empty means discover all stored project.project Many2one blockers at runtime.
+    _PROJECT_UNLINK_BLOCK_MODELS = ()
 
     _STAGE_XMLID_BY_KEY = {
         "planning": "smart_construction_core.project_stage_planning",
@@ -2033,6 +2000,8 @@ class ProjectProject(models.Model):
             if model_name not in self.env:
                 continue
             Model = self.env[model_name].sudo().with_context(active_test=False)
+            if not getattr(Model, "_auto", True):
+                continue
             label = str(getattr(Model, "_description", "") or model_name).strip() or model_name
             for project_id in project_ids:
                 count = int(Model.search_count([("project_id", "=", project_id)]) or 0)

--- a/addons/smart_construction_demo/__manifest__.py
+++ b/addons/smart_construction_demo/__manifest__.py
@@ -16,6 +16,7 @@
         "data/base/20_projects.xml",
         "data/base/25_project_tasks.xml",
         "data/demo/sc_demo_users.xml",
+        "data/demo/admin_menu_access.xml",
         "data/demo/role_matrix_demo_users.xml",
         "data/demo/sc_demo_showcase_actions.xml",
         "data/demo/demo_company_currency.xml",

--- a/addons/smart_construction_demo/data/demo/admin_menu_access.xml
+++ b/addons/smart_construction_demo/data/demo/admin_menu_access.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+  <data noupdate="0">
+
+    <!--
+      Demo environments use the built-in admin account for acceptance.
+      Grant platform-admin and Smart Construction full business groups so the
+      frontend menu API starts from the complete native menu surface.
+    -->
+    <function
+      model="res.users"
+      name="write"
+      eval="([
+        ref('base.user_admin')
+      ], {
+        'groups_id': [
+          (4, ref('smart_core.group_smart_core_admin')),
+          (4, ref('smart_construction_core.group_sc_super_admin'))
+        ]
+      })"
+    />
+
+  </data>
+</odoo>

--- a/addons/smart_construction_demo/models/project_demo_cleanup.py
+++ b/addons/smart_construction_demo/models/project_demo_cleanup.py
@@ -37,8 +37,17 @@ class ProjectProject(models.Model):
             "payment.request",
             "construction.contract",
             "project.material.plan",
+            "sc.material.rental.settlement",
             "tender.bid",
             "sc.project.document",
+            "sc.quality.issue",
+            "sc.safety.issue",
+            "sc.site.photo.batch",
+            "sc.safety.disclosure",
+            "sc.safety.plan",
+            "sc.hazard.source",
+            "sc.safety.patrol.task",
+            "sc.check.standard",
             "project.cost.ledger",
             "project.cost.period",
             "project.progress.entry",
@@ -76,10 +85,16 @@ class ProjectProject(models.Model):
         if model_name not in self.env:
             return
         Model = self.env[model_name].sudo().with_context(active_test=False)
+        if not getattr(Model, "_auto", True):
+            return
         if "project_id" not in Model._fields:
             return
         records = Model.search([("project_id", "in", project_ids)])
         if not records:
+            return
+        if model_name in ("account.move", "account.move.line"):
+            records.write({"project_id": False})
+            deleted[f"{model_name}.project_id"] = deleted.get(f"{model_name}.project_id", 0) + len(records)
             return
         if model_name == "payment.request" and "state" in records._fields:
             records.with_context(allow_transition=True).write({"state": "cancel"})
@@ -87,5 +102,7 @@ class ProjectProject(models.Model):
             records.write({"state": "cancel"})
         elif model_name == "project.material.plan" and "state" in records._fields:
             records.write({"state": "draft"})
+        elif model_name in ("sc.quality.issue", "sc.safety.issue") and hasattr(records, "action_cancel"):
+            records.filtered(lambda record: record.state != "cancel").action_cancel()
         deleted[model_name] = deleted.get(model_name, 0) + len(records)
         records.unlink()

--- a/addons/smart_construction_demo/tools/scenario_loader.py
+++ b/addons/smart_construction_demo/tools/scenario_loader.py
@@ -15,6 +15,7 @@ BASE_SEED_FILES: List[str] = [
     "data/base/10_partners.xml",
     "data/base/20_projects.xml",
     "data/base/25_project_tasks.xml",
+    "data/demo/admin_menu_access.xml",
 ]
 
 

--- a/scripts/demo/load.sh
+++ b/scripts/demo/load.sh
@@ -37,3 +37,8 @@ print("[demo.load] loading scenario:", scenario, "step:", step)
 load_scenario(env, scenario, mode="update", step=step)
 print("[demo.load] done")
 PY
+
+if [ "${DEMO_RESTART_AFTER_LOAD:-1}" = "1" ]; then
+  printf '[demo.load] restart odoo to refresh ACL/menu caches\n'
+  compose_dev up -d --force-recreate "${ODOO_SERVICE:-odoo}"
+fi

--- a/scripts/demo/load_all.sh
+++ b/scripts/demo/load_all.sh
@@ -36,3 +36,8 @@ PY
 
 printf '[demo.load.all] apply showroom reconciliation seed chain\n'
 STEPS=demo_showroom,demo_40_contracts,demo_50_boq_wbs,demo_60_attachments,z_demo_full_my_work,project_stage_sync DB_NAME="$DB_NAME" bash "$ROOT_DIR/scripts/seed/run.sh"
+
+if [ "${DEMO_RESTART_AFTER_LOAD:-1}" = "1" ]; then
+  printf '[demo.load.all] restart odoo to refresh ACL/menu caches\n'
+  compose_dev up -d --force-recreate "${ODOO_SERVICE:-odoo}"
+fi

--- a/scripts/demo/load_full.sh
+++ b/scripts/demo/load_full.sh
@@ -17,7 +17,12 @@ guard_prod_forbid
 
 printf '[demo.load.full] db=%s\n' "$DB_NAME"
 
-bash "$ROOT_DIR/scripts/demo/load_all.sh"
+DEMO_RESTART_AFTER_LOAD=0 bash "$ROOT_DIR/scripts/demo/load_all.sh"
 
 printf '[demo.load.full] seed demo_full\n'
 PROFILE=demo_full DB_NAME="$DB_NAME" bash "$ROOT_DIR/scripts/seed/run.sh"
+
+if [ "${DEMO_RESTART_AFTER_LOAD:-1}" = "1" ]; then
+  printf '[demo.load.full] restart odoo to refresh ACL/menu caches\n'
+  compose_dev up -d --force-recreate "${ODOO_SERVICE:-odoo}"
+fi

--- a/scripts/demo/load_release.sh
+++ b/scripts/demo/load_release.sh
@@ -38,4 +38,9 @@ PY
 printf '[demo.load.release] apply showroom reconciliation seed chain\n'
 STEPS=demo_showroom,demo_40_contracts,demo_50_boq_wbs,demo_60_attachments,z_demo_full_my_work,project_stage_sync DB_NAME="$DB_NAME" bash "$ROOT_DIR/scripts/seed/run.sh"
 
+if [ "${DEMO_RESTART_AFTER_LOAD:-1}" = "1" ]; then
+  printf '[demo.load.release] restart odoo to refresh ACL/menu caches\n'
+  compose_dev up -d --force-recreate "${ODOO_SERVICE:-odoo}"
+fi
+
 printf '[demo.load.release] done\n'

--- a/scripts/demo/verify.sh
+++ b/scripts/demo/verify.sh
@@ -327,6 +327,85 @@ run_check "S90 finance user lacks contract capability" "s90_users_roles" \
 run_check "S90 readonly user not in settlement user group" "s90_users_roles" \
   "select case when count(*) = 0 then 'ok' else 'S90 readonly has settlement group' end from res_groups_users_rel r where r.uid = (select id from res_users where login='demo_readonly') and r.gid in (select id from res_groups where coalesce(name->>'zh_CN', name->>'en_US') = 'SC 能力 - 结算中心经办');" \
   "select u.login, coalesce(g.name->>'zh_CN', g.name->>'en_US') as group_name from res_groups_users_rel r join res_users u on u.id = r.uid join res_groups g on g.id = r.gid where u.login='demo_readonly' order by group_name;"
+run_check "S90 admin has full demo menu groups" "s90_users_roles" \
+  "select case when (select count(*) from res_groups_users_rel r join ir_model_data d on d.res_id=r.gid and d.model='res.groups' where r.uid=(select id from res_users where login='admin') and ((d.module='smart_core' and d.name='group_smart_core_admin') or (d.module='smart_construction_core' and d.name='group_sc_super_admin'))) = 2 then 'ok' else 'S90 admin menu groups missing' end;" \
+  "select u.login, d.module || '.' || d.name as group_xmlid, coalesce(g.name->>'zh_CN', g.name->>'en_US') as group_name from res_groups_users_rel r join res_users u on u.id=r.uid join res_groups g on g.id=r.gid join ir_model_data d on d.res_id=g.id and d.model='res.groups' where u.login='admin' and d.module in ('smart_core','smart_construction_core') order by group_xmlid;"
+if [ -z "$scenario" ] || [ "$scenario" = "s90_users_roles" ]; then
+  printf '[demo.verify] S90 admin menu openability\n'
+  if compose_dev exec -T odoo odoo shell -d "$DB_NAME" -c /var/lib/odoo/odoo.conf <<'PY'
+import sys
+
+admin = env.ref("base.user_admin")
+required_groups = [
+    "smart_core.group_smart_core_admin",
+    "smart_construction_core.group_sc_super_admin",
+    "smart_construction_core.group_sc_cap_config_admin",
+    "smart_construction_core.group_sc_cap_business_config_admin",
+    "smart_construction_core.group_sc_cap_project_read",
+    "smart_construction_core.group_sc_cap_cost_read",
+    "smart_construction_core.group_sc_cap_material_read",
+    "smart_construction_core.group_sc_cap_finance_read",
+    "project.group_project_user",
+    "project.group_project_manager",
+]
+missing_groups = [xmlid for xmlid in required_groups if not admin.has_group(xmlid)]
+if missing_groups:
+    print("missing admin groups:", ", ".join(missing_groups))
+    sys.exit(1)
+
+root = env.ref("smart_construction_core.menu_sc_root", raise_if_not_found=False)
+domain = [("action", "!=", False)]
+if root:
+    domain.append(("id", "child_of", root.id))
+menus = env["ir.ui.menu"].with_user(admin).search(domain)
+failures = []
+checked = 0
+for menu in menus:
+    action = menu.action if menu.action._name == "ir.actions.act_window" else False
+    if not action or not action.res_model or action.res_model not in env:
+        continue
+    checked += 1
+    model_name = action.res_model
+    Model = env[model_name].with_user(admin)
+    try:
+        Model.check_access_rights("read", raise_exception=True)
+        Model.search([], limit=1)
+        if action.search_view_id:
+            Model.with_context(load_all_views=True).get_view(
+                view_id=action.search_view_id.id,
+                view_type="search",
+            )
+        for mode in [m.strip() for m in (action.view_mode or "tree,form").split(",") if m.strip()][:3]:
+            view_type = "tree" if mode == "list" else mode
+            if view_type not in {"tree", "form", "kanban", "pivot", "graph", "calendar", "activity"}:
+                continue
+            view_id = False
+            for action_view in action.view_ids:
+                action_view_type = "tree" if action_view.view_mode == "list" else action_view.view_mode
+                if action_view_type == view_type and action_view.view_id:
+                    view_id = action_view.view_id.id
+                    break
+            if view_id:
+                Model.with_context(load_all_views=True).get_view(view_id=view_id, view_type=view_type)
+            else:
+                Model.with_context(load_all_views=True).get_view(view_type=view_type)
+    except Exception as exc:
+        failures.append((menu.complete_name, model_name, type(exc).__name__, str(exc).splitlines()[0]))
+
+if failures:
+    print("admin menu open failures:", len(failures), "checked:", checked)
+    for row in failures[:50]:
+        print("FAIL", row)
+    sys.exit(1)
+print("ok admin menu openability checked:", checked)
+PY
+  then
+    echo "✓ S90 admin can open delivered menus"
+  else
+    echo "✗ S90 admin can open delivered menus"
+    exit 1
+  fi
+fi
 run_check "showroom projects >= 8" "showroom" \
   "select case when count(*) >= 8 then 'ok' else 'showroom projects < 8' end from project_project where coalesce(name->>'zh_CN', name->>'en_US', name::text) like '展厅-%';" \
   "select id, name, lifecycle_state from project_project where coalesce(name->>'zh_CN', name->>'en_US', name::text) like '展厅-%' order by id;"


### PR DESCRIPTION
## Summary
- grant demo admin the full Smart Construction menu/runtime groups
- restart Odoo after demo loads to refresh ACL/menu caches
- verify admin can open delivered menus during demo verification
- close demo project cleanup gaps for new dependent models

## Verification
- `python3 -m py_compile addons/smart_construction_core/models/core/project_core.py addons/smart_construction_demo/models/project_demo_cleanup.py addons/smart_construction_demo/tools/scenario_loader.py`
- `bash -n scripts/demo/load.sh scripts/demo/load_all.sh scripts/demo/load_full.sh scripts/demo/load_release.sh scripts/demo/verify.sh`
- `git diff --check`
- `COMPOSE_BIN='sudo docker compose' ENV=dev ENV_FILE=.env DB_NAME=sc_demo make demo.verify`