### PR TITLE
fix: hide raw arrival confirmation attachment ids

### DIFF
--- a/addons/smart_construction_core/models/support/legacy_fund_confirmation_document.py
+++ b/addons/smart_construction_core/models/support/legacy_fund_confirmation_document.py
@@ -155,7 +155,14 @@ class ScLegacyFundConfirmationDocument(models.Model):
                     d.previous_retained_balance,
                     d.creator_name,
                     d.created_time,
-                    COALESCE(a.attachment_links, d.attachment_ref) AS attachment_links,
+                    COALESCE(
+                        a.attachment_links,
+                        CASE
+                            WHEN COALESCE(NULLIF(d.attachment_ref, ''), '') <> ''
+                            THEN '历史附件 | legacy-file-id://' || d.attachment_ref
+                            ELSE NULL
+                        END
+                    ) AS attachment_links,
                     d.attachment_ref,
                     d.legacy_header_id,
                     d.active

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -989,7 +989,7 @@ function semanticCell(field: string, value: unknown) {
   const numericText = formatNumericCellValue(field, raw);
   const fieldType = String(option?.type || '').trim().toLowerCase();
   const rawText = typeof raw === 'string' ? raw : '';
-  const attachmentText = rawText && /\|\s*(?:legacy-file|https?|file):\/\//i.test(rawText)
+  const attachmentText = rawText && /\|\s*(?:legacy-file-id|legacy-file|https?|file):\/\//i.test(rawText)
     ? formatAttachmentReferenceValue(rawText)
     : '';
   const text = selectionText

--- a/frontend/apps/web/src/utils/display.ts
+++ b/frontend/apps/web/src/utils/display.ts
@@ -37,7 +37,7 @@ export function parseAttachmentReferenceLinks(value: unknown): Array<{ name: str
   const rawItems = Array.isArray(value) ? value.map((item) => String(item ?? '')) : [String(value ?? '')];
   const seen = new Set<string>();
   const links: Array<{ name: string; url: string }> = [];
-  const urlStartPattern = '(?:legacy-file|https?|file):\\/\\/|\\/web\\/content\\/';
+  const urlStartPattern = '(?:legacy-file-id|legacy-file|https?|file):\\/\\/|\\/web\\/content\\/';
   const itemBoundary = new RegExp(`\\s+(?=[^\\s|]+\\s+\\|\\s+(?:${urlStartPattern}))`, 'i');
   const itemPattern = new RegExp(`^(.*?)\\s+\\|\\s+((?:${urlStartPattern}).+)$`, 'i');
 
@@ -109,7 +109,7 @@ export function formatDisplayValue(
       return normalized.emptyText;
     }
     const attachmentText = formatAttachmentReferenceValue(value);
-    if (attachmentText && value.some((item) => /\|\s*(?:legacy-file|https?|file):\/\//i.test(String(item ?? '')))) {
+    if (attachmentText && value.some((item) => /\|\s*(?:legacy-file-id|legacy-file|https?|file):\/\//i.test(String(item ?? '')))) {
       return attachmentText;
     }
     return value.map((item) => String(item)).join(', ');
@@ -120,7 +120,7 @@ export function formatDisplayValue(
   }
 
   const rawText = String(value);
-  if (/\|\s*(?:legacy-file|https?|file):\/\//i.test(rawText)) {
+  if (/\|\s*(?:legacy-file-id|legacy-file|https?|file):\/\//i.test(rawText)) {
     return formatAttachmentReferenceValue(rawText) || rawText;
   }
   return rawText;


### PR DESCRIPTION
## Summary
- convert arrival confirmation attachment fallback values into `历史附件 | legacy-file-id://...`
- teach frontend attachment parsing to handle `legacy-file-id://` links so list cells show readable attachment text instead of raw IDs

## Testing
- `python3 -m py_compile addons/smart_construction_core/models/support/legacy_fund_confirmation_document.py`
- `git diff --check`
- `ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo make verify.frontend.typecheck.strict`
- node regex smoke for `legacy-file-id://45934dbf35365ca713da9b5e5b8`