### PR TITLE
fix: keep prepaid tax empty attachments blank

### DIFF
--- a/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
+++ b/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
@@ -941,6 +941,11 @@ def _alias_value(record, label):
         legacy_links = _legacy_attachment_links(record)
         if legacy_links:
             return legacy_links
+        for field_name in ('attachment_ids', 'biz_attachment_ids', 'tech_attachment_ids', 'legacy_attachment_name'):
+            value = _format_alias_value(record, field_name)
+            if value:
+                return value
+        return ""
     if record._name == 'sc.tax.deduction.registration' and label == '单据状态':
         legacy_state = _format_alias_value(record, 'legacy_document_state')
         if legacy_state:


### PR DESCRIPTION
## Summary
- keep `sc.invoice.registration` attachment aliases scoped to real attachment sources
- prevent empty prepaid-tax attachments from falling back to document numbers

## Verification
- `python3 -m py_compile addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py`
- server audit before fix: `verify.prepaid_tax.visible_surface_alignment.audit` passed header/order checks and exposed attachment values falling back to `YJSKDJ-*` document numbers