### PR TITLE
Add SCBS55 form operability alignment probes

### DIFF
--- a/scripts/migration/scbs_55_old_system_form_surface_login_probe.py
+++ b/scripts/migration/scbs_55_old_system_form_surface_login_probe.py
@@ -1,0 +1,312 @@
+#!/usr/bin/env python3
+"""Capture SCBS55 old-system add/show form surfaces through a real user login.
+
+Credentials are intentionally read from environment variables:
+  OLD_SCBS_LOGIN_URL
+  OLD_SCBS_USERNAME
+  OLD_SCBS_PASSWORD
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import requests
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+INPUT_CSV = REPO_ROOT / "docs/migration_alignment/scbs_55_user_visible_surface_live_alignment_v1.csv"
+ARTIFACT_ROOT = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", str(REPO_ROOT / "artifacts/migration")))
+OUTPUT_JSON = ARTIFACT_ROOT / "scbs_55_old_system_form_surface_login_probe_result_v1.json"
+OUTPUT_REPORT = ARTIFACT_ROOT / "scbs_55_old_system_form_surface_login_probe_report_v1.md"
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def old_base_url(login_url: str) -> str:
+    parsed = urlparse(login_url)
+    path = parsed.path.rstrip("/")
+    marker = "/System/User/Login"
+    if path.endswith(marker):
+        path = path[: -len(marker)]
+    return f"{parsed.scheme}://{parsed.netloc}{path}".rstrip("/")
+
+
+def truthy_hide(value: object) -> bool:
+    return value is True or clean(value).lower() in {"true", "1", "yes"}
+
+
+def as_dict(value: object) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def config_dict(component: dict[str, Any]) -> dict[str, Any]:
+    config = component.get("Config")
+    if isinstance(config, dict):
+        return config
+    if isinstance(config, list):
+        for item in config:
+            if isinstance(item, dict):
+                return item
+    return {}
+
+
+def login(session: requests.Session, base_url: str, username: str, password: str) -> dict[str, Any]:
+    payload = {
+        "Type": "Common",
+        "Param": {
+            "UserName": username,
+            "IsEncrypt": False,
+            "Password": password,
+            "PasswordMd5": hashlib.md5(password.encode("utf-8")).hexdigest(),
+            "VerificationCodeKey": "",
+            "VerificationCode": "",
+            "EncryptLockKey": "",
+            "PhoneNumber": "",
+            "SMSVerificationCodeKey": "",
+            "SMSVerificationCode": "",
+        },
+    }
+    response = session.post(
+        f"{base_url}/api/System/UserApi/Login",
+        json=payload,
+        timeout=30,
+        headers={"Referer": f"{base_url}/System/User/Login"},
+    )
+    response.raise_for_status()
+    body = response.json()
+    if str(body.get("Code")) != "10000" or not body.get("Data", {}).get("Token"):
+        raise RuntimeError({"old_system_login_failed": {"Code": body.get("Code"), "Msg": body.get("Msg")}})
+    return body["Data"]
+
+
+def api_get(session: requests.Session, base_url: str, token: str, path: str) -> dict[str, Any]:
+    response = session.get(
+        urljoin(f"{base_url}/api/", path),
+        headers={"Token": token, "Referer": base_url + "/"},
+        timeout=60,
+    )
+    response.raise_for_status()
+    body = response.json()
+    if str(body.get("Code")) != "10000":
+        raise RuntimeError({"old_system_get_failed": path, "Code": body.get("Code"), "Msg": body.get("Msg")})
+    return body
+
+
+def section_names(detail: dict[str, Any]) -> list[str]:
+    names: list[str] = []
+    for item in (detail.get("Collapse") or {}).get("GroupList") or []:
+        info = item.get("Info") or {}
+        if truthy_hide(info.get("IsHide")):
+            continue
+        name = clean(info.get("Name"))
+        if name:
+            names.append(name)
+    return names
+
+
+def form_item_label(item: dict[str, Any]) -> str:
+    form_info = as_dict(item.get("FormItemConfig")).get("Info") or {}
+    component_info = config_dict(as_dict(item.get("CustomComponent"))).get("Info") or {}
+    if truthy_hide(form_info.get("IsHide")) or truthy_hide(component_info.get("IsHide")):
+        return ""
+    return clean(form_info.get("Name") or component_info.get("Name"))
+
+
+def main_table_fields(detail: dict[str, Any]) -> list[dict[str, str]]:
+    fields: list[dict[str, str]] = []
+    for table in detail.get("MainTable") or []:
+        section = clean(table.get("CollapseName"))
+        for item in table.get("FormItemList") or []:
+            label = form_item_label(item)
+            if not label:
+                continue
+            info = (item.get("FormItemConfig") or {}).get("Info") or {}
+            component = as_dict(item.get("CustomComponent"))
+            config = config_dict(component)
+            fields.append(
+                {
+                    "section": section,
+                    "label": label,
+                    "rule_name": clean(info.get("RuleName")),
+                    "component": clean(component.get("Path")),
+                    "data_config": "/".join(clean(value) for value in (config.get("DataConfig") or []) if clean(value)),
+                    "readonly": clean((config.get("Info") or {}).get("Readonly")),
+                }
+            )
+    return fields
+
+
+def from_table_fields(detail: dict[str, Any]) -> list[dict[str, str]]:
+    fields: list[dict[str, str]] = []
+    for table in detail.get("FromTable") or []:
+        section = clean(table.get("CollapseName"))
+        table_config = table.get("TableConfig") or {}
+        for column in table_config.get("ColumnConfig") or []:
+            info = column.get("Info") or {}
+            if truthy_hide(info.get("IsHide")):
+                continue
+            label = clean(info.get("Name"))
+            if label:
+                fields.append(
+                    {
+                        "section": section,
+                        "label": label,
+                        "field": clean(info.get("Field") or info.get("Code")),
+                        "component": clean(as_dict(column.get("CustomComponent")).get("Path")),
+                    }
+                )
+    return fields
+
+
+def load_form_config(session: requests.Session, base_url: str, token: str, config_id: str) -> dict[str, Any]:
+    body = api_get(session, base_url, token, f"LowCode/FormApi/GetConfigById?Id={config_id}&LoadInitData=true")
+    data = body["Data"]
+    detail = json.loads(data["DETAIL_CONFIG"])
+    return {
+        "config_id": config_id,
+        "config_name": clean(data.get("CONFIGNAME")),
+        "config_type": clean(data.get("CONFIGTYPE")),
+        "title": clean(((detail.get("TopBar") or {}).get("Info") or {}).get("TitleName")),
+        "sections": section_names(detail),
+        "main_fields": main_table_fields(detail),
+        "line_fields": from_table_fields(detail),
+        "has_file_section": any(
+            clean(((item.get("CustomComponent") or {}).get("Path"))) == "form/FormFile.vue"
+            for item in (detail.get("Collapse") or {}).get("GroupList") or []
+        ),
+        "has_approval": bool(detail.get("Approval")),
+    }
+
+
+def report_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# SCBS55 Old System Form Surface Login Probe v1",
+        "",
+        f"Status: {payload['status']}",
+        f"Old User: {payload['old_user']['UserName']} / {payload['old_user']['PersonName']}",
+        f"Old Project: {payload['old_user']['ProjectName']}",
+        f"Generated At: {payload['generated_at']}",
+        "",
+        "| seq | group | name | add fields | show fields | sections | file | approval | status |",
+        "| ---: | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {seq} | {group} | {name} | {add_field_count} | {show_field_count} | {section_count} | "
+            "{has_file_section} | {has_approval} | {status} |".format(**row)
+        )
+    lines.extend(["", "## Failures", "", "```json", json.dumps(payload["failures"], ensure_ascii=False, indent=2), "```", ""])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    login_url = os.getenv("OLD_SCBS_LOGIN_URL", "https://www.builderp.cn/SCBS/System/User/Login")
+    username = os.getenv("OLD_SCBS_USERNAME")
+    password = os.getenv("OLD_SCBS_PASSWORD")
+    if not username or not password:
+        raise RuntimeError("OLD_SCBS_USERNAME and OLD_SCBS_PASSWORD are required")
+
+    rows = list(csv.DictReader(INPUT_CSV.open("r", encoding="utf-8-sig", newline="")))
+    base_url = old_base_url(login_url)
+    session = requests.Session()
+    user_info = login(session, base_url, username, password)
+    token = user_info["Token"]
+
+    result_rows: list[dict[str, Any]] = []
+    failures: list[dict[str, Any]] = []
+    for row in rows:
+        add_config_id = clean(row.get("add_config_id"))
+        show_config_id = clean(row.get("show_add_config_id"))
+        result: dict[str, Any] = {
+            "seq": int(row["seq"]),
+            "group": row["group"],
+            "name": row["name"],
+            "target_model": row.get("target_model", ""),
+            "add_config_id": add_config_id,
+            "show_add_config_id": show_config_id,
+            "add": None,
+            "show": None,
+            "status": "SKIP_NO_FORM_CONFIG",
+        }
+        try:
+            if add_config_id:
+                result["add"] = load_form_config(session, base_url, token, add_config_id)
+            if show_config_id:
+                result["show"] = load_form_config(session, base_url, token, show_config_id)
+            if add_config_id or show_config_id:
+                result["status"] = "PASS"
+        except Exception as exc:
+            result["status"] = "FAIL_FETCH_FORM_CONFIG"
+            result["error"] = repr(exc)
+
+        add = result.get("add") or {}
+        show = result.get("show") or {}
+        add_fields = (add.get("main_fields") or []) + (add.get("line_fields") or [])
+        show_fields = (show.get("main_fields") or []) + (show.get("line_fields") or [])
+        sections = add.get("sections") or show.get("sections") or []
+        result.update(
+            {
+                "add_field_count": len(add_fields),
+                "show_field_count": len(show_fields),
+                "section_count": len(sections),
+                "has_file_section": bool(add.get("has_file_section") or show.get("has_file_section")),
+                "has_approval": bool(add.get("has_approval") or show.get("has_approval")),
+            }
+        )
+        if str(result["status"]).startswith("FAIL"):
+            failures.append(result)
+        result_rows.append(result)
+
+    payload = {
+        "status": "PASS" if not failures else "FAIL",
+        "mode": "scbs_55_old_system_form_surface_login_probe",
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "old_login_url": login_url,
+        "old_user": {
+            "UserId": user_info.get("UserId"),
+            "UserName": user_info.get("UserName"),
+            "PersonName": user_info.get("PersonName"),
+            "ProjectId": user_info.get("ProjectId"),
+            "ProjectName": user_info.get("ProjectName"),
+            "CompanyId": user_info.get("CompanyId"),
+            "CompanyName": user_info.get("CompanyName"),
+        },
+        "row_count": len(result_rows),
+        "form_config_count": len([item for item in result_rows if item["status"] != "SKIP_NO_FORM_CONFIG"]),
+        "failure_count": len(failures),
+        "failures": failures,
+        "rows": result_rows,
+    }
+    OUTPUT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    OUTPUT_REPORT.write_text(report_markdown(payload), encoding="utf-8")
+    print(
+        "SCBS_55_OLD_SYSTEM_FORM_SURFACE_LOGIN_PROBE="
+        + json.dumps(
+            {
+                "status": payload["status"],
+                "row_count": payload["row_count"],
+                "form_config_count": payload["form_config_count"],
+                "failure_count": payload["failure_count"],
+                "output_json": str(OUTPUT_JSON),
+                "output_report": str(OUTPUT_REPORT),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    return 0 if payload["status"] == "PASS" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/migration/scbs_55_user_visible_action_form_contract_write.py
+++ b/scripts/migration/scbs_55_user_visible_action_form_contract_write.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Write action-scoped SCBS55 form contracts from the user-visible list plan."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_DOCUMENT = "/home/odoo/workspace/partner_import_source/5.6优化（老系统菜单，字段列表展示）1.docx"
+OUTPUT_JSON_NAME = "scbs_55_user_visible_action_form_contract_write_result_v1.json"
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.append(Path("/mnt/artifacts/migration"))
+    candidates.append(Path(f"/tmp/scbs_55_form_contract/{env.cr.dbname}"))  # noqa: F821
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".write_probe"
+            probe.write_text("ok\n", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except Exception:
+            continue
+    return Path(f"/tmp/scbs_55_form_contract/{env.cr.dbname}")  # noqa: F821
+
+
+def ensure_allowed_db() -> None:
+    allowlist = {
+        item.strip()
+        for item in os.getenv("MIGRATION_REPLAY_DB_ALLOWLIST", env.cr.dbname).split(",")  # noqa: F821
+        if item.strip()
+    }
+    if env.cr.dbname not in allowlist:  # noqa: F821
+        raise RuntimeError({"db_name_not_allowed_for_replay": env.cr.dbname, "allowlist": sorted(allowlist)})  # noqa: F821
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def alias_field_name(label: str) -> str:
+    return "p1_visible_" + hashlib.sha1(label.encode("utf-8")).hexdigest()[:12]
+
+
+def slug(value: str) -> str:
+    raw = re.sub(r"[^0-9A-Za-z]+", "_", value).strip("_").lower()
+    return raw[:56] or hashlib.sha1(value.encode("utf-8")).hexdigest()[:12]
+
+
+def contract_labels(record) -> list[str]:
+    labels: list[str] = []
+    for item in record.list_field_contract or []:
+        if isinstance(item, dict):
+            label = str(item.get("legacy_label") or "").strip()
+            if label:
+                labels.append(label)
+    return labels
+
+
+def payload_for(record, labels: list[str]) -> dict[str, Any]:
+    fields = [
+        {
+            "name": alias_field_name(label),
+            "sequence": index * 10,
+            "readonly": True,
+            "legacy_label": label,
+        }
+        for index, label in enumerate(labels, start=1)
+    ]
+    sections = record.form_section_contract or []
+    return {
+        "view_orchestration": {
+            "views": {
+                "form": {
+                    "sections": sections
+                    or [
+                        {"title": "老系统列表字段", "sequence": 10},
+                        {"title": "附件", "sequence": 90, "required": bool(record.attachment_required)},
+                        {"title": "日志", "sequence": 100, "required": bool(record.chatter_required)},
+                    ],
+                    "fields": fields,
+                }
+            }
+        }
+    }
+
+
+ensure_allowed_db()
+artifact_dir = artifact_root()
+Plan = env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False)  # noqa: F821
+Contract = env["ui.business.config.contract"].sudo()  # noqa: F821
+rows = Plan.search([("source_document", "=", SOURCE_DOCUMENT)], order="priority_sequence")
+
+written = 0
+skipped: list[dict[str, Any]] = []
+failures: list[dict[str, Any]] = []
+result_rows: list[dict[str, Any]] = []
+
+for record in rows:
+    labels = contract_labels(record)
+    model = str(record.target_model or "")
+    action = record.target_action_id
+    if not labels:
+        skipped.append({"seq": int(record.priority_sequence or 0), "name": record.legacy_menu_name, "reason": "empty_list_contract"})
+        continue
+    if not model or model not in env or not action:  # noqa: F821
+        skipped.append(
+            {
+                "seq": int(record.priority_sequence or 0),
+                "name": record.legacy_menu_name,
+                "reason": "missing_model_or_action",
+                "model": model,
+                "action_id": int(action.id or 0),
+            }
+        )
+        continue
+    missing = [label for label in labels if alias_field_name(label) not in env[model]._fields]  # noqa: F821
+    if missing:
+        failures.append(
+            {
+                "seq": int(record.priority_sequence or 0),
+                "name": record.legacy_menu_name,
+                "model": model,
+                "missing_labels": missing,
+            }
+        )
+        continue
+
+    name = "scbs55_%03d_%s_action_form_facts_v1" % (record.priority_sequence, slug(record.legacy_menu_name or "menu"))
+    values = {
+        "name": name,
+        "model": model,
+        "view_type": "form",
+        "action_id": action.id,
+        "view_id": False,
+        "priority": 87,
+        "company_id": False,
+        "active": True,
+        "status": "published",
+        "version_no": 1,
+        "contract_json": payload_for(record, labels),
+    }
+    contract = Contract.search([("name", "=", name), ("company_id", "=", False)], limit=1)
+    if contract:
+        contract.write(values)
+    else:
+        contract = Contract.create(values)
+    written += 1
+    result_rows.append(
+        {
+            "seq": int(record.priority_sequence or 0),
+            "name": record.legacy_menu_name or "",
+            "model": model,
+            "action_id": int(action.id),
+            "contract_id": int(contract.id),
+            "field_count": len(labels),
+        }
+    )
+
+payload = {
+    "status": "PASS" if not failures else "FAIL",
+    "mode": "scbs_55_user_visible_action_form_contract_write",
+    "database": env.cr.dbname,  # noqa: F821
+    "source_document": SOURCE_DOCUMENT,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "written_count": written,
+    "skipped_count": len(skipped),
+    "failure_count": len(failures),
+    "skipped": skipped,
+    "failures": failures,
+    "rows": result_rows,
+    "db_writes": written,
+}
+write_json(artifact_dir / OUTPUT_JSON_NAME, payload)
+if payload["status"] == "PASS":
+    env.cr.commit()  # noqa: F821
+print(
+    "SCBS_55_USER_VISIBLE_ACTION_FORM_CONTRACT_WRITE="
+    + json.dumps(
+        {
+            "status": payload["status"],
+            "written_count": payload["written_count"],
+            "skipped_count": payload["skipped_count"],
+            "failure_count": payload["failure_count"],
+            "output_json": str(artifact_dir / OUTPUT_JSON_NAME),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+)
+if payload["status"] != "PASS":
+    raise SystemExit(2)

--- a/scripts/migration/scbs_55_user_visible_form_operability_probe.py
+++ b/scripts/migration/scbs_55_user_visible_form_operability_probe.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Read-only probe for SCBS55 user-visible form alignment and operability."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from xml.etree import ElementTree as ET
+
+
+SOURCE_DOCUMENT = "/home/odoo/workspace/partner_import_source/5.6优化（老系统菜单，字段列表展示）1.docx"
+OLD_FORM_BASELINE_NAME = "scbs_55_old_system_form_surface_login_probe_result_v1.json"
+OUTPUT_JSON_NAME = "scbs_55_user_visible_form_operability_probe_result_v1.json"
+OUTPUT_REPORT_NAME = "scbs_55_user_visible_form_operability_probe_report_v1.md"
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.append(Path("/mnt/artifacts/migration"))
+    candidates.append(Path(f"/tmp/scbs_55_form_operability/{env.cr.dbname}"))  # noqa: F821
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".write_probe"
+            probe.write_text("ok\n", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except Exception:
+            continue
+    return Path(f"/tmp/scbs_55_form_operability/{env.cr.dbname}")  # noqa: F821
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def alias_field_name(label: str) -> str:
+    return "p1_visible_" + hashlib.sha1(label.encode("utf-8")).hexdigest()[:12]
+
+
+def contract_labels(record) -> list[str]:
+    labels: list[str] = []
+    for item in record.list_field_contract or []:
+        if isinstance(item, dict):
+            label = str(item.get("legacy_label") or "").strip()
+            if label:
+                labels.append(label)
+    return labels
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def old_baseline_by_key(path: Path) -> dict[tuple[str, str], dict[str, Any]]:
+    if not path.exists():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {(clean(row.get("group")), clean(row.get("name"))): row for row in payload.get("rows") or []}
+
+
+def view_arch_fields(model_name: str, view_id: int | None = None) -> tuple[list[str], str, str]:
+    if model_name not in env:  # noqa: F821
+        return [], "", "model_missing"
+    try:
+        Model = env[model_name].sudo()  # noqa: F821
+        data = Model.get_view(view_id=view_id or None, view_type="form") if hasattr(Model, "get_view") else {}
+        arch = data.get("arch") or ""
+    except Exception as exc:
+        return [], "", f"get_view_failed:{exc}"
+    try:
+        root = ET.fromstring(arch)
+    except Exception as exc:
+        return [], arch, f"parse_failed:{exc}"
+    return [node.attrib.get("name", "") for node in root.iter("field") if node.attrib.get("name")], arch, ""
+
+
+def old_form_labels(row: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for key in ("add", "show"):
+        cfg = row.get(key) or {}
+        for item in (cfg.get("main_fields") or []) + (cfg.get("line_fields") or []):
+            label = str(item.get("label") or "").strip()
+            if label and label not in labels:
+                labels.append(label)
+    return labels
+
+
+def old_sections(row: dict[str, Any]) -> list[str]:
+    for key in ("add", "show"):
+        cfg = row.get(key) or {}
+        sections = [str(item or "").strip() for item in cfg.get("sections") or [] if str(item or "").strip()]
+        if sections:
+            return sections
+    return []
+
+
+def new_form_label_set(model_name: str, fields_in_arch: list[str]) -> set[str]:
+    if model_name not in env:  # noqa: F821
+        return set()
+    Model = env[model_name].sudo()  # noqa: F821
+    labels = set()
+    for field_name in fields_in_arch:
+        field = Model._fields.get(field_name)
+        if field and getattr(field, "string", None):
+            labels.add(str(field.string).strip())
+    return labels
+
+
+def hidden_required_without_defaults(model_name: str, form_fields: list[str]) -> list[str]:
+    if model_name not in env:  # noqa: F821
+        return []
+    Model = env[model_name].sudo()  # noqa: F821
+    required = [
+        name
+        for name, field in Model._fields.items()
+        if getattr(field, "required", False)
+        and not getattr(field, "compute", None)
+        and not getattr(field, "related", None)
+        and getattr(field, "type", "") not in {"one2many", "many2many"}
+    ]
+    try:
+        defaults = Model.default_get(required)
+    except Exception:
+        defaults = {}
+    visible = set(form_fields)
+    return [name for name in required if name not in visible and defaults.get(name) in (None, False, "")]
+
+
+def effective_form_contract_fields(model_name: str, action_id: int = 0, view_id: int = 0) -> list[str]:
+    if "ui.business.config.contract" not in env or model_name not in env:  # noqa: F821
+        return []
+    Contract = env["ui.business.config.contract"].sudo()  # noqa: F821
+    rows = Contract._effective_view_orchestration_contracts(
+        model_name,
+        view_type="form",
+        action_id=action_id or None,
+        view_id=view_id or None,
+    )
+    names: list[str] = []
+    for row in rows:
+        payload = row.get("contract_json") if isinstance(row, dict) else row.contract_json
+        form = (((payload or {}).get("view_orchestration") or {}).get("views") or {}).get("form") or {}
+        for item in form.get("fields") or []:
+            name = item.get("name") if isinstance(item, dict) else item
+            if name and str(name) not in names:
+                names.append(str(name))
+    return names
+
+
+def status_for(row: dict[str, Any]) -> str:
+    if row["model_missing"] or row["get_view_error"]:
+        return "FAIL_FORM_VIEW"
+    if row["missing_list_alias_fields"]:
+        return "FAIL_FORM_LIST_FACTS"
+    if row["old_form_field_count"] and row["old_label_match_count"] == 0:
+        return "FAIL_OLD_FORM_SURFACE_UNMAPPED"
+    if row["create_access"] and row["hidden_required_without_defaults"]:
+        return "WARN_HIDDEN_REQUIRED_DEFAULTS"
+    return "PASS"
+
+
+def report_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# SCBS55 User Visible Form Operability Probe v1",
+        "",
+        f"Status: {payload['status']}",
+        f"Database: {payload['database']}",
+        f"Generated At: {payload['generated_at']}",
+        "",
+        "| seq | menu | model | old fields | label hits | list facts missing | create | status |",
+        "| ---: | --- | --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in payload["rows"]:
+        lines.append(
+            "| {seq} | {name} | {model} | {old_form_field_count} | {old_label_match_count} | "
+            "{missing_list_alias_count} | {create_access} | {status} |".format(**row)
+        )
+    lines.extend(
+        [
+            "",
+            "## Failures",
+            "",
+            "```json",
+            json.dumps(payload["failures"], ensure_ascii=False, indent=2, sort_keys=True),
+            "```",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+artifact_dir = artifact_root()
+old_baseline = old_baseline_by_key(artifact_dir / OLD_FORM_BASELINE_NAME)
+Plan = env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False)  # noqa: F821
+records = Plan.search([("source_document", "=", SOURCE_DOCUMENT)], order="priority_sequence")
+
+result_rows: list[dict[str, Any]] = []
+for record in records:
+    seq = int(record.priority_sequence or 0)
+    model = str(record.target_model or "")
+    model_missing = bool(model and model not in env)  # noqa: F821
+    view_id = int(record.target_view_id.id or 0)
+    form_view_id = view_id if getattr(record.target_view_id, "type", "") == "form" else 0
+    form_fields, _arch, get_view_error = view_arch_fields(model, form_view_id or None)
+    labels = contract_labels(record)
+    expected_alias_fields = [alias_field_name(label) for label in labels]
+    contract_fields = effective_form_contract_fields(model, int(record.target_action_id.id or 0), form_view_id)
+    missing_list_alias_fields = [field for field in expected_alias_fields if field not in contract_fields and field not in form_fields]
+    old_row = old_baseline.get((clean(record.legacy_menu_group), clean(record.legacy_menu_name)), {})
+    old_labels = old_form_labels(old_row)
+    old_label_hits = sorted(new_form_label_set(model, form_fields + contract_fields).intersection(old_labels))
+    create_access = False
+    access_error = ""
+    if model and not model_missing:
+        try:
+            create_access = bool(env[model].sudo().check_access_rights("create", raise_exception=False))  # noqa: F821
+        except Exception as exc:
+            access_error = repr(exc)
+    row = {
+        "seq": seq,
+        "name": record.legacy_menu_name or "",
+        "group": record.legacy_menu_group or "",
+        "model": model,
+        "model_missing": model_missing,
+        "view_id": view_id,
+        "form_view_id": form_view_id,
+        "get_view_error": get_view_error,
+        "form_arch_field_count": len(form_fields),
+        "contract_form_field_count": len(contract_fields),
+        "list_fact_count": len(expected_alias_fields),
+        "missing_list_alias_fields": missing_list_alias_fields,
+        "missing_list_alias_count": len(missing_list_alias_fields),
+        "old_sections": old_sections(old_row),
+        "planned_sections": record.form_section_contract or [],
+        "old_form_field_count": len(old_labels),
+        "old_label_match_count": len(old_label_hits),
+        "old_label_hits": old_label_hits,
+        "create_access": create_access,
+        "access_error": access_error,
+        "hidden_required_without_defaults": hidden_required_without_defaults(model, form_fields) if create_access else [],
+        "attachment_required": bool(record.attachment_required),
+        "chatter_required": bool(record.chatter_required),
+    }
+    row["status"] = status_for(row)
+    result_rows.append(row)
+
+failures = [row for row in result_rows if str(row["status"]).startswith("FAIL")]
+warnings = [row for row in result_rows if str(row["status"]).startswith("WARN")]
+payload = {
+    "status": "PASS" if not failures else "FAIL",
+    "mode": "scbs_55_user_visible_form_operability_probe",
+    "database": env.cr.dbname,  # noqa: F821
+    "source_document": SOURCE_DOCUMENT,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "old_form_baseline_path": str(artifact_dir / OLD_FORM_BASELINE_NAME),
+    "row_count": len(result_rows),
+    "failure_count": len(failures),
+    "warning_count": len(warnings),
+    "failures": failures,
+    "warnings": warnings,
+    "rows": result_rows,
+    "db_writes": 0,
+}
+write_json(artifact_dir / OUTPUT_JSON_NAME, payload)
+(artifact_dir / OUTPUT_REPORT_NAME).write_text(report_markdown(payload), encoding="utf-8")
+print(
+    "SCBS_55_USER_VISIBLE_FORM_OPERABILITY_PROBE="
+    + json.dumps(
+        {
+            "status": payload["status"],
+            "row_count": payload["row_count"],
+            "failure_count": payload["failure_count"],
+            "warning_count": payload["warning_count"],
+            "output_json": str(artifact_dir / OUTPUT_JSON_NAME),
+            "output_report": str(artifact_dir / OUTPUT_REPORT_NAME),
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+    )
+)
+if payload["status"] != "PASS":
+    raise SystemExit(2)


### PR DESCRIPTION
## Summary
- add old-system real-login form surface probe for SCBS55 add/show configs
- add action-scoped form contract writer so user-visible list facts are available on forms
- add Odoo form operability probe for 55 delivered menus

## Validation
- `python3 -m py_compile scripts/migration/scbs_55_old_system_form_surface_login_probe.py scripts/migration/scbs_55_user_visible_action_form_contract_write.py scripts/migration/scbs_55_user_visible_form_operability_probe.py`
- old-system form probe: PASS, 55 rows, 42 form configs, 0 failures
- server `sc_demo` action form contract write: PASS, written 42, skipped 13, failures 0
- server `sc_demo` form operability probe: PASS, 55 rows, failures 0, warnings 1 (`资金日报表` legacy fact line create-not-applicable warning)