### PR TITLE
Fix SCBS55 legacy visible list browser contract

### DIFF
--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import logging
+import hashlib
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
@@ -157,6 +158,7 @@ BUSINESS_FORM_STRUCTURE_INTERNAL_SUFFIXES = (
     "_count",
     "_rate",
 )
+SCBS55_SOURCE_DOCUMENT = "/home/odoo/workspace/partner_import_source/5.6优化（老系统菜单，字段列表展示）1.docx"
 
 
 class UiContractV2Handler(BaseIntentHandler):
@@ -1033,6 +1035,7 @@ class UiContractV2Handler(BaseIntentHandler):
         views = source_contract.get("views") if isinstance(source_contract.get("views"), dict) else {}
         tree = views.get("tree") if isinstance(views.get("tree"), dict) else views.get("list") if isinstance(views.get("list"), dict) else {}
         raw_columns = tree.get("columns") if isinstance(tree.get("columns"), list) else []
+        legacy_override = self._scbs55_legacy_visible_list_override(source_contract)
         columns: list[str] = []
         for row in raw_columns:
             name = str(row.get("name") if isinstance(row, dict) else row or "").strip()
@@ -1045,6 +1048,17 @@ class UiContractV2Handler(BaseIntentHandler):
                 columns.append(normalized)
         column_policy = profile.get("column_policy") if isinstance(profile.get("column_policy"), dict) else {}
         strict_columns = str(column_policy.get("mode") or "").strip().lower() == "strict"
+        override_labels = {}
+        if legacy_override:
+            columns = list(legacy_override.get("columns") or [])
+            override_labels = dict(legacy_override.get("column_labels") or {})
+            strict_columns = True
+        if not strict_columns and columns and all(str(name or "").startswith("p1_visible_") for name in columns):
+            # SCBS55 legacy-visible delivery actions use action-scoped alias
+            # columns to mirror the old system. Keep that list exact: appending
+            # business-operation fallback fields reintroduces user-hidden
+            # migration columns and can truncate long old-system lists.
+            strict_columns = True
         if not strict_columns:
             for name in common_fields:
                 if name and name not in columns:
@@ -1052,7 +1066,7 @@ class UiContractV2Handler(BaseIntentHandler):
             if note_field and note_field not in columns:
                 columns.append(note_field)
         max_visible_columns = 24
-        if len(columns) > max_visible_columns:
+        if not strict_columns and len(columns) > max_visible_columns:
             selected = columns[:max_visible_columns]
             list_visibility_fields = [
                 "operation_strategy",
@@ -1081,7 +1095,7 @@ class UiContractV2Handler(BaseIntentHandler):
             return
 
         labels = profile.get("column_labels") if isinstance(profile.get("column_labels"), dict) else {}
-        labels = {**labels, **{name: label_for(name) for name in columns}}
+        labels = {**labels, **{name: label_for(name) for name in columns}, **override_labels}
         deduped_columns: list[str] = []
         seen_labels: set[str] = set()
         for name in columns:
@@ -1110,20 +1124,26 @@ class UiContractV2Handler(BaseIntentHandler):
         if not row_secondary and row_primary != derived_status_field and "project_id" in columns:
             row_secondary = "project_id"
         profile.update({
-            "source": "ui.contract.v2.business_operation_projection",
+            "source": "ui.contract.v2.scbs55_legacy_visible_projection" if legacy_override else "ui.contract.v2.business_operation_projection",
             "columns": columns,
             "fact_columns": columns,
             "hidden_columns": [name for name in (profile.get("hidden_columns") if isinstance(profile.get("hidden_columns"), list) else []) if name in columns],
             "column_labels": labels,
+            "show_row_number": False if legacy_override else profile.get("show_row_number", True),
             "row_primary": row_primary,
             "row_secondary": row_secondary,
             "status_field": derived_status_field,
             "preference_policy": {
                 **(profile.get("preference_policy") if isinstance(profile.get("preference_policy"), dict) else {}),
                 "scope": "ui_only",
-                "allow_visibility": True,
-                "allow_order": True,
-                "allow_width": True,
+                "allow_visibility": False if legacy_override else True,
+                "allow_order": False if legacy_override else True,
+                "allow_width": False if legacy_override else True,
+                "locked_columns": columns if legacy_override else (
+                    (profile.get("preference_policy") or {}).get("locked_columns", [])
+                    if isinstance(profile.get("preference_policy"), dict)
+                    else []
+                ),
                 "must_request_columns": columns,
             },
         })
@@ -1153,6 +1173,68 @@ class UiContractV2Handler(BaseIntentHandler):
             elif "list" in views:
                 views["list"] = tree
             source_contract["views"] = views
+
+    def _scbs55_legacy_visible_list_override(self, source_contract: dict[str, Any]) -> dict[str, Any] | None:
+        action_id = 0
+        for raw in (
+            source_contract.get("action_id"),
+            source_contract.get("actionId"),
+            (source_contract.get("head") or {}).get("action_id") if isinstance(source_contract.get("head"), dict) else None,
+            (source_contract.get("source_meta") or {}).get("action_id") if isinstance(source_contract.get("source_meta"), dict) else None,
+        ):
+            try:
+                action_id = int(raw or 0)
+            except Exception:
+                action_id = 0
+            if action_id > 0:
+                break
+        if action_id <= 0 or "sc.legacy.user.priority.menu.plan" not in self.env:
+            return None
+        try:
+            plan = self.env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False).search(
+                [
+                    ("source_document", "=", SCBS55_SOURCE_DOCUMENT),
+                    ("target_action_id", "=", action_id),
+                    ("list_field_contract", "!=", False),
+                ],
+                limit=1,
+            )
+        except Exception:
+            _logger.debug("SCBS55 legacy visible list override lookup skipped", exc_info=True)
+            return None
+        if not plan:
+            return None
+        model_name = str(getattr(plan, "target_model", "") or source_contract.get("model") or "").strip()
+        model_fields = {}
+        try:
+            model_fields = getattr(self.env[model_name], "_fields", {}) if model_name in self.env else {}
+        except Exception:
+            model_fields = {}
+
+        columns: list[str] = []
+        labels: dict[str, str] = {}
+        for item in plan.list_field_contract or []:
+            if not isinstance(item, dict):
+                continue
+            label = str(item.get("legacy_label") or "").strip()
+            if not label or label == "操作":
+                continue
+            field_name = "p1_visible_" + hashlib.sha1(label.encode("utf-8")).hexdigest()[:12]
+            if field_name in columns:
+                continue
+            if model_fields and field_name not in model_fields:
+                continue
+            columns.append(field_name)
+            labels[field_name] = label
+        if not columns:
+            return None
+        return {
+            "source": "scbs55_legacy_user_priority_menu_plan",
+            "action_id": action_id,
+            "plan_id": int(plan.id),
+            "columns": columns,
+            "column_labels": labels,
+        }
 
     def _inject_collaboration_contract(self, source_contract: dict[str, Any], *, model: str, view_type: str) -> None:
         try:

--- a/frontend/apps/web/src/app/action_runtime/useActionViewContractShapeRuntime.ts
+++ b/frontend/apps/web/src/app/action_runtime/useActionViewContractShapeRuntime.ts
@@ -497,6 +497,7 @@ export function useActionViewContractShapeRuntime(options: UseActionViewContract
     });
     const rowPrimary = String(rawProfile.row_primary || listSemantics.row_primary || '').trim();
     const rowSecondary = String(rawProfile.row_secondary || listSemantics.row_secondary || '').trim();
+    const showRowNumber = rawProfile.show_row_number !== false;
     const statusField = String(rawProfile.status_field || listSemantics.status_field || '').trim();
     const metricFields = Array.isArray(rawProfile.metric_fields || listSemantics.metric_fields)
       ? ((rawProfile.metric_fields || listSemantics.metric_fields) as unknown[])
@@ -562,6 +563,7 @@ export function useActionViewContractShapeRuntime(options: UseActionViewContract
       preference_policy: preferencePolicy,
       row_primary: rowPrimary,
       row_secondary: rowSecondary,
+      show_row_number: showRowNumber,
       status_field: statusField,
       metric_fields: metricFields,
       batch_policy: batchPolicy,

--- a/frontend/apps/web/src/app/resolvers/sceneRegistry.ts
+++ b/frontend/apps/web/src/app/resolvers/sceneRegistry.ts
@@ -44,6 +44,7 @@ export interface SceneListProfile {
   };
   row_primary?: string;
   row_secondary?: string;
+  show_row_number?: boolean;
   status_field?: string;
   metric_fields?: string[];
   batch_policy?: {

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -243,7 +243,7 @@
           >
             <colgroup>
               <col v-if="showSelectionColumn" class="col-select" />
-              <col class="col-row-number" />
+              <col v-if="showRowNumberColumn" class="col-row-number" />
               <col v-for="col in displayedColumns" :key="`group-col-width-${group.key}-${col}`" :style="columnWidthStyle(col)" />
             </colgroup>
             <thead>
@@ -257,7 +257,7 @@
                     @change="onGroupSelectAllChange(group, $event)"
                   />
                 </th>
-                <th class="cell-row-number">{{ uiLabel('row_number', '序号') }}</th>
+                <th v-if="showRowNumberColumn" class="cell-row-number">{{ uiLabel('row_number', '序号') }}</th>
                 <th
                   v-for="col in displayedColumns"
                   :key="`group-col-${group.key}-${col}`"
@@ -310,7 +310,7 @@
                     @change="onRowCheckboxChange(row, $event)"
                   />
                 </td>
-                <td class="cell-row-number">{{ groupedRowNumber(group.key, index) }}</td>
+                <td v-if="showRowNumberColumn" class="cell-row-number">{{ groupedRowNumber(group.key, index) }}</td>
                 <td
                   v-for="col in displayedColumns"
                   :key="`group-cell-${group.key}-${String(row.id ?? index)}-${col}`"
@@ -355,7 +355,7 @@
             <tfoot>
               <tr>
                 <td v-if="showSelectionColumn" class="cell-select"></td>
-                <th class="cell-row-number footer-row-label">{{ footerRowLabel('page', group.sampleRows.length) }}</th>
+                <th v-if="showRowNumberColumn" class="cell-row-number footer-row-label">{{ footerRowLabel('page', group.sampleRows.length) }}</th>
                 <td
                   v-for="col in displayedColumns"
                   :key="`group-footer-page-${group.key}-${col}`"
@@ -368,7 +368,7 @@
               </tr>
               <tr>
                 <td v-if="showSelectionColumn" class="cell-select"></td>
-                <th class="cell-row-number footer-row-label">{{ footerRowLabel('total', group.count) }}</th>
+                <th v-if="showRowNumberColumn" class="cell-row-number footer-row-label">{{ footerRowLabel('total', group.count) }}</th>
                 <td
                   v-for="col in displayedColumns"
                   :key="`group-footer-total-${group.key}-${col}`"
@@ -389,12 +389,12 @@
         :class="{ 'has-selection-column': showSelectionColumn }"
         :style="tableWidthStyle"
       >
-        <colgroup>
-          <col v-if="showSelectionColumn" class="col-select" />
-          <col class="col-row-number" />
-          <col v-for="col in displayedColumns" :key="`col-width-${col}`" :style="columnWidthStyle(col)" />
-          <col v-if="columnChoices.length" class="col-column-picker" />
-        </colgroup>
+          <colgroup>
+            <col v-if="showSelectionColumn" class="col-select" />
+          <col v-if="showRowNumberColumn" class="col-row-number" />
+            <col v-for="col in displayedColumns" :key="`col-width-${col}`" :style="columnWidthStyle(col)" />
+            <col v-if="columnChoices.length" class="col-column-picker" />
+          </colgroup>
         <thead>
           <tr>
             <th v-if="showSelectionColumn" class="cell-select">
@@ -406,7 +406,7 @@
                 @change="onSelectAllChange"
               />
             </th>
-            <th class="cell-row-number">{{ uiLabel('row_number', '序号') }}</th>
+            <th v-if="showRowNumberColumn" class="cell-row-number">{{ uiLabel('row_number', '序号') }}</th>
             <th
               v-for="col in displayedColumns"
               :key="col"
@@ -482,7 +482,7 @@
                 @change="onRowCheckboxChange(row, $event)"
               />
             </td>
-            <td class="cell-row-number">{{ flatRowNumber(index) }}</td>
+            <td v-if="showRowNumberColumn" class="cell-row-number">{{ flatRowNumber(index) }}</td>
             <td v-for="col in displayedColumns" :key="col" :style="columnWidthStyle(col)" :class="columnDensityClass(col)">
               <button
                 v-if="isFavoriteColumn(col)"
@@ -527,7 +527,7 @@
         <tfoot>
           <tr>
             <td v-if="showSelectionColumn" class="cell-select"></td>
-            <th class="cell-row-number footer-row-label">{{ footerRowLabel('page', pageVisibleRows.length) }}</th>
+            <th v-if="showRowNumberColumn" class="cell-row-number footer-row-label">{{ footerRowLabel('page', pageVisibleRows.length) }}</th>
             <td
               v-for="col in displayedColumns"
               :key="`footer-page-${col}`"
@@ -541,7 +541,7 @@
           </tr>
           <tr>
             <td v-if="showSelectionColumn" class="cell-select"></td>
-            <th class="cell-row-number footer-row-label">{{ footerRowLabel('total', listTotal || pageVisibleRows.length) }}</th>
+            <th v-if="showRowNumberColumn" class="cell-row-number footer-row-label">{{ footerRowLabel('total', listTotal || pageVisibleRows.length) }}</th>
             <td
               v-for="col in displayedColumns"
               :key="`footer-total-${col}`"
@@ -1534,6 +1534,7 @@ function onRowCheckboxChange(row: Record<string, unknown>, event: Event) {
 
 const rowPrimary = computed(() => props.listProfile?.row_primary || '');
 const rowSecondary = computed(() => props.listProfile?.row_secondary || '');
+const showRowNumberColumn = computed(() => props.listProfile?.show_row_number !== false);
 const hiddenColumns = computed(() => {
   return (props.listProfile?.hidden_columns || []).reduce<Record<string, true>>((acc, col) => {
     acc[col] = true;
@@ -1593,7 +1594,9 @@ const displayedColumns = computed(() => {
   return filtered.length ? filtered : source.slice(0, 1);
 });
 const tableMinWidthPx = computed(() => {
-  const fixedWidth = (showSelectionColumn.value ? 44 : 0) + 64 + (columnChoices.value.length ? 72 : 0);
+  const fixedWidth = (showSelectionColumn.value ? 44 : 0)
+    + (showRowNumberColumn.value ? 64 : 0)
+    + (columnChoices.value.length ? 72 : 0);
   const dynamicWidth = displayedColumns.value.reduce((total, field) => {
     const explicit = effectiveColumnWidth(field);
     if (explicit) return total + explicit;

--- a/frontend/apps/web/src/views/ActionView.vue
+++ b/frontend/apps/web/src/views/ActionView.vue
@@ -2811,6 +2811,8 @@ async function loadListColumnPreference(): Promise<void> {
     }, {});
     const preferencePolicy = listProfile.value?.preference_policy || {};
     const allowVisibility = preferencePolicy.allow_visibility !== false;
+    const allowOrder = preferencePolicy.allow_order !== false;
+    const allowWidth = preferencePolicy.allow_width !== false;
     const lockedColumns = new Set(
       (Array.isArray(preferencePolicy.locked_columns) ? preferencePolicy.locked_columns : [])
         .map((item) => String(item || '').trim())
@@ -2826,8 +2828,8 @@ async function loadListColumnPreference(): Promise<void> {
       });
     }
     listColumnVisibility.value = next;
-    listColumnOrder.value = columnOrder;
-    listColumnWidths.value = columnWidths;
+    listColumnOrder.value = allowOrder ? columnOrder : [];
+    listColumnWidths.value = allowWidth ? columnWidths : {};
   } catch (err) {
     if (seq === listColumnPreferenceLoadSeq) {
       listColumnVisibility.value = {};

--- a/scripts/migration/scbs_55_user_visible_surface_action_tree_alias_write.py
+++ b/scripts/migration/scbs_55_user_visible_surface_action_tree_alias_write.py
@@ -153,6 +153,7 @@ artifact_dir = artifact_root()
 Plan = env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False)  # noqa: F821
 View = env["ir.ui.view"].sudo()  # noqa: F821
 Action = env["ir.actions.act_window"].sudo()  # noqa: F821
+ActionView = env["ir.actions.act_window.view"].sudo()  # noqa: F821
 Menu = env["ir.ui.menu"].sudo().with_context(active_test=False)  # noqa: F821
 
 rows = Plan.search([("source_document", "=", SOURCE_DOCUMENT)], order="priority_sequence")
@@ -202,6 +203,17 @@ def action_for_record(record, base_action, view):
         action.write(values)
     else:
         action = Action.create(values)
+    action_view = ActionView.search([("act_window_id", "=", action.id), ("view_mode", "=", "tree")], limit=1)
+    action_view_values = {
+        "sequence": 1,
+        "view_id": view.id,
+        "act_window_id": action.id,
+        "view_mode": "tree",
+    }
+    if action_view:
+        action_view.write(action_view_values)
+    else:
+        ActionView.create(action_view_values)
     return action
 
 for record in rows:

--- a/scripts/verify/scbs_55_user_visible_list_browser_acceptance.js
+++ b/scripts/verify/scbs_55_user_visible_list_browser_acceptance.js
@@ -1,0 +1,352 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { createRequire } = require('module');
+
+const requireBase = fs.existsSync(path.join(process.cwd(), 'frontend/apps/web/package.json'))
+  ? path.join(process.cwd(), 'frontend/apps/web/package.json')
+  : path.join(process.cwd(), 'package.json');
+const requireFromRoot = createRequire(requireBase);
+const { chromium } = requireFromRoot('playwright');
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:5174';
+const DB_NAME = process.env.DB_NAME || process.env.E2E_DB || 'sc_demo';
+const LOGIN = process.env.E2E_LOGIN || 'wutao';
+const PASSWORD = process.env.E2E_PASSWORD || '123456';
+const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR || 'artifacts';
+const BROWSER_EXECUTABLE_PATH = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || '';
+const OUT_DIR = path.join(
+  ARTIFACTS_DIR,
+  'browser',
+  'scbs55-user-visible-list',
+  new Date().toISOString().replace(/[-:]/g, '').replace(/\..+$/, ''),
+);
+
+const SCREENSHOT_SEQS = new Set([350, 360, 410]);
+const ALLOW_ZERO_RECORD_SEQS = new Set([130]);
+const HELPER_HEADERS = new Set(['', '序号', '列', '操作', 'Actions']);
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function normalize(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function writeJson(name, payload) {
+  ensureDir(OUT_DIR);
+  fs.writeFileSync(path.join(OUT_DIR, name), JSON.stringify(payload, null, 2) + '\n', 'utf8');
+}
+
+function writeMarkdown(report) {
+  const lines = [
+    '# SCBS55 User Visible List Browser Acceptance',
+    '',
+    `- ok: ${report.ok}`,
+    `- frontend_url: ${report.frontend_url}`,
+    `- db_name: ${report.db_name}`,
+    `- login: ${report.login}`,
+    `- checked_count: ${report.summary.checked_count}`,
+    `- pass_count: ${report.summary.pass_count}`,
+    `- fail_count: ${report.summary.fail_count}`,
+    '',
+    '| seq | menu | action | rows | headers | status | screenshot |',
+    '| ---: | --- | ---: | ---: | ---: | --- | --- |',
+  ];
+  for (const row of report.rows) {
+    lines.push(
+      `| ${row.seq} | ${row.name} | ${row.action_id} | ${row.row_count} | ${row.actual_headers.length} | ${row.status} | ${row.screenshot || ''} |`,
+    );
+  }
+  fs.writeFileSync(path.join(OUT_DIR, 'report.md'), lines.join('\n') + '\n', 'utf8');
+}
+
+function meaningfulConsoleErrors(messages) {
+  return messages.filter((message) => {
+    const text = normalize(message);
+    if (!text) return false;
+    if (/Failed to load resource: the server responded with a status of 404/.test(text)) return false;
+    if (/favicon\.ico/.test(text)) return false;
+    return true;
+  });
+}
+
+async function login(page) {
+  await page.goto(`${FRONTEND_URL}/login?db=${encodeURIComponent(DB_NAME)}&t=${Date.now()}`, {
+    waitUntil: 'networkidle',
+    timeout: 45000,
+  });
+  const inputs = page.locator('input');
+  await inputs.nth(0).fill(LOGIN);
+  await inputs.nth(1).fill(PASSWORD);
+  const dbInput = inputs.nth(2);
+  if (await dbInput.isEditable().catch(() => false)) {
+    await dbInput.fill(DB_NAME);
+  }
+  await page.getByRole('button', { name: /^登录$/ }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 45000 });
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => undefined);
+}
+
+async function authToken(page) {
+  return page.evaluate((dbName) => sessionStorage.getItem(`sc_auth_token:${dbName}`) || '', DB_NAME);
+}
+
+async function intent(page, intentName, params) {
+  const token = await authToken(page);
+  return page.evaluate(async ({ dbName, tokenValue, intentName, params }) => {
+    const response = await fetch(`/api/v1/intent?db=${encodeURIComponent(dbName)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: tokenValue ? `Bearer ${tokenValue}` : '',
+        'X-Trace-Id': `scbs55-list-browser-${Date.now()}`,
+      },
+      body: JSON.stringify({ intent: intentName, params }),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok || body.ok === false) {
+      throw new Error(body?.error?.message || body?.message || `${intentName} failed`);
+    }
+    return body.data || {};
+  }, { dbName: DB_NAME, tokenValue: token, intentName, params });
+}
+
+async function fetchPlanRows(page) {
+  const data = await intent(page, 'api.data', {
+    op: 'list',
+    model: 'sc.legacy.user.priority.menu.plan',
+    domain: [
+      ['source_document', '=', '/home/odoo/workspace/partner_import_source/5.6优化（老系统菜单，字段列表展示）1.docx'],
+      ['list_field_contract', '!=', false],
+    ],
+    fields: [
+      'priority_sequence',
+      'legacy_menu_group',
+      'legacy_menu_name',
+      'target_action_id',
+      'target_model',
+      'list_field_contract',
+    ],
+    order: 'priority_sequence',
+    limit: 80,
+    context: { active_test: false },
+  });
+  const records = Array.isArray(data.records) ? data.records : [];
+  return records
+    .map((row) => {
+      const actionValue = row.target_action_id;
+      const actionId = Array.isArray(actionValue) ? Number(actionValue[0] || 0) : Number(actionValue || 0);
+      const contract = Array.isArray(row.list_field_contract) ? row.list_field_contract : [];
+      const seenLabels = new Set();
+      const labels = contract
+        .map((item) => (item && typeof item === 'object' ? normalize(item.legacy_label) : ''))
+        .filter((label) => {
+          if (!label || label === '操作') return false;
+          if (seenLabels.has(label)) return false;
+          seenLabels.add(label);
+          return true;
+        });
+      return {
+        seq: Number(row.priority_sequence || 0),
+        group: normalize(row.legacy_menu_group),
+        name: normalize(row.legacy_menu_name),
+        model: normalize(row.target_model),
+        action_id: actionId,
+        expected_headers: labels,
+      };
+    })
+    .filter((row) => row.action_id > 0 && row.expected_headers.length > 0);
+}
+
+async function waitForList(page) {
+  await page.waitForFunction(() => {
+    const text = String(document.body?.textContent || '');
+    if (/页面加载失败|页面渲染失败|System exception|NAV_MENU_NO_ACTION/.test(text)) return true;
+    if (/没有匹配记录|暂无数据|0 条/.test(text)) return true;
+    return Boolean(document.querySelector('table.flat-table thead, table.group-table thead, .table table thead, table thead'));
+  }, null, { timeout: 45000 });
+  const bodyText = normalize(await page.locator('body').innerText({ timeout: 5000 }).catch(() => ''));
+  if (/页面加载失败|页面渲染失败|System exception|NAV_MENU_NO_ACTION/.test(bodyText)) {
+    throw new Error(bodyText.slice(0, 400));
+  }
+}
+
+async function tableHeaders(page) {
+  return page.evaluate((helperHeaders) => {
+    function normalizeText(value) {
+      return String(value || '').replace(/\s+/g, ' ').trim();
+    }
+
+    function headerText(node) {
+      const clone = node.cloneNode(true);
+      for (const child of Array.from(clone.querySelectorAll('svg,.sort-indicator,.column-resize-handle,[aria-hidden="true"]'))) {
+        child.remove();
+      }
+      return normalizeText(clone.textContent);
+    }
+
+    const tables = Array.from(document.querySelectorAll('table.flat-table, table.group-table, .table table, table'));
+    const candidates = tables
+      .filter((table) => {
+        const rect = table.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      })
+      .map((table) => Array.from(table.querySelectorAll('thead th'))
+        .map(headerText)
+        .filter((text) => !helperHeaders.includes(text)));
+    candidates.sort((left, right) => right.length - left.length);
+    return candidates[0] || [];
+  }, Array.from(HELPER_HEADERS));
+}
+
+async function firstRowValues(page) {
+  return page.evaluate(() => {
+    function normalizeText(value) {
+      return String(value || '').replace(/\s+/g, ' ').trim();
+    }
+
+    const tables = Array.from(document.querySelectorAll('table.flat-table, table.group-table, .table table, table'))
+      .filter((table) => {
+        const rect = table.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      });
+    const candidates = tables.map((table) => {
+      const row = table.querySelector('tbody tr');
+      if (!row) return [];
+      return Array.from(row.querySelectorAll('td'))
+        .filter((cell) => !cell.classList.contains('cell-select')
+          && !cell.classList.contains('cell-row-number')
+          && !cell.classList.contains('cell-column-picker'))
+        .map((cell) => normalizeText(cell.textContent));
+    });
+    candidates.sort((left, right) => right.length - left.length);
+    return candidates[0] || [];
+  });
+}
+
+async function visibleRowCount(page) {
+  return page.evaluate(() => {
+    const tables = Array.from(document.querySelectorAll('table.flat-table, table.group-table, .table table, table'))
+      .filter((table) => {
+        const rect = table.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      });
+    return tables.reduce((count, table) => count + table.querySelectorAll('tbody tr').length, 0);
+  });
+}
+
+async function run() {
+  ensureDir(OUT_DIR);
+  const launchOptions = { headless: true, args: ['--no-sandbox'] };
+  if (BROWSER_EXECUTABLE_PATH) {
+    launchOptions.executablePath = BROWSER_EXECUTABLE_PATH;
+  }
+  const browser = await chromium.launch(launchOptions);
+  const page = await browser.newPage({ viewport: { width: 1440, height: 960 }, locale: 'zh-CN' });
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+  const report = {
+    ok: false,
+    frontend_url: FRONTEND_URL,
+    db_name: DB_NAME,
+    login: LOGIN,
+    artifact_dir: OUT_DIR,
+    rows: [],
+    console_errors: consoleErrors,
+    summary: { checked_count: 0, pass_count: 0, fail_count: 0 },
+  };
+
+  try {
+    await login(page);
+    const planRows = await fetchPlanRows(page);
+    if (!planRows.length) throw new Error('no user-visible list plan rows resolved through browser intent');
+
+    for (const plan of planRows) {
+      const actionUrl = `${FRONTEND_URL}/a/${plan.action_id}?db=${encodeURIComponent(DB_NAME)}&scbs55_browser_acceptance=${Date.now()}`;
+      const row = {
+        ...plan,
+        url: actionUrl,
+        actual_headers: [],
+        first_row_values: [],
+        row_count: 0,
+        status: 'FAIL',
+        errors: [],
+        notes: [],
+        screenshot: '',
+      };
+      try {
+        await page.goto(actionUrl, { waitUntil: 'domcontentloaded', timeout: 45000 });
+        await page.waitForLoadState('networkidle', { timeout: 45000 }).catch(() => undefined);
+        await waitForList(page);
+        row.actual_headers = await tableHeaders(page);
+        row.first_row_values = await firstRowValues(page);
+        row.row_count = await visibleRowCount(page);
+        if (row.row_count < 1 && ALLOW_ZERO_RECORD_SEQS.has(plan.seq)) {
+          row.status = 'PASS';
+          row.notes.push('zero_record_allowed');
+          if (SCREENSHOT_SEQS.has(plan.seq)) {
+            const fileName = `seq_${String(plan.seq).padStart(3, '0')}_${plan.name.replace(/[^\w\u4e00-\u9fa5]+/g, '_')}.png`;
+            await page.screenshot({ path: path.join(OUT_DIR, fileName), fullPage: true });
+            row.screenshot = fileName;
+          }
+          report.rows.push(row);
+          continue;
+        }
+        const visibleHeaders = row.actual_headers.slice(0, plan.expected_headers.length);
+        const extraHeaders = row.actual_headers.slice(plan.expected_headers.length);
+        const missing = plan.expected_headers.filter((header, idx) => visibleHeaders[idx] !== header);
+        const extraMeaningful = extraHeaders.filter((header) => !['操作', 'Actions'].includes(header));
+        if (missing.length) row.errors.push(`header_order_mismatch:${missing.join(',')}`);
+        if (extraMeaningful.length) row.errors.push(`extra_headers:${extraMeaningful.join(',')}`);
+        if (row.row_count < 1 && plan.seq !== 130) row.errors.push('no_rows_rendered');
+        if (SCREENSHOT_SEQS.has(plan.seq)) {
+          const fileName = `seq_${String(plan.seq).padStart(3, '0')}_${plan.name.replace(/[^\w\u4e00-\u9fa5]+/g, '_')}.png`;
+          await page.screenshot({ path: path.join(OUT_DIR, fileName), fullPage: true });
+          row.screenshot = fileName;
+        }
+        row.status = row.errors.length ? 'FAIL' : 'PASS';
+      } catch (err) {
+        row.errors.push(err && err.message ? err.message : String(err));
+        const fileName = `seq_${String(plan.seq).padStart(3, '0')}_failure.png`;
+        await page.screenshot({ path: path.join(OUT_DIR, fileName), fullPage: true }).catch(() => undefined);
+        row.screenshot = fileName;
+      }
+      report.rows.push(row);
+    }
+
+    report.summary.checked_count = report.rows.length;
+    report.summary.pass_count = report.rows.filter((row) => row.status === 'PASS').length;
+    report.summary.fail_count = report.rows.filter((row) => row.status !== 'PASS').length;
+    const fatalConsoleErrors = meaningfulConsoleErrors(consoleErrors);
+    report.summary.console_error_count = consoleErrors.length;
+    report.summary.fatal_console_error_count = fatalConsoleErrors.length;
+    report.fatal_console_errors = fatalConsoleErrors;
+    report.ok = report.summary.fail_count === 0 && fatalConsoleErrors.length === 0;
+    writeJson('summary.json', report);
+    writeMarkdown(report);
+    if (!report.ok) {
+      throw new Error(`browser acceptance failed: fail_count=${report.summary.fail_count}, fatal_console_errors=${fatalConsoleErrors.length}`);
+    }
+    console.log(`[scbs55_list_browser_acceptance] PASS artifacts=${OUT_DIR}`);
+  } catch (err) {
+    report.ok = false;
+    report.error = err && err.message ? err.message : String(err);
+    writeJson('summary.json', report);
+    writeMarkdown(report);
+    console.error(`[scbs55_list_browser_acceptance] FAIL ${report.error}`);
+    console.error(`[scbs55_list_browser_acceptance] artifacts=${OUT_DIR}`);
+    process.exitCode = 1;
+  } finally {
+    await browser.close().catch(() => undefined);
+  }
+}
+
+run();


### PR DESCRIPTION
## Summary
- enforce SCBS55 legacy-visible list columns from the 55-menu plan in ui.contract.v2
- disable saved column visibility/order/width preferences for those locked delivery lists
- allow SCBS55 list profiles to hide the fixed row-number column in the custom frontend
- add Playwright browser acceptance for the user-visible list contract

## Verification
- `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py`
- `node --check scripts/verify/scbs_55_user_visible_list_browser_acceptance.js`
- server browser acceptance: `checked_count=42`, `pass_count=42`, `fail_count=0`
- browser evidence: `/tmp/scbs55-browser-evidence/browser/scbs55-user-visible-list/20260528T080422`