### PR TITLE
[codex] Tighten legacy visible data parity probe

### DIFF
--- a/addons/smart_construction_core/views/projection/fund_daily_views.xml
+++ b/addons/smart_construction_core/views/projection/fund_daily_views.xml
@@ -157,11 +157,11 @@
                     <field name="project_id"/>
                     <field name="account_name"/>
                     <field name="bank_account_no"/>
-                    <field name="daily_income"/>
-                    <field name="daily_expense"/>
-                    <field name="current_account_balance"/>
-                    <field name="current_bank_balance"/>
-                    <field name="bank_system_difference"/>
+                    <field name="daily_income" sum="当日累计收入合计"/>
+                    <field name="daily_expense" sum="当日累计支出合计"/>
+                    <field name="current_account_balance" sum="当前账户余额合计"/>
+                    <field name="current_bank_balance" sum="当前账户银行余额合计"/>
+                    <field name="bank_system_difference" sum="银行系统差额合计"/>
                     <field name="document_state"/>
                 </tree>
             </field>

--- a/scripts/verify/user_data_reconciliation_full_scope_probe.py
+++ b/scripts/verify/user_data_reconciliation_full_scope_probe.py
@@ -149,8 +149,25 @@ def view_fields(model_name: str, view_type: str) -> dict[str, set[str]]:
 
 
 AXES = {
-    "project": ["project_id", "business_entity_id", "legacy_project_name", "project_name", "project_name_text"],
-    "document": ["document_no", "name", "contract_no", "invoice_no"],
+    "project": [
+        "project_id",
+        "business_entity_id",
+        "legacy_project_name",
+        "legacy_visible_project_name",
+        "project_name",
+        "project_name_text",
+        "legacy_xmmc",
+    ],
+    "document": [
+        "document_no",
+        "legacy_document_no",
+        "legacy_visible_document_no",
+        "name",
+        "contract_no",
+        "invoice_no",
+        "source_login",
+        "generated_login",
+    ],
     "date": [
         "document_date",
         "request_date",
@@ -196,11 +213,16 @@ AXES = {
         "legacy_receipt_subtype",
         "operation_type",
         "operation_strategy",
+        "entity_type",
+        "fact_type",
         "invoice_type",
         "tax_rate",
         "cost_category_name",
         "document_scope",
         "source_family",
+        "document_state",
+        "user_type",
+        "person_state",
         "state",
     ],
     "creator": ["source_created_by", "creator_name", "requester_id", "owner_id"],
@@ -208,6 +230,10 @@ AXES = {
 }
 
 AMOUNT_FIELDS = [
+    "visible_contract_amount",
+    "visible_invoice_amount",
+    "visible_received_amount",
+    "visible_unreceived_amount",
     "amount_total",
     "amount",
     "paid_amount",
@@ -287,10 +313,15 @@ for model_name, labels in sorted(P1_ALIAS_LABELS.items()):
     domain = domain_for_model(model_name)
     total = Model.search_count(domain)
     fields = existing_fields(model_name)
-    amount_field = first_existing(model_name, AMOUNT_FIELDS)
-    amount_total = amount_sum(model_name, amount_field, domain) if amount_field and total else 0.0
     search = view_fields(model_name, "search")
     tree = view_fields(model_name, "tree")
+    amount_candidates = [
+        field_name
+        for field_name in AMOUNT_FIELDS
+        if field_name in fields and field_name in tree["visible_fields"]
+    ]
+    amount_field = first_existing(model_name, amount_candidates)
+    amount_total = amount_sum(model_name, amount_field, domain) if amount_field and total else 0.0
 
     axes = {}
     missing_axes = []


### PR DESCRIPTION
## Summary

- Tighten the full-scope user data reconciliation probe so amount checks use fields that are actually visible in the user tree view.
- Add legacy-visible aliases to the probe axes for project, document, and type fields used by migrated old-system data.
- Add list footer sums for legacy fund daily amount columns so users can reconcile visible daily fund totals.

## Validation

- `python3 -m py_compile scripts/verify/user_data_reconciliation_full_scope_probe.py && git diff --check`
- Daily dev `sc_demo`: `verify.user_visible_business_fact_alignment` PASS after projecting `project_cost_ledger` to 73,068 visible facts.
- Daily dev `sc_demo`: `scbs_55_legacy_visible_field_full_reconcile_probe.py` PASS, 42/42 required visible entries, 0 blocking mismatches.
- Daily dev `sc_demo`: `user_data_reconciliation_full_scope_probe.py` PASS, `blocking_gap_count=0`.
- SCBSLY direct project new-system alignment probe PASS for 34 comparable direct-project entries.

## Notes

Online old-system credential env vars were not present in the local/server environment, so current online re-fetch against SCBS/SCBSLY still requires the old-system usernames/passwords to be exported before regenerating fresh dumps.