### PR TITLE
[codex] Hide raw inline legacy attachment ids

### DIFF
--- a/addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py
+++ b/addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py
@@ -58,6 +58,7 @@ LEGACY_PAYMENT_REQUEST_STATUS_DISPLAY = {
     "1": "部分申请",
     "2": "已申请",
 }
+LEGACY_ATTACHMENT_LABEL_RE = re.compile(r"^附件\([1-9]\d*\)$")
 
 class ScLegacyDirectAcceptanceFact(models.Model):
     _name = "sc.legacy.direct.acceptance.fact"
@@ -123,6 +124,10 @@ class ScLegacyDirectAcceptanceFact(models.Model):
 
     @classmethod
     def _legacy_payload_value(cls, payload, field_name, acceptance_label="", visible_index=0, attachment_ref=""):
+        display_value = cls._legacy_attachment_display_value(payload, field_name)
+        if display_value:
+            return display_value
+
         if acceptance_label == "还租" and field_name in {"f_LRR", "f_LRSJ"}:
             fallback_field = "XGR" if field_name == "f_LRR" else "XGSJ"
             value = payload.get(field_name) or payload.get(fallback_field)
@@ -157,7 +162,7 @@ class ScLegacyDirectAcceptanceFact(models.Model):
                     continue
                 text = str(value).strip()
                 if text:
-                    return text if text.startswith("附件(") else text
+                    return text if LEGACY_ATTACHMENT_LABEL_RE.match(text) else ""
             raw_value = payload.get(field_name)
             raw_text = "" if raw_value is None or raw_value is False else str(raw_value).strip()
             clean_attachment_ref = str(attachment_ref or "").strip()
@@ -180,6 +185,16 @@ class ScLegacyDirectAcceptanceFact(models.Model):
                     return cls._legacy_tax_rate_text(text)
                 return text
         return ""
+
+    @staticmethod
+    def _legacy_attachment_display_value(payload, field_name):
+        if not field_name:
+            return ""
+        value = payload.get(f"{field_name}_FJ")
+        if value is None or value is False:
+            return ""
+        text = str(value).strip()
+        return text if LEGACY_ATTACHMENT_LABEL_RE.match(text) else ""
 
     @staticmethod
     def _legacy_number(payload, *field_names):

--- a/addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py
+++ b/addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+MODULE_PATH = ROOT / "addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py"
+
+
+def _load_module():
+    fake_odoo = types.ModuleType("odoo")
+    fake_api = types.SimpleNamespace(depends=lambda *args: (lambda method: method))
+
+    class _Fields:
+        def __getattr__(self, _name):
+            return lambda *args, **kwargs: None
+
+    class _Model:
+        pass
+
+    fake_odoo.api = fake_api
+    fake_odoo.fields = _Fields()
+    fake_odoo.models = types.SimpleNamespace(Model=_Model)
+    sys.modules["odoo"] = fake_odoo
+    try:
+        spec = importlib.util.spec_from_file_location("legacy_direct_acceptance_fact_test", MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        assert spec and spec.loader
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        sys.modules.pop("odoo", None)
+
+
+class TestLegacyDirectAcceptanceAttachmentDisplay(unittest.TestCase):
+    def test_inline_attachment_display_field_does_not_expose_raw_id(self):
+        module = _load_module()
+        payload = {
+            "f_FDWB": "648de2ebffb0562545d750d3ba05642a",
+            "f_FDWB_FJ": "附件(1)",
+        }
+
+        value = module.ScLegacyDirectAcceptanceFact._legacy_payload_value(
+            payload,
+            "f_FDWB",
+            acceptance_label="方单",
+        )
+
+        self.assertEqual(value, "附件(1)")
+
+    def test_non_attachment_display_value_is_hidden_for_attachment_field(self):
+        module = _load_module()
+        payload = {"f_FJ": "abc123", "f_FJ_FJ": "abc123"}
+
+        value = module.ScLegacyDirectAcceptanceFact._legacy_payload_value(
+            payload,
+            "f_FJ",
+            acceptance_label="分包方单",
+        )
+
+        self.assertEqual(value, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Treat legacy inline attachment display fields such as `f_FDWB_FJ` as attachment labels even when the visible business field is not named `FJ`.
- Stop exposing raw legacy IDs from attachment display candidates unless the value is a valid `附件(n)` label.
- Add a focused regression test for the `方单` case where `f_FDWB` held a raw legacy ID and `f_FDWB_FJ` held `附件(1)`.

## Root Cause

The previous attachment cleanup only handled fields named like `FJ`/`f_FJ`. Some direct-acceptance old-system rows store an attachment-bearing business field plus a companion display field, for example `f_FDWB=648de2...` and `f_FDWB_FJ=附件(1)`. The visible-field computation read `f_FDWB` as a normal field and exposed the raw ID.

## Validation

- `python3 addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py`
- `python3 -m py_compile addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py`
- Daily server Odoo shell on `sc_demo`: `方单 / FDGL-20260326-001 / field_11` now returns `附件(1)`.
- Daily server Odoo shell scan for visible fields containing `648de2ebffb0562545d750d3ba0564`: `[]`.