### PR TITLE
Project remaining SCBS55 finance menus

### DIFF
--- a/scripts/migration/fresh_db_legacy_employee_loan_replay_adapter.py
+++ b/scripts/migration/fresh_db_legacy_employee_loan_replay_adapter.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Build replay payload for legacy employee loan request/repayment rows."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_DIR = REPO_ROOT / "artifacts" / "migration"
+OUTPUT_CSV = ARTIFACT_DIR / "fresh_db_legacy_employee_loan_replay_payload_v1.csv"
+OUTPUT_JSON = ARTIFACT_DIR / "fresh_db_legacy_employee_loan_replay_adapter_result_v1.json"
+SQL_CONTAINER = os.getenv("LEGACY_MSSQL_CONTAINER", "legacy-mssql-restore")
+SQLCMD = os.getenv("LEGACY_SQLCMD", "/opt/mssql-tools18/bin/sqlcmd")
+SQL_PASSWORD = os.getenv("LEGACY_MSSQL_SA_PASSWORD", "LegacyRestore!2026")
+SQL_DATABASE = os.getenv("LEGACY_MSSQL_DATABASE", "LegacyDb")
+
+FIELDS = [
+    "source_table",
+    "legacy_record_id",
+    "legacy_pid",
+    "loan_type",
+    "direction",
+    "document_no",
+    "document_date",
+    "due_date",
+    "legacy_state",
+    "project_legacy_id",
+    "project_name",
+    "counterparty_legacy_id",
+    "counterparty_name",
+    "amount",
+    "amount_field",
+    "purpose",
+    "source_type_label",
+    "source_extra_ref",
+    "source_extra_label",
+    "account_legacy_id",
+    "account_name",
+    "creator_legacy_user_id",
+    "creator_name",
+    "created_time",
+    "modifier_legacy_user_id",
+    "modifier_name",
+    "modified_time",
+    "note",
+]
+
+
+def clean_sql(field: str) -> str:
+    return (
+        "REPLACE(REPLACE(REPLACE(COALESCE(CONVERT(varchar(max), "
+        f"{field}), ''), CHAR(9), ' '), CHAR(10), ' '), CHAR(13), ' ')"
+    )
+
+
+def sqlcmd(sql: str) -> list[str]:
+    return [
+        "docker",
+        "exec",
+        SQL_CONTAINER,
+        SQLCMD,
+        "-S",
+        "localhost",
+        "-U",
+        "sa",
+        "-P",
+        SQL_PASSWORD,
+        "-C",
+        "-d",
+        SQL_DATABASE,
+        "-W",
+        "-s",
+        "\t",
+        "-h",
+        "-1",
+        "-Q",
+        sql,
+    ]
+
+
+def payload_sql() -> str:
+    return f"""
+SET NOCOUNT ON;
+SELECT
+  'BGGL_JHK_JKSQ' AS source_table,
+  {clean_sql("Id")} AS legacy_record_id,
+  {clean_sql("pid")} AS legacy_pid,
+  'borrowing_request' AS loan_type,
+  'borrowed_fund' AS direction,
+  {clean_sql("DJBH")} AS document_no,
+  {clean_sql("CONVERT(varchar(10), SQSJ, 23)")} AS document_date,
+  {clean_sql("CONVERT(varchar(10), YJGHSJ, 23)")} AS due_date,
+  {clean_sql("DJZT")} AS legacy_state,
+  {clean_sql("XMID")} AS project_legacy_id,
+  {clean_sql("XMMC")} AS project_name,
+  {clean_sql("COALESCE(NULLIF(WLDWID, ''), NULLIF(SKR, ''), NULLIF(SQRID, ''))")} AS counterparty_legacy_id,
+  {clean_sql("COALESCE(NULLIF(WLDWMC, ''), NULLIF(SKR, ''), NULLIF(SQR, ''))")} AS counterparty_name,
+  {clean_sql("COALESCE(NULLIF(SJPFJE, 0), NULLIF(SQJE, 0), NULLIF(JKJE, 0), 0)")} AS amount,
+  'SJPFJE/SQJE/JKJE' AS amount_field,
+  {clean_sql("ZYZJSYAP")} AS purpose,
+  {clean_sql("COALESCE(NULLIF(FKFSMC, ''), NULLIF(FX, ''), NULLIF(SX, ''))")} AS source_type_label,
+  {clean_sql("SQBM")} AS source_extra_ref,
+  {clean_sql("COALESCE(NULLIF(SFYSN, ''), NULLIF(YS, ''))")} AS source_extra_label,
+  {clean_sql("ZKZHID")} AS account_legacy_id,
+  {clean_sql("ZKZH")} AS account_name,
+  {clean_sql("LRRID")} AS creator_legacy_user_id,
+  {clean_sql("LRR")} AS creator_name,
+  {clean_sql("CONVERT(varchar(19), LRSJ, 120)")} AS created_time,
+  {clean_sql("XGRID")} AS modifier_legacy_user_id,
+  {clean_sql("XGR")} AS modifier_name,
+  {clean_sql("CONVERT(varchar(19), XGSJ, 120)")} AS modified_time,
+  {clean_sql("COALESCE(NULLIF(BZ, ''), NULLIF(FJ, ''), NULLIF(LJJKQK, ''))")} AS note
+FROM dbo.BGGL_JHK_JKSQ
+WHERE NULLIF(LTRIM(RTRIM(Id)), '') IS NOT NULL
+  AND ISNULL(DEL, 0) = 0
+  AND ISNULL(COALESCE(NULLIF(SJPFJE, 0), NULLIF(SQJE, 0), NULLIF(JKJE, 0), 0), 0) <> 0
+UNION ALL
+SELECT
+  'BGGL_JHK_HKDJ' AS source_table,
+  {clean_sql("Id")} AS legacy_record_id,
+  {clean_sql("pid")} AS legacy_pid,
+  'borrowing_request' AS loan_type,
+  'borrowed_fund' AS direction,
+  {clean_sql("DJBH")} AS document_no,
+  {clean_sql("CONVERT(varchar(10), HKRQ, 23)")} AS document_date,
+  '' AS due_date,
+  {clean_sql("DJZT")} AS legacy_state,
+  {clean_sql("XMID")} AS project_legacy_id,
+  {clean_sql("XMMC")} AS project_name,
+  {clean_sql("COALESCE(NULLIF(WLDWID, ''), NULLIF(PersonId, ''))")} AS counterparty_legacy_id,
+  {clean_sql("COALESCE(NULLIF(WLDWMC, ''), NULLIF(HKR, ''), NULLIF(SQR, ''))")} AS counterparty_name,
+  {clean_sql("HKJE")} AS amount,
+  'HKJE' AS amount_field,
+  {clean_sql("ZYZJSYAP")} AS purpose,
+  '还款登记' AS source_type_label,
+  {clean_sql("SQBM")} AS source_extra_ref,
+  {clean_sql("SFYSN")} AS source_extra_label,
+  {clean_sql("HKZHID")} AS account_legacy_id,
+  {clean_sql("HKZH")} AS account_name,
+  {clean_sql("LRRID")} AS creator_legacy_user_id,
+  {clean_sql("LRR")} AS creator_name,
+  {clean_sql("CONVERT(varchar(19), LRSJ, 120)")} AS created_time,
+  {clean_sql("XGRID")} AS modifier_legacy_user_id,
+  {clean_sql("XGR")} AS modifier_name,
+  {clean_sql("CONVERT(varchar(19), XGSJ, 120)")} AS modified_time,
+  {clean_sql("FJ")} AS note
+FROM dbo.BGGL_JHK_HKDJ
+WHERE NULLIF(LTRIM(RTRIM(Id)), '') IS NOT NULL
+  AND ISNULL(DEL, 0) = 0
+  AND ISNULL(HKJE, 0) <> 0
+ORDER BY source_table, document_date, legacy_record_id;
+"""
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    OUTPUT_CSV.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    by_source: dict[str, int] = {}
+    with subprocess.Popen(sqlcmd(payload_sql()), stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True) as proc:
+        if proc.stdout is None:
+            raise RuntimeError("sqlcmd stdout unavailable")
+        with OUTPUT_CSV.open("w", encoding="utf-8-sig", newline="") as handle:
+            writer = csv.writer(handle)
+            writer.writerow(FIELDS)
+            for line in proc.stdout:
+                stripped = line.strip()
+                if not stripped or stripped.startswith("(") and stripped.endswith("rows affected)"):
+                    continue
+                parts = line.rstrip("\r\n").split("\t")
+                if len(parts) != len(FIELDS):
+                    raise RuntimeError({"unexpected_sqlcmd_row_shape": len(parts), "expected": len(FIELDS), "line": line[:500]})
+                writer.writerow(parts)
+                count += 1
+                by_source[parts[0]] = by_source.get(parts[0], 0) + 1
+        return_code = proc.wait()
+    if return_code != 0:
+        raise RuntimeError({"sqlcmd_failed": return_code})
+    payload = {
+        "status": "PASS",
+        "mode": "fresh_db_legacy_employee_loan_replay_adapter",
+        "rows": count,
+        "by_source": by_source,
+        "payload_csv": str(OUTPUT_CSV),
+    }
+    write_json(OUTPUT_JSON, payload)
+    print("LEGACY_EMPLOYEE_LOAN_REPLAY_ADAPTER=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migration/fresh_db_scbs55_remaining_finance_projection_write.py
+++ b/scripts/migration/fresh_db_scbs55_remaining_finance_projection_write.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Project the remaining SCBS55 finance menus from verified legacy facts."""
+
+from __future__ import annotations
+
+import csv
+import json
+import os
+from pathlib import Path
+
+
+def repo_root() -> Path:
+    env_root = os.getenv("MIGRATION_REPO_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.extend([Path("/mnt"), Path.cwd()])
+    for candidate in candidates:
+        if (candidate / "artifacts/migration/fresh_db_legacy_employee_loan_replay_payload_v1.csv").exists():
+            return candidate
+    return Path.cwd()
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.append(REPO_ROOT / "artifacts" / "migration")
+    candidates.append(Path("/mnt/artifacts/migration"))
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".write_probe"
+            probe.write_text("ok\n", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except Exception:
+            continue
+    return Path(f"/tmp/scbs55_remaining_finance/{env.cr.dbname}")  # noqa: F821
+
+
+def ensure_allowed_db() -> None:
+    allowlist = {
+        item.strip()
+        for item in os.getenv("MIGRATION_REPLAY_DB_ALLOWLIST", "sc_migration_fresh,sc_demo").split(",")
+        if item.strip()
+    }
+    if env.cr.dbname not in allowlist:  # noqa: F821
+        raise RuntimeError({"db_name_not_allowed_for_replay": env.cr.dbname, "allowlist": sorted(allowlist)})  # noqa: F821
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open("r", encoding="utf-8-sig", newline="") as handle:
+        return [dict(row) for row in csv.DictReader(handle)]
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def as_float(value: object) -> float:
+    text = clean(value)
+    return float(text) if text else 0.0
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def project_id_for(legacy_project_id: str, project_name: str) -> int:
+    Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+    project = Project.browse()
+    if legacy_project_id:
+        project = Project.search([("legacy_project_id", "=", legacy_project_id)], limit=1)
+    if not project and project_name:
+        project = Project.search([("name", "=", project_name)], limit=1)
+    if project:
+        return project.id
+    fallback_name = project_name or "历史未归集资金项目"
+    return Project.create({"name": fallback_name, "legacy_project_id": legacy_project_id or False}).id
+
+
+def state_from_legacy(value: str) -> str:
+    return "legacy_confirmed" if clean(value) in {"2", "已通过", "已确认", "已完成"} else "draft"
+
+
+def loan_values_from_employee_row(row: dict[str, str]) -> dict[str, object]:
+    source_table = clean(row.get("source_table"))
+    legacy_record_id = clean(row.get("legacy_record_id"))
+    document_date = clean(row.get("document_date")) or False
+    amount = as_float(row.get("amount"))
+    purpose = clean(row.get("purpose"))
+    counterparty_name = clean(row.get("counterparty_name"))
+    account_name = clean(row.get("account_name"))
+    extra_parts = [
+        clean(row.get("source_extra_ref")),
+        clean(row.get("source_extra_label")),
+        account_name,
+    ]
+    return {
+        "name": clean(row.get("document_no")) or f"{source_table}-{legacy_record_id}",
+        "source_origin": "legacy",
+        "loan_type": clean(row.get("loan_type")) or "borrowing_request",
+        "direction": clean(row.get("direction")) or "borrowed_fund",
+        "state": state_from_legacy(clean(row.get("legacy_state"))),
+        "project_id": project_id_for(clean(row.get("project_legacy_id")), clean(row.get("project_name"))),
+        "document_no": clean(row.get("document_no")) or False,
+        "document_date": document_date,
+        "due_date": clean(row.get("due_date")) or False,
+        "amount": max(amount, 0.0),
+        "currency_id": env.company.currency_id.id,  # noqa: F821
+        "purpose": purpose or clean(row.get("note")) or False,
+        "rate_label": clean(row.get("source_type_label")) or False,
+        "extra_ref": " / ".join(part for part in extra_parts if part) or False,
+        "extra_label": "还款登记" if source_table == "BGGL_JHK_HKDJ" else "借款申请",
+        "legacy_source_model": "sc.legacy.employee.loan",
+        "legacy_source_table": source_table,
+        "legacy_record_id": f"{source_table}:{legacy_record_id}",
+        "legacy_document_state": clean(row.get("legacy_state")) or False,
+        "legacy_counterparty_id": clean(row.get("counterparty_legacy_id")) or False,
+        "legacy_counterparty_name": counterparty_name or False,
+        "legacy_amount_field": clean(row.get("amount_field")) or False,
+        "creator_legacy_user_id": clean(row.get("creator_legacy_user_id")) or False,
+        "creator_name": clean(row.get("creator_name")) or False,
+        "created_time": clean(row.get("created_time")) or False,
+        "note": "\n".join(
+            part
+            for part in [
+                "[migration:employee_loan]",
+                f"source_table={source_table}",
+                f"legacy_record_id={legacy_record_id}",
+                f"counterparty={counterparty_name}",
+                clean(row.get("note")),
+            ]
+            if part
+        ),
+        "active": True,
+    }
+
+
+def upsert_loan(values: dict[str, object]) -> str:
+    Loan = env["sc.financing.loan"].sudo().with_context(active_test=False)  # noqa: F821
+    existing = Loan.search(
+        [
+            ("legacy_source_model", "=", values["legacy_source_model"]),
+            ("legacy_record_id", "=", values["legacy_record_id"]),
+        ],
+        limit=1,
+    )
+    if existing:
+        env.cr.execute(  # noqa: F821
+            """
+            UPDATE sc_financing_loan
+               SET loan_type = %s,
+                   direction = %s,
+                   state = %s,
+                   project_id = %s,
+                   document_no = %s,
+                   document_date = %s,
+                   due_date = %s,
+                   amount = %s,
+                   purpose = %s,
+                   rate_label = %s,
+                   extra_ref = %s,
+                   extra_label = %s,
+                   legacy_source_table = %s,
+                   legacy_document_state = %s,
+                   legacy_counterparty_id = %s,
+                   legacy_counterparty_name = %s,
+                   legacy_amount_field = %s,
+                   creator_legacy_user_id = %s,
+                   creator_name = %s,
+                   created_time = %s,
+                   note = %s,
+                   active = TRUE,
+                   write_uid = 1,
+                   write_date = NOW()
+             WHERE id = %s
+            """,
+            [
+                values["loan_type"],
+                values["direction"],
+                values["state"],
+                values["project_id"],
+                values["document_no"],
+                values["document_date"],
+                values["due_date"],
+                values["amount"],
+                values["purpose"],
+                values["rate_label"],
+                values["extra_ref"],
+                values["extra_label"],
+                values["legacy_source_table"],
+                values["legacy_document_state"],
+                values["legacy_counterparty_id"],
+                values["legacy_counterparty_name"],
+                values["legacy_amount_field"],
+                values["creator_legacy_user_id"],
+                values["creator_name"],
+                values["created_time"],
+                values["note"],
+                existing.id,
+            ],
+        )
+        return "updated"
+    Loan.create(values)
+    return "created"
+
+
+def project_employee_loans(input_csv: Path) -> dict[str, object]:
+    rows = read_csv(input_csv)
+    stats = {"rows": len(rows), "created": 0, "updated": 0, "skipped_no_amount": 0, "by_source": {}}
+    for row in rows:
+        values = loan_values_from_employee_row(row)
+        if not values["amount"]:
+            stats["skipped_no_amount"] += 1
+            continue
+        result = upsert_loan(values)
+        stats[result] += 1
+        source_table = values["legacy_source_table"]
+        by_source = stats["by_source"]
+        by_source[source_table] = by_source.get(source_table, 0) + 1
+    return stats
+
+
+def project_project_company_repayments() -> dict[str, object]:
+    Line = env["sc.legacy.account.transaction.line"].sudo().with_context(active_test=False)  # noqa: F821
+    domain = [("source_table", "=", "ZJGL_ZJSZ_DKGL_HKDJ"), ("amount", ">", 0), ("project_id", "!=", False)]
+    stats = {"candidate_count": Line.search_count(domain), "created": 0, "updated": 0}
+    for line in Line.search(domain, order="transaction_date desc, id desc"):
+        values = {
+            "name": clean(line.document_no) or f"ZJGL_ZJSZ_DKGL_HKDJ-{line.legacy_record_id}",
+            "source_origin": "legacy",
+            "loan_type": "borrowing_request",
+            "direction": "borrowed_fund",
+            "state": state_from_legacy(clean(line.document_state)),
+            "project_id": line.project_id.id,
+            "document_no": clean(line.document_no) or False,
+            "document_date": line.transaction_date or False,
+            "due_date": line.transaction_date or False,
+            "amount": float(line.amount or 0.0),
+            "currency_id": env.company.currency_id.id,  # noqa: F821
+            "purpose": clean(line.source_summary) or "项目还公司款登记",
+            "rate_label": clean(line.category) or False,
+            "extra_ref": clean(line.account_name) or False,
+            "extra_label": "项目还公司款登记",
+            "legacy_source_model": "sc.legacy.account.transaction.line",
+            "legacy_source_table": line.source_table,
+            "legacy_record_id": clean(line.source_key) or f"{line.source_table}:{line.legacy_record_id}",
+            "legacy_document_state": clean(line.document_state) or False,
+            "legacy_counterparty_id": clean(line.counterparty_account_legacy_id) or False,
+            "legacy_counterparty_name": clean(line.counterparty_account_name) or False,
+            "legacy_amount_field": "HKJE",
+            "note": clean(line.note) or False,
+            "active": True,
+        }
+        result = upsert_loan(values)
+        stats[result] += 1
+    return stats
+
+
+def project_deduction_bills() -> dict[str, object]:
+    Residual = env["sc.legacy.payment.residual.fact"].sudo().with_context(active_test=False)  # noqa: F821
+    Target = env["sc.tax.deduction.registration"].sudo().with_context(active_test=False)  # noqa: F821
+    domain = [("source_table", "=", "C_ZFSQGL_KKD"), ("project_id", "!=", False), ("planned_amount", ">", 0)]
+    stats = {"candidate_count": Residual.search_count(domain), "created": 0, "updated": 0}
+    for item in Residual.search(domain, order="document_date desc, id desc"):
+        amount = float(item.planned_amount or 0.0)
+        values = {
+            "name": clean(item.document_no) or f"KKD-{item.legacy_record_id}",
+            "source_origin": "legacy",
+            "state": state_from_legacy(clean(item.document_state)),
+            "document_no": clean(item.document_no) or False,
+            "document_date": item.document_date or False,
+            "project_id": item.project_id.id,
+            "partner_id": item.partner_id.id or False,
+            "partner_name": clean(item.partner_name) or clean(item.taxpayer_name) or False,
+            "deduction_amount": amount,
+            "deduction_tax_amount": 0.0,
+            "deduction_surcharge_amount": 0.0,
+            "currency_id": env.company.currency_id.id,  # noqa: F821
+            "legacy_source_model": "sc.legacy.payment.residual.fact",
+            "legacy_source_table": item.source_table,
+            "legacy_record_id": f"{item.source_table}:{item.legacy_record_id}",
+            "legacy_document_state": clean(item.document_state) or False,
+            "creator_legacy_user_id": clean(item.creator_legacy_user_id) or False,
+            "creator_name": clean(item.creator_name) or False,
+            "created_time": item.created_time or False,
+            "note": "\n".join(
+                part
+                for part in [
+                    clean(item.residual_reason),
+                    clean(item.note),
+                    f"[migration:deduction_bill] legacy_record_id={item.legacy_record_id}",
+                ]
+                if part
+            ),
+            "active": True,
+        }
+        existing = Target.search(
+            [
+                ("legacy_source_model", "=", values["legacy_source_model"]),
+                ("legacy_record_id", "=", values["legacy_record_id"]),
+            ],
+            limit=1,
+        )
+        if existing:
+            env.cr.execute(  # noqa: F821
+                """
+                UPDATE sc_tax_deduction_registration
+                   SET state = %s,
+                       document_no = %s,
+                       document_date = %s,
+                       project_id = %s,
+                       partner_id = %s,
+                       partner_name = %s,
+                       deduction_amount = %s,
+                       legacy_source_table = %s,
+                       legacy_document_state = %s,
+                       creator_legacy_user_id = %s,
+                       creator_name = %s,
+                       created_time = %s,
+                       note = %s,
+                       active = TRUE,
+                       write_uid = 1,
+                       write_date = NOW()
+                 WHERE id = %s
+                """,
+                [
+                    values["state"],
+                    values["document_no"],
+                    values["document_date"],
+                    values["project_id"],
+                    values["partner_id"],
+                    values["partner_name"],
+                    values["deduction_amount"],
+                    values["legacy_source_table"],
+                    values["legacy_document_state"],
+                    values["creator_legacy_user_id"],
+                    values["creator_name"],
+                    values["created_time"],
+                    values["note"],
+                    existing.id,
+                ],
+            )
+            stats["updated"] += 1
+            continue
+        Target.create(values)
+        stats["created"] += 1
+    return stats
+
+
+REPO_ROOT = repo_root()
+ARTIFACT_ROOT = artifact_root()
+INPUT_CSV = REPO_ROOT / "artifacts" / "migration" / "fresh_db_legacy_employee_loan_replay_payload_v1.csv"
+OUTPUT_JSON = ARTIFACT_ROOT / "fresh_db_scbs55_remaining_finance_projection_write_result_v1.json"
+
+ensure_allowed_db()
+employee = project_employee_loans(INPUT_CSV)
+project_repay = project_project_company_repayments()
+deduction = project_deduction_bills()
+
+env.cr.commit()  # noqa: F821
+
+payload = {
+    "status": "PASS",
+    "mode": "fresh_db_scbs55_remaining_finance_projection_write",
+    "database": env.cr.dbname,  # noqa: F821
+    "employee_loans": employee,
+    "project_company_repayments": project_repay,
+    "deduction_bills": deduction,
+}
+write_json(OUTPUT_JSON, payload)
+print("SCBS55_REMAINING_FINANCE_PROJECTION_WRITE=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))


### PR DESCRIPTION
## Summary
- Add a replay adapter for legacy `BGGL_JHK_JKSQ` and `BGGL_JHK_HKDJ` employee loan rows.
- Add an idempotent Odoo projection script for remaining SCBS55 finance menus:
  - 借款申请 -> `sc.financing.loan`
  - 还款登记 -> `sc.financing.loan`
  - 扣款单 -> `sc.tax.deduction.registration`
  - 项目还公司款登记 -> `sc.financing.loan`

## Server validation
- Adapter extracted 61 old SQL Server rows:
  - `BGGL_JHK_JKSQ`: 37
  - `BGGL_JHK_HKDJ`: 24
- Projection write completed with `status=PASS`:
  - employee loans: created 61
  - deduction bills: created 137
  - project-company repayments: created 98
- Menu recount after projection:
  - 借款申请: 37
  - 还款登记: 24
  - 扣款单: 137
  - 项目还公司款登记: 98
- Final SCBS55 audit: `missing_alias_count=0`, `field_order_mismatch_count=0`, `zero_count=1`.

## Remaining zero menu
- 奖金 remains 0 because legacy tables `BGGL_XZ_JJ` and `BGGL_XZ_JJ_CB` contain 0 rows.