### PR TITLE
fix: remove arrival confirmation sequence column

### DIFF
--- a/addons/smart_construction_core/views/support/legacy_invoice_runtime_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_invoice_runtime_views.xml
@@ -233,7 +233,6 @@
       <field name="model">sc.legacy.fund.confirmation.document</field>
       <field name="arch" type="xml">
         <tree string="到款确认表" create="false" edit="false" delete="false" default_order="receipt_time desc, document_no desc">
-          <field name="sequence_no"/>
           <field name="document_state"/>
           <field name="document_no"/>
           <field name="receipt_time"/>


### PR DESCRIPTION
## Summary
- remove the visible `序号` column from the arrival confirmation list view
- keep the backing read-only sequence field unchanged to avoid SQL view churn

## Testing
- XML parse for `legacy_invoice_runtime_views.xml`
- `git diff --check`