### PR TITLE
[codex] Expose legacy reconciliation grouping axes

### DIFF
--- a/addons/smart_construction_core/views/core/document_admin_document_views.xml
+++ b/addons/smart_construction_core/views/core/document_admin_document_views.xml
@@ -22,7 +22,11 @@
           <filter string="办理中" name="in_progress" domain="[('state', '=', 'in_progress')]"/>
           <filter string="已完成" name="done" domain="[('state', '=', 'done')]"/>
           <group expand="0" string="分组">
+            <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+            <filter string="按历史项目名称" name="group_legacy_project" context="{'group_by': 'legacy_visible_project_name'}"/>
+            <filter string="按业务日期" name="group_business_date" context="{'group_by': 'business_date'}"/>
             <filter string="按类型" name="group_type" context="{'group_by': 'fact_type'}"/>
+            <filter string="按录入人" name="group_requester" context="{'group_by': 'requester_id'}"/>
             <filter string="按借阅人" name="group_borrow_user" context="{'group_by': 'borrow_user_id'}"/>
             <filter string="按状态" name="group_state" context="{'group_by': 'state'}"/>
           </group>

--- a/addons/smart_construction_core/views/core/expense_business_fact_taxonomy_views.xml
+++ b/addons/smart_construction_core/views/core/expense_business_fact_taxonomy_views.xml
@@ -203,6 +203,7 @@
                     <filter string="有项目" name="has_project" domain="[('project_id', '!=', False)]"/>
                     <filter string="有往来单位" name="has_partner" domain="[('partner_id', '!=', False)]"/>
                     <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+                    <filter string="按单据日期" name="group_document_date" context="{'group_by': 'document_date'}"/>
                     <filter string="按往来单位" name="group_partner" context="{'group_by': 'partner_id'}"/>
                     <filter string="按残余原因" name="group_residual_reason" context="{'group_by': 'residual_reason'}"/>
                     <filter string="按付款族" name="group_payment_family" context="{'group_by': 'payment_family'}"/>

--- a/addons/smart_construction_core/views/core/hr_payroll_document_views.xml
+++ b/addons/smart_construction_core/views/core/hr_payroll_document_views.xml
@@ -25,8 +25,11 @@
           <filter string="办理中" name="in_progress" domain="[('state', '=', 'in_progress')]"/>
           <filter string="已完成" name="done" domain="[('state', '=', 'done')]"/>
           <group expand="0" string="分组">
+            <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+            <filter string="按业务日期" name="group_business_date" context="{'group_by': 'business_date'}"/>
             <filter string="按类型" name="group_type" context="{'group_by': 'fact_type'}"/>
             <filter string="按部门" name="group_department" context="{'group_by': 'department_id'}"/>
+            <filter string="按申请人" name="group_requester" context="{'group_by': 'requester_id'}"/>
             <filter string="按人员" name="group_employee" context="{'group_by': 'employee_user_id'}"/>
             <filter string="按年度" name="group_year" context="{'group_by': 'period_year'}"/>
             <filter string="按状态" name="group_state" context="{'group_by': 'state'}"/>

--- a/addons/smart_construction_core/views/core/office_admin_document_views.xml
+++ b/addons/smart_construction_core/views/core/office_admin_document_views.xml
@@ -19,6 +19,9 @@
           <filter string="办理中" name="in_progress" domain="[('state', '=', 'in_progress')]"/>
           <filter string="已完成" name="done" domain="[('state', '=', 'done')]"/>
           <group expand="0" string="分组">
+            <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+            <filter string="按历史项目名称" name="group_legacy_project" context="{'group_by': 'legacy_visible_project_name'}"/>
+            <filter string="按业务日期" name="group_business_date" context="{'group_by': 'business_date'}"/>
             <filter string="按类型" name="group_type" context="{'group_by': 'fact_type'}"/>
             <filter string="按部门" name="group_department" context="{'group_by': 'department_id'}"/>
             <filter string="按申请人" name="group_requester" context="{'group_by': 'requester_id'}"/>

--- a/addons/smart_construction_core/views/projection/fund_daily_views.xml
+++ b/addons/smart_construction_core/views/projection/fund_daily_views.xml
@@ -143,6 +143,7 @@
                     <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
                     <filter string="按日期" name="group_document_date" context="{'group_by': 'document_date'}"/>
                     <filter string="按账户" name="group_account" context="{'group_by': 'account_name'}"/>
+                    <filter string="按单据状态" name="group_document_state" context="{'group_by': 'document_state'}"/>
                 </search>
             </field>
         </record>

--- a/addons/smart_construction_core/views/support/business_entity_views.xml
+++ b/addons/smart_construction_core/views/support/business_entity_views.xml
@@ -15,6 +15,9 @@
                     <filter string="冲突" name="state_conflict" domain="[('mapping_state', '=', 'conflict')]"/>
                     <filter string="平台主体" name="type_platform" domain="[('entity_type', '=', 'platform')]"/>
                     <filter string="按隔离公司" name="group_company" context="{'group_by': 'company_id'}"/>
+                    <filter string="按旧主体名称" name="group_legacy_xmmc" context="{'group_by': 'legacy_xmmc'}"/>
+                    <filter string="按往来单位" name="group_partner" context="{'group_by': 'partner_id'}"/>
+                    <filter string="按创建时间" name="group_create_date" context="{'group_by': 'create_date'}"/>
                     <filter string="按类型" name="group_type" context="{'group_by': 'entity_type'}"/>
                     <filter string="按状态" name="group_state" context="{'group_by': 'mapping_state'}"/>
                 </search>

--- a/addons/smart_construction_core/views/support/legacy_invoice_runtime_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_invoice_runtime_views.xml
@@ -321,6 +321,8 @@
           <filter name="has_attachment" string="有附件" domain="[('attachment_links', '!=', False)]"/>
           <group expand="0" string="分组">
             <filter name="group_project" string="项目" context="{'group_by': 'project_name'}"/>
+            <filter name="group_receipt_time" string="到款时间" context="{'group_by': 'receipt_time'}"/>
+            <filter name="group_created_time" string="创建时间" context="{'group_by': 'created_time'}"/>
             <filter name="group_state" string="单据状态" context="{'group_by': 'document_state'}"/>
             <filter name="group_construction_unit" string="施工单位" context="{'group_by': 'construction_unit_name'}"/>
           </group>

--- a/addons/smart_construction_core/views/support/legacy_invoice_tax_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_invoice_tax_views.xml
@@ -22,6 +22,29 @@
     </field>
   </record>
 
+  <record id="view_sc_legacy_invoice_tax_fact_search" model="ir.ui.view">
+    <field name="name">sc.legacy.invoice.tax.fact.search</field>
+    <field name="model">sc.legacy.invoice.tax.fact</field>
+    <field name="arch" type="xml">
+      <search string="历史发票税额事实">
+        <field name="document_no"/>
+        <field name="document_date"/>
+        <field name="project_id"/>
+        <field name="legacy_project_name"/>
+        <field name="legacy_partner_name"/>
+        <field name="direction"/>
+        <field name="invoice_type"/>
+        <field name="source_family"/>
+        <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+        <filter string="按日期" name="group_document_date" context="{'group_by': 'document_date'}"/>
+        <filter string="按往来单位" name="group_legacy_partner" context="{'group_by': 'legacy_partner_name'}"/>
+        <filter string="按方向" name="group_direction" context="{'group_by': 'direction'}"/>
+        <filter string="按发票类型" name="group_invoice_type" context="{'group_by': 'invoice_type'}"/>
+        <filter string="按来源族" name="group_source_family" context="{'group_by': 'source_family'}"/>
+      </search>
+    </field>
+  </record>
+
   <record id="view_sc_legacy_invoice_tax_fact_form" model="ir.ui.view">
     <field name="name">sc.legacy.invoice.tax.fact.form</field>
     <field name="model">sc.legacy.invoice.tax.fact</field>
@@ -66,6 +89,7 @@
     <field name="name">历史发票税额事实</field>
     <field name="res_model">sc.legacy.invoice.tax.fact</field>
     <field name="view_mode">tree,form</field>
+    <field name="search_view_id" ref="view_sc_legacy_invoice_tax_fact_search"/>
     <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_config_admin')])]"/>
   </record>
 </odoo>

--- a/addons/smart_construction_core/views/support/legacy_user_context_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_user_context_views.xml
@@ -68,7 +68,11 @@
                 <field name="legacy_user_id"/>
                 <field name="user_id"/>
                 <filter string="已绑定新用户" name="with_user" domain="[('user_id', '!=', False)]"/>
+                <filter string="按项目" name="group_project_name" context="{'group_by': 'project_name'}"/>
                 <filter string="按部门" name="group_department" context="{'group_by': 'department_name'}"/>
+                <filter string="按用户类型" name="group_user_type" context="{'group_by': 'user_type'}"/>
+                <filter string="按人员状态" name="group_person_state" context="{'group_by': 'person_state'}"/>
+                <filter string="按创建时间" name="group_create_date" context="{'group_by': 'create_date'}"/>
             </search>
         </field>
     </record>

--- a/addons/smart_construction_core/views/support/tender_views.xml
+++ b/addons/smart_construction_core/views/support/tender_views.xml
@@ -269,6 +269,7 @@
                 <filter string="已确认" name="confirmed" domain="[('state', '=', 'confirmed')]"/>
                 <filter string="已取消" name="cancel" domain="[('state', '=', 'cancel')]"/>
                 <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+                <filter string="按日期" name="group_date" context="{'group_by': 'date'}"/>
                 <filter string="按类型" name="group_type" context="{'group_by': 'type'}"/>
                 <filter string="按状态" name="group_state" context="{'group_by': 'state'}"/>
             </search>
@@ -297,6 +298,8 @@
                 <group expand="0" string="分组">
                     <filter string="按投标" name="group_bid" context="{'group_by': 'bid_id'}"/>
                     <filter string="按项目" name="group_project" context="{'group_by': 'project_id'}"/>
+                    <filter string="按申请日期" name="group_apply_date" context="{'group_by': 'apply_date'}"/>
+                    <filter string="按收款单位" name="group_receipt_partner" context="{'group_by': 'receipt_partner_name'}"/>
                     <filter string="按申请人" name="group_applicant" context="{'group_by': 'applicant_id'}"/>
                     <filter string="按状态" name="group_state" context="{'group_by': 'state'}"/>
                 </group>

--- a/scripts/verify/user_data_reconciliation_full_scope_probe.py
+++ b/scripts/verify/user_data_reconciliation_full_scope_probe.py
@@ -127,7 +127,8 @@ def view_fields(model_name: str, view_type: str) -> dict[str, set[str]]:
     views = env["ir.ui.view"].sudo().search([("model", "=", model_name), ("type", "=", view_type)])  # noqa: F821
     for view in views:
         arch = view.arch_db or ""
-        group_fields.update(re.findall(r"group_by'?\s*:\s*'([^']+)'", arch))
+        for group_field in re.findall(r"group_by'?\s*:\s*'([^']+)'", arch):
+            group_fields.add(group_field.split(":", 1)[0])
         try:
             root = etree.fromstring(arch.encode("utf-8")) if arch else None
         except Exception:
@@ -177,6 +178,11 @@ AXES = {
         "date_receipt",
         "invoice_date",
         "operation_date",
+        "date_contract",
+        "business_date",
+        "apply_date",
+        "date",
+        "receipt_time",
         "settlement_date",
         "contract_date",
         "date_diary",
@@ -197,6 +203,7 @@ AXES = {
         "partner_name",
         "partner_name_text",
         "legacy_partner_name",
+        "construction_unit_name",
         "receipt_partner_name",
     ],
     "type": [
@@ -216,6 +223,7 @@ AXES = {
         "entity_type",
         "fact_type",
         "invoice_type",
+        "direction",
         "tax_rate",
         "cost_category_name",
         "document_scope",


### PR DESCRIPTION
## Summary

- Add user-facing grouping filters for legacy reconciliation-heavy lists: business entities, document/admin records, HR payroll records, office admin records, tender records, fund daily lines, fund confirmations, payment residuals, and legacy user profiles.
- Add a search view for `sc.legacy.invoice.tax.fact` so historical invoice/tax facts can be grouped by project, date, counterparty, direction, invoice type, and source family.
- Tighten the full-scope reconciliation probe to understand Odoo grouped date granularities like `date_contract:month` and additional legacy-visible field names.

## Validation

- `python3 -m py_compile scripts/verify/user_data_reconciliation_full_scope_probe.py`
- XML parsed with Python stdlib for the touched view files.
- `git diff --check`
- Daily dev `sc_demo`: applied equivalent `ir.ui.view` hotfixes through Odoo shell.
- Daily dev `sc_demo`: `user_data_reconciliation_full_scope_probe.py` PASS, `blocking_gap_count=0`, warnings reduced from 47 to 36.

## Notes

Remaining warnings are not menu/grouping gaps. They are mostly low-coverage migrated old fields, attachment placeholders, or labels requiring fresh online old-system field evidence and/or dedicated backfill scripts.