### PR TITLE
fix: enforce SCBS 55 browser menu release

### DIFF
--- a/addons/smart_core/delivery/menu_service.py
+++ b/addons/smart_core/delivery/menu_service.py
@@ -87,7 +87,7 @@ class MenuService:
             yield parent_chain, node
 
     def _resolve_preview_group_anchor(self, ancestors: list[dict]) -> tuple[str, str]:
-        skipped_labels = {"智慧施工管理平台", "系统菜单", "业务菜单", "产品发布面"}
+        skipped_labels = {"智慧施工管理平台", "系统菜单", "业务菜单", "产品发布面", "用户核对菜单"}
         for ancestor in ancestors or []:
             if not isinstance(ancestor, dict):
                 continue

--- a/addons/smart_core/delivery/product_policy_service.py
+++ b/addons/smart_core/delivery/product_policy_service.py
@@ -420,7 +420,10 @@ class ProductPolicyService:
     def _construction_policy_needs_catalog_refresh(self, payload: dict) -> bool:
         if not isinstance(payload, dict):
             return True
-        return not (payload.get("menu_groups") and payload.get("scenes") and payload.get("capabilities"))
+        # Native action/menu release policies can be complete without scene entries:
+        # scenes are only required for scene-first products, while user-visible
+        # menu publishing is driven by menu_groups plus capabilities.
+        return not (payload.get("menu_groups") and payload.get("capabilities"))
 
     def _stable_policy_domain(self, *, base_product_key: str):
         return [

--- a/addons/smart_core/model/ui_menu_config_policy.py
+++ b/addons/smart_core/model/ui_menu_config_policy.py
@@ -250,8 +250,9 @@ class UiMenuConfigPolicy(models.Model):
                 normalized_menu_id = int(menu_id or 0)
             except Exception:
                 normalized_menu_id = 0
+            children = node.get("children")
             policy = policies_by_menu.get(normalized_menu_id)
-            if not policy:
+            if not policy and not (isinstance(children, list) and children):
                 labels = [
                     str(node.get("name") or "").strip(),
                     str(node.get("label") or "").strip(),
@@ -271,7 +272,6 @@ class UiMenuConfigPolicy(models.Model):
                 if policy.sequence_override:
                     node["sequence"] = policy.sequence_override
                     stats["reordered_count"] += 1
-            children = node.get("children")
             if isinstance(children, list):
                 next_children = []
                 for child in children:

--- a/addons/smart_core/tests/test_delivery_menu_entry_target.py
+++ b/addons/smart_core/tests/test_delivery_menu_entry_target.py
@@ -279,6 +279,53 @@ class TestDeliveryMenuEntryTarget(unittest.TestCase):
         labels = [child.get("label") for group in groups for child in group.get("children") or []]
         self.assertEqual(labels, ["项目台账"])
 
+    def test_user_acceptance_container_is_not_used_as_native_preview_group(self):
+        groups = menu_service.MenuService()._native_preview_menus(
+            native_nav=[
+                {
+                    "label": "系统菜单",
+                    "children": [
+                        {
+                            "label": "用户核对菜单",
+                            "menu_id": 100,
+                            "children": [
+                                {
+                                    "label": "基础资料",
+                                    "menu_id": 101,
+                                    "children": [
+                                        self._native_leaf(
+                                            label="供应商/合作单位",
+                                            menu_id=652,
+                                            route="/a/900?menu_id=652",
+                                            action_id=900,
+                                            model="res.partner",
+                                        )
+                                    ],
+                                },
+                                {
+                                    "label": "发票税务",
+                                    "menu_id": 102,
+                                    "children": [
+                                        self._native_leaf(
+                                            label="预缴税款",
+                                            menu_id=709,
+                                            route="/a/901?menu_id=709",
+                                            action_id=901,
+                                            model="sc.prepaid.tax",
+                                        )
+                                    ],
+                                },
+                            ],
+                        }
+                    ],
+                }
+            ],
+            policy={},
+        )
+
+        self.assertEqual([group.get("group_label") for group in groups], ["基础资料", "发票税务"])
+        self.assertEqual([group["menus"][0]["label"] for group in groups], ["供应商/合作单位", "预缴税款"])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py
+++ b/scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import os
+import hashlib
 from pathlib import Path
 
 
@@ -304,8 +305,136 @@ for menu_id, sequence in hidden_menu_rows:
     )
 
 from odoo.addons.smart_core.delivery.product_policy_catalog_sync_service import ProductPolicyCatalogSyncService  # noqa: E402
+from odoo import SUPERUSER_ID, api  # noqa: E402
+from odoo.modules.registry import Registry  # noqa: E402
+
+
+def policy_release_pages(groups: list[dict]) -> list[dict]:
+    pages = []
+    for group in groups:
+        if not isinstance(group, dict) or group.get("category") == "hidden_original_menu":
+            continue
+        group_label = str(group.get("group_label") or "").strip()
+        for menu in group.get("menus") if isinstance(group.get("menus"), list) else []:
+            if not isinstance(menu, dict) or not effective(menu):
+                continue
+            menu_xmlid = str(menu.get("menu_xmlid") or "").strip()
+            menu_id = int(menu.get("menu_id") or 0)
+            action_id = int(menu.get("action_id") or 0)
+            route = str(menu.get("route") or "").strip()
+            if not route and action_id:
+                route = f"/a/{action_id}" + (f"?menu_id={menu_id}" if menu_id else "")
+            pages.append(
+                {
+                    "page_key": menu_xmlid or str(menu.get("menu_key") or "").strip(),
+                    "menu_key": menu_xmlid or str(menu.get("menu_key") or "").strip(),
+                    "menu_xmlid": menu_xmlid,
+                    "label": str(menu.get("label") or "").strip(),
+                    "route": route,
+                    "menu_id": menu_id,
+                    "action_id": action_id,
+                    "res_model": str(menu.get("model") or menu.get("res_model") or "").strip(),
+                    "enabled": True,
+                    "release_state": "released",
+                    "access_level": "public",
+                    "visible_menu_path": f"系统菜单 / 用户核对菜单 / {group_label} / {str(menu.get('label') or '').strip()}",
+                }
+            )
+    return pages
+
+
+def merge_release_pages(existing_pages: list, required_pages: list[dict]) -> tuple[list[dict], int]:
+    merged = [dict(page) for page in existing_pages if isinstance(page, dict)]
+    index = {}
+    for pos, page in enumerate(merged):
+        for key in ("menu_xmlid", "page_key", "menu_key"):
+            value = str(page.get(key) or "").strip()
+            if value:
+                index.setdefault(value, pos)
+        menu_id = int(page.get("menu_id") or 0)
+        action_id = int(page.get("action_id") or 0)
+        if menu_id:
+            index.setdefault(f"menu_id:{menu_id}", pos)
+        if action_id:
+            index.setdefault(f"action_id:{action_id}", pos)
+    added = 0
+    for page in required_pages:
+        keys = [
+            str(page.get("menu_xmlid") or "").strip(),
+            str(page.get("page_key") or "").strip(),
+            str(page.get("menu_key") or "").strip(),
+        ]
+        menu_id = int(page.get("menu_id") or 0)
+        action_id = int(page.get("action_id") or 0)
+        if menu_id:
+            keys.append(f"menu_id:{menu_id}")
+        if action_id:
+            keys.append(f"action_id:{action_id}")
+        hit = next((index[key] for key in keys if key and key in index), None)
+        if hit is None:
+            index[str(page.get("menu_xmlid") or page.get("page_key") or len(merged))] = len(merged)
+            merged.append(dict(page))
+            added += 1
+            continue
+        next_page = dict(merged[hit])
+        next_page.update({key: value for key, value in page.items() if value not in ("", 0, None)})
+        next_page["enabled"] = True
+        next_page["release_state"] = "released"
+        next_page["access_level"] = "public"
+        merged[hit] = next_page
+    return merged, added
+
+
+def sync_platform_release_gate_pages(product_key: str, required_pages: list[dict]) -> dict[str, object]:
+    platform_db = str(env["ir.config_parameter"].sudo().get_param("smart_core.platform_release_db", "") or "").strip()  # noqa: F821
+    platform_db = platform_db or "sc_platform_core"
+    current_db = str(env.cr.dbname)  # noqa: F821
+
+    def update_in(read_env):
+        Snapshot = read_env["sc.edition.release.snapshot"].sudo()
+        snapshot = Snapshot.search(
+            [
+                ("product_key", "=", product_key),
+                ("state", "=", "released"),
+                ("is_active", "=", True),
+                ("active", "=", True),
+            ],
+            order="released_at desc, activated_at desc, id desc",
+            limit=1,
+        )
+        if not snapshot:
+            return {"status": "SKIP", "reason": "active_release_snapshot_not_found", "platform_db": platform_db}
+        meta = dict(snapshot.meta_json if isinstance(snapshot.meta_json, dict) else {})
+        draft = dict(meta.get("release_draft") if isinstance(meta.get("release_draft"), dict) else {})
+        existing_pages = draft.get("pages") if isinstance(draft.get("pages"), list) else []
+        merged_pages, added = merge_release_pages(existing_pages, required_pages)
+        draft["pages"] = merged_pages
+        draft["page_count"] = sum(1 for page in merged_pages if isinstance(page, dict) and page.get("enabled", True) and str(page.get("release_state") or "released") in {"released", "preview"})
+        draft["total_page_count"] = len(merged_pages)
+        draft["fingerprint"] = hashlib.sha256(json.dumps(merged_pages, ensure_ascii=False, sort_keys=True).encode("utf-8")).hexdigest()
+        meta["release_draft"] = draft
+        snapshot.write({"meta_json": meta})
+        return {
+            "status": "PASS",
+            "platform_db": platform_db,
+            "snapshot_id": int(snapshot.id),
+            "snapshot_version": str(snapshot.version or ""),
+            "required_page_count": len(required_pages),
+            "added_page_count": added,
+            "release_draft_page_count": int(draft["page_count"]),
+        }
+
+    if platform_db == current_db:
+        return update_in(env)  # noqa: F821
+    registry = Registry(platform_db)
+    with registry.cursor() as cr:
+        read_env = api.Environment(cr, SUPERUSER_ID, dict(env.context or {}))  # noqa: F821
+        result = update_in(read_env)
+        cr.commit()
+        return result
 
 policy_results = {}
+platform_release_gate_results = {}
 for product_key in PRODUCT_KEYS:
     policy = ProductPolicyCatalogSyncService(env).sync_policy(product_key=product_key)
     menu_groups = policy.menu_groups if isinstance(policy.menu_groups, list) else []
@@ -367,6 +496,10 @@ for product_key in PRODUCT_KEYS:
             "note": "SCBS 55 user acceptance menu-only publishing strategy active.",
         }
     )
+    platform_release_gate_results[product_key] = sync_platform_release_gate_pages(
+        product_key,
+        policy_release_pages(next_groups),
+    )
     policy_results[product_key] = {
         "total_policy_menus": total,
         "enabled_policy_menus": enabled,
@@ -392,6 +525,7 @@ payload = {
     "acceptance_root_xmlid": ACCEPTANCE_ROOT_XMLID,
     "allowed_menu_xmlids": sorted(allowed_xmlids),
     "policy_results": policy_results,
+    "platform_release_gate_results": platform_release_gate_results,
     "menus": created_or_updated,
 }
 write_json(artifact_dir / OUTPUT_JSON_NAME, payload)


### PR DESCRIPTION
## Summary
- preserve legacy grouping under the SCBS 55 user acceptance menu in delivery navigation
- prevent runtime menu-config hidden label policies from hiding synthetic grouped delivery nodes
- treat native menu/action policies as complete without scene entries when menu groups and capabilities exist
- sync the platform release-gate snapshot with the 55 required user-acceptance menu pages

## Verification
- `python3 -m py_compile addons/smart_core/model/ui_menu_config_policy.py addons/smart_core/delivery/menu_service.py addons/smart_core/delivery/product_policy_service.py scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py`
- `python3 addons/smart_core/tests/test_delivery_menu_entry_target.py`
- `git diff --check`
- Browser validation on server `http://1.95.85.92:18081`, db `sc_demo`, login `admin/admin`: 21 groups, 55 leaves, no hidden-original group, no console errors
- Browser validation on server `http://1.95.85.92:18081`, db `sc_demo`, login `caisiqi/123456`: 21 groups, 55 leaves, no hidden-original group, no console errors