### PR TITLE
fix: suppress duplicate list secondary text

### DIFF
--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -503,7 +503,7 @@
               </div>
               <div v-else-if="isPrimaryTextColumn(col)" class="cell-primary">
                 <div class="primary">{{ semanticCell(col, row[col]).text }}</div>
-                <div v-if="shouldRenderRowSecondary(col)" class="secondary">{{ semanticCell(rowSecondary, row[rowSecondary]).text }}</div>
+                <div v-if="shouldRenderRowSecondary(col, row)" class="secondary">{{ semanticCell(rowSecondary, row[rowSecondary]).text }}</div>
               </div>
               <div v-else-if="attachmentLinks(row[col]).length" class="attachment-links">
                 <a
@@ -1026,8 +1026,31 @@ function isPrimaryTextColumn(field: string) {
   return field === rowPrimary.value && !isStatusLikeColumn(field);
 }
 
-function shouldRenderRowSecondary(field: string) {
-  return Boolean(rowSecondary.value) && isPrimaryTextColumn(field);
+function normalizeDuplicateDisplayText(value: unknown) {
+  return String(value ?? '')
+    .replace(/\s+/g, '')
+    .replace(/[（）()【】\[\]「」『』《》,，.。:：;；\-_—]/g, '')
+    .replace(/[\\/|]/g, '')
+    .trim();
+}
+
+function isSameDisplayTextFamily(primary: string, secondary: string) {
+  const left = normalizeDuplicateDisplayText(primary);
+  const right = normalizeDuplicateDisplayText(secondary);
+  if (!left || !right) return false;
+  if (left === right) return true;
+  const shorter = left.length <= right.length ? left : right;
+  const longer = left.length > right.length ? left : right;
+  if (shorter.length < 8) return false;
+  return longer.startsWith(shorter);
+}
+
+function shouldRenderRowSecondary(field: string, row: Record<string, unknown>) {
+  if (!rowSecondary.value || !isPrimaryTextColumn(field) || rowSecondary.value === field) return false;
+  const primaryText = semanticCell(field, row[field]).text;
+  const secondaryText = semanticCell(rowSecondary.value, row[rowSecondary.value]).text;
+  if (!secondaryText || secondaryText === '--') return false;
+  return !isSameDisplayTextFamily(primaryText, secondaryText);
 }
 
 function isFavoriteColumn(field: string) {


### PR DESCRIPTION
## Summary
- hide row secondary text when it is the same display family as the primary text
- covers truncated-prefix duplicates such as project names shown twice in list rows

## Verification
- `git diff --check`
- `COREPACK_HOME=/tmp/corepack corepack pnpm@9.12.3 --dir frontend/apps/web run typecheck`
- `COREPACK_HOME=/tmp/corepack corepack pnpm@9.12.3 --dir frontend/apps/web run build`