### PR TITLE
Refine legacy acceptance menu scope

### DIFF
--- a/scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py
+++ b/scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py
@@ -339,6 +339,9 @@ def is_internal_only_path(path: str) -> bool:
             "旧库往来单位映射",
             "旧库项目映射",
             "旧库报表承载清单",
+            "用户信息与权限",
+            "SCBS旧库事实暂存",
+            "SCBS旧库材料映射",
         )
     )
 
@@ -398,6 +401,19 @@ def discover_legacy_data_menus(root_menu) -> list[dict[str, object]]:
                 "acceptance_path": acceptance_path,
             }
         )
+    best_by_identity = {}
+    for item in discovered:
+        key = (str(item["path"]), str(item["action_name"]), str(item["model"]))
+        xmlid = str(item.get("menu_xmlid") or "")
+        priority = (
+            1 if "analysis_report" in xmlid else 0,
+            1 if "scbs55_user_acceptance" in xmlid else 0,
+            int(item["menu_id"]),
+        )
+        current = best_by_identity.get(key)
+        if current is None or priority < current[0]:
+            best_by_identity[key] = (priority, item)
+    discovered = [item for _, item in best_by_identity.values()]
     discovered.sort(key=lambda item: (str(item["path"]), int(item["menu_id"])))
     return discovered
 


### PR DESCRIPTION
## Summary
- exclude user permission/history mapping technical menus from customer legacy-data acceptance discovery
- deduplicate same path/action/model legacy menus before applying runtime and product policies
- keep customer-facing old business data entries visible while hiding technical staging and duplicate report links

## Validation
- `python3 -m py_compile scripts/ops/scbs_55_user_acceptance_menu_policy_apply.py`
- `git diff --check`
- server daily-dev `sc_demo` replay PASS: `runtime_allowed_menu_count=296`, `enabled_policy_menus=227`, `missing_allowed_xmlids=[]`
- post-replay audit: visible technical/permission entries `0`, demo entries `0`, duplicate visible paths `{}`