### PR TITLE
fix: keep prepaid tax detail row count

### DIFF
--- a/scripts/migration/fresh_db_invoice_registration_projection_write.py
+++ b/scripts/migration/fresh_db_invoice_registration_projection_write.py
@@ -387,17 +387,21 @@ env.cr.execute(  # noqa: F821
       NULLIF(f.tax_certificate_no, ''),
       NULLIF(f.invoice_no, ''),
       NULLIF(f.invoice_code, ''),
-      NULLIF(f.invoice_type, ''),
+      COALESCE(NULLIF(f.invoice_type, ''), NULLIF(header_fact.invoice_type, '')),
       CASE
         WHEN COALESCE(f.tax_rate, 0) > 0
         THEN RTRIM(RTRIM(TO_CHAR(ROUND((f.tax_rate * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
         WHEN COALESCE(f.tax_amount, 0) <> 0 AND COALESCE(f.amount_no_tax, 0) <> 0
         THEN RTRIM(RTRIM(TO_CHAR(ROUND((ABS(f.tax_amount) / NULLIF(ABS(f.amount_no_tax), 0) * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
+        WHEN COALESCE(header_fact.tax_rate, 0) > 0
+        THEN RTRIM(RTRIM(TO_CHAR(ROUND((header_fact.tax_rate * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
+        WHEN COALESCE(header_fact.tax_amount, 0) <> 0 AND COALESCE(header_fact.amount_no_tax, 0) <> 0
+        THEN RTRIM(RTRIM(TO_CHAR(ROUND((ABS(header_fact.tax_amount) / NULLIF(ABS(header_fact.amount_no_tax), 0) * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
         ELSE NULL
       END,
-      NULLIF(f.invoice_content, ''),
-      COALESCE(f.amount_no_tax, 0),
-      COALESCE(f.tax_amount, 0),
+      COALESCE(NULLIF(f.invoice_content, ''), NULLIF(header_fact.invoice_content, '')),
+      COALESCE(NULLIF(f.amount_no_tax, 0), header_fact.amount_no_tax, 0),
+      COALESCE(NULLIF(f.tax_amount, 0), header_fact.tax_amount, 0),
       COALESCE(f.amount_total, 0),
       %s,
       'sc.legacy.income.invoice.fact',
@@ -419,6 +423,18 @@ env.cr.execute(  # noqa: F821
       NOW()
     FROM sc_legacy_income_invoice_fact f
     LEFT JOIN LATERAL (
+      SELECT h.invoice_type, h.invoice_content, h.tax_rate, h.amount_no_tax, h.tax_amount
+        FROM sc_legacy_income_invoice_fact h
+       WHERE h.active
+         AND h.fact_type = 'prepaid_tax'
+         AND h.document_no = f.document_no
+         AND (h.project_id = f.project_id OR h.project_id IS NULL OR f.project_id IS NULL)
+       ORDER BY
+         CASE WHEN h.project_id = f.project_id THEN 0 ELSE 1 END,
+         h.id
+       LIMIT 1
+    ) header_fact ON TRUE
+    LEFT JOIN LATERAL (
       SELECT rp.id
         FROM res_partner rp
        WHERE rp.active
@@ -433,7 +449,7 @@ env.cr.execute(  # noqa: F821
     ) partner_match ON TRUE
     WHERE f.active
       AND f.project_id IS NOT NULL
-      AND f.fact_type = 'prepaid_tax'
+      AND f.fact_type = 'prepaid_tax_line'
       AND COALESCE(f.amount_total, 0) <> 0
     ON CONFLICT (legacy_source_model, legacy_record_id)
     DO UPDATE SET
@@ -480,10 +496,10 @@ env.cr.execute(  # noqa: F821
            write_date = NOW()
       FROM sc_legacy_income_invoice_fact fact
      WHERE target.source_kind = 'prepaid_tax'
-       AND target.direction = 'prepaid'
-       AND target.legacy_source_model = 'sc.legacy.income.invoice.fact'
-       AND target.legacy_record_id = fact.legacy_record_id
-       AND fact.fact_type = 'prepaid_tax_line'
+      AND target.direction = 'prepaid'
+      AND target.legacy_source_model = 'sc.legacy.income.invoice.fact'
+      AND target.legacy_record_id = fact.legacy_record_id
+      AND fact.fact_type = 'prepaid_tax'
     """
 )
 

--- a/scripts/verify/prepaid_tax_visible_surface_alignment_audit.py
+++ b/scripts/verify/prepaid_tax_visible_surface_alignment_audit.py
@@ -161,7 +161,7 @@ def visible_value_coverage(expected_labels: list[str], field_names: list[str]) -
 def projection_coverage() -> dict[str, object]:
     Fact = env["sc.legacy.income.invoice.fact"].sudo()  # noqa: F821
     Invoice = env["sc.invoice.registration"].sudo()  # noqa: F821
-    fact_domain = [("fact_type", "=", "prepaid_tax")]
+    fact_domain = [("fact_type", "=", "prepaid_tax_line")]
     eligible_domain = fact_domain + [("active", "=", True), ("amount_total", "!=", 0)]
     missing_project = Fact.search(eligible_domain + [("project_id", "=", False)], order="document_date desc, id", limit=20)
     runtime_domain = [("source_kind", "=", "prepaid_tax"), ("direction", "=", "prepaid"), ("active", "=", True)]
@@ -197,7 +197,10 @@ def projection_coverage() -> dict[str, object]:
         ],
         "status_project_name_contamination_count": len(status_project_name_hits),
         "status_project_name_contamination_examples": status_project_name_hits[:5],
-        "decision": "runtime_rows_match_project_anchored_eligible_prepaid_tax_headers",
+        "decision": (
+            "runtime_rows_match_project_anchored_eligible_prepaid_tax_lines; "
+            "summary tax fields are enriched from same-document prepaid_tax headers"
+        ),
     }
 
 


### PR DESCRIPTION
## Summary
- restore prepaid tax projection to detail-line rows so list count stays aligned with original surface
- enrich line rows with same-document prepaid tax header fields for no-tax amount, tax amount, tax rate, and invoice type/content
- deactivate header-only prepaid tax rows after projection so they do not replace or inflate the list count
- update the prepaid tax audit to compare against line fact coverage again

## Verification
- `python3 -m py_compile scripts/migration/fresh_db_invoice_registration_projection_write.py scripts/verify/prepaid_tax_visible_surface_alignment_audit.py`