### PR TITLE
fix: disable list secondary row text

### DIFF
--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1026,31 +1026,10 @@ function isPrimaryTextColumn(field: string) {
   return field === rowPrimary.value && !isStatusLikeColumn(field);
 }
 
-function normalizeDuplicateDisplayText(value: unknown) {
-  return String(value ?? '')
-    .replace(/\s+/g, '')
-    .replace(/[（）()【】\[\]「」『』《》,，.。:：;；\-_—]/g, '')
-    .replace(/[\\/|]/g, '')
-    .trim();
-}
-
-function isSameDisplayTextFamily(primary: string, secondary: string) {
-  const left = normalizeDuplicateDisplayText(primary);
-  const right = normalizeDuplicateDisplayText(secondary);
-  if (!left || !right) return false;
-  if (left === right) return true;
-  const shorter = left.length <= right.length ? left : right;
-  const longer = left.length > right.length ? left : right;
-  if (shorter.length < 8) return false;
-  return longer.startsWith(shorter);
-}
-
 function shouldRenderRowSecondary(field: string, row: Record<string, unknown>) {
-  if (!rowSecondary.value || !isPrimaryTextColumn(field) || rowSecondary.value === field) return false;
-  const primaryText = semanticCell(field, row[field]).text;
-  const secondaryText = semanticCell(rowSecondary.value, row[rowSecondary.value]).text;
-  if (!secondaryText || secondaryText === '--') return false;
-  return !isSameDisplayTextFamily(primaryText, secondaryText);
+  void field;
+  void row;
+  return false;
 }
 
 function isFavoriteColumn(field: string) {


### PR DESCRIPTION
## Summary
- disable secondary row text rendering in list primary cells
- removes two-line display such as date + platform/project helper text
- keeps explicit columns unchanged

## Verification
- `git diff --check`
- `COREPACK_HOME=/tmp/corepack corepack pnpm@9.12.3 --dir frontend/apps/web run typecheck`
- `COREPACK_HOME=/tmp/corepack corepack pnpm@9.12.3 --dir frontend/apps/web run build`