### PR TITLE
fix: project prepaid tax line fields from source assets

### DIFF
--- a/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
+++ b/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
@@ -776,7 +776,7 @@ MODEL_LABEL_SOURCE_OVERRIDES = {
         '预计回款日期': ['expected_receipt_date'],
         '申请人': ['applicant_name', 'creator_name', 'source_created_by'],
         '受票方名称': ['partner_id', 'legacy_partner_name'],
-        '交税类型': ['tax_type', 'invoice_content', 'source_kind', 'operation_strategy'],
+        '交税类型': ['tax_type', 'invoice_content', 'operation_strategy'],
         '数据类型': ['source_kind'],
         '金额': ['amount_total'],
         '发票开具日期': ['invoice_date', 'document_date'],

--- a/scripts/migration/fresh_db_invoice_registration_projection_write.py
+++ b/scripts/migration/fresh_db_invoice_registration_projection_write.py
@@ -387,21 +387,17 @@ env.cr.execute(  # noqa: F821
       NULLIF(f.tax_certificate_no, ''),
       NULLIF(f.invoice_no, ''),
       NULLIF(f.invoice_code, ''),
-      COALESCE(NULLIF(f.invoice_type, ''), NULLIF(header_fact.invoice_type, '')),
+      NULLIF(f.invoice_type, ''),
       CASE
         WHEN COALESCE(f.tax_rate, 0) > 0
         THEN RTRIM(RTRIM(TO_CHAR(ROUND((f.tax_rate * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
         WHEN COALESCE(f.tax_amount, 0) <> 0 AND COALESCE(f.amount_no_tax, 0) <> 0
         THEN RTRIM(RTRIM(TO_CHAR(ROUND((ABS(f.tax_amount) / NULLIF(ABS(f.amount_no_tax), 0) * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
-        WHEN COALESCE(header_fact.tax_rate, 0) > 0
-        THEN RTRIM(RTRIM(TO_CHAR(ROUND((header_fact.tax_rate * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
-        WHEN COALESCE(header_fact.tax_amount, 0) <> 0 AND COALESCE(header_fact.amount_no_tax, 0) <> 0
-        THEN RTRIM(RTRIM(TO_CHAR(ROUND((ABS(header_fact.tax_amount) / NULLIF(ABS(header_fact.amount_no_tax), 0) * 100)::numeric, 2), 'FM999999990.00'), '0'), '.') || '%%'
         ELSE NULL
       END,
-      COALESCE(NULLIF(f.invoice_content, ''), NULLIF(header_fact.invoice_content, '')),
-      COALESCE(NULLIF(f.amount_no_tax, 0), header_fact.amount_no_tax, 0),
-      COALESCE(NULLIF(f.tax_amount, 0), header_fact.tax_amount, 0),
+      NULLIF(f.invoice_content, ''),
+      COALESCE(f.amount_no_tax, 0),
+      COALESCE(f.tax_amount, 0),
       COALESCE(f.amount_total, 0),
       %s,
       'sc.legacy.income.invoice.fact',
@@ -422,18 +418,6 @@ env.cr.execute(  # noqa: F821
       NOW(),
       NOW()
     FROM sc_legacy_income_invoice_fact f
-    LEFT JOIN LATERAL (
-      SELECT h.invoice_type, h.invoice_content, h.tax_rate, h.amount_no_tax, h.tax_amount
-        FROM sc_legacy_income_invoice_fact h
-       WHERE h.active
-         AND h.fact_type = 'prepaid_tax'
-         AND h.document_no = f.document_no
-         AND (h.project_id = f.project_id OR h.project_id IS NULL OR f.project_id IS NULL)
-       ORDER BY
-         CASE WHEN h.project_id = f.project_id THEN 0 ELSE 1 END,
-         h.id
-       LIMIT 1
-    ) header_fact ON TRUE
     LEFT JOIN LATERAL (
       SELECT rp.id
         FROM res_partner rp

--- a/scripts/verify/prepaid_tax_visible_surface_alignment_audit.py
+++ b/scripts/verify/prepaid_tax_visible_surface_alignment_audit.py
@@ -197,10 +197,7 @@ def projection_coverage() -> dict[str, object]:
         ],
         "status_project_name_contamination_count": len(status_project_name_hits),
         "status_project_name_contamination_examples": status_project_name_hits[:5],
-        "decision": (
-            "runtime_rows_match_project_anchored_eligible_prepaid_tax_lines; "
-            "summary tax fields are enriched from same-document prepaid_tax headers"
-        ),
+        "decision": "runtime_rows_match_project_anchored_eligible_prepaid_tax_lines",
     }
 
 


### PR DESCRIPTION
## Summary
- project prepaid tax visible fields from the migration asset's prepaid_tax_line facts
- remove header-level amount backfill from prepaid tax line rows
- keep tax type sourced from tax_type/invoice_content instead of source_kind

## Verification
- python3 -m py_compile addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py scripts/migration/fresh_db_invoice_registration_projection_write.py scripts/verify/prepaid_tax_visible_surface_alignment_audit.py
- git diff --check