### PR TITLE
[codex] Resolve inline legacy attachment downloads

### DIFF
--- a/addons/smart_core/handlers/file_download.py
+++ b/addons/smart_core/handlers/file_download.py
@@ -7,6 +7,7 @@ import json
 import logging
 import mimetypes
 import os
+import re
 from pathlib import Path
 from typing import Any, Dict
 from urllib.error import URLError
@@ -33,6 +34,7 @@ _logger = logging.getLogger(__name__)
 
 LEGACY_FILE_URL_PREFIX = "legacy-file://"
 LEGACY_FILE_ID_URL_PREFIX = "legacy-file-id://"
+LEGACY_ATTACHMENT_LABEL_RE = re.compile(r"^附件\([1-9]\d*\)$")
 DEFAULT_ONLINE_LEGACY_BASE_URL = "https://www.builderp.cn/SCBSLY_V2"
 DEFAULT_LEGACY_FILE_ROOTS = (
     "/mnt/legacy-files",
@@ -379,6 +381,7 @@ class FileDownloadHandler(BaseIntentHandler):
             value = getattr(record, field, "")
             if isinstance(value, str):
                 refs.extend(_split_legacy_refs(value))
+        refs.extend(_legacy_inline_attachment_refs(getattr(record, "raw_payload", "")))
         return list(dict.fromkeys(refs))
 
 
@@ -395,6 +398,33 @@ def _split_legacy_refs(value: str) -> list[str]:
         if clean and "://" not in clean:
             refs.append(clean)
     return refs
+
+
+def _legacy_inline_attachment_refs(raw_payload: Any) -> list[str]:
+    if not raw_payload:
+        return []
+    if isinstance(raw_payload, str):
+        try:
+            payload = json.loads(raw_payload)
+        except (TypeError, ValueError, json.JSONDecodeError):
+            return []
+    elif isinstance(raw_payload, dict):
+        payload = raw_payload
+    else:
+        return []
+    refs: list[str] = []
+    for key, label_value in payload.items():
+        key_text = str(key or "").strip()
+        if not key_text.endswith("_FJ"):
+            continue
+        label_text = str(label_value or "").strip()
+        if not LEGACY_ATTACHMENT_LABEL_RE.match(label_text):
+            continue
+        source_key = key_text[:-3]
+        ref = str(payload.get(source_key) or "").strip()
+        if ref and "://" not in ref:
+            refs.append(ref)
+    return list(dict.fromkeys(refs))
 
 
 def _fetch_online_legacy_file_by_bill_id(bill_id: str) -> dict[str, Any] | None:

--- a/addons/smart_core/tests/test_file_download_locator_policy.py
+++ b/addons/smart_core/tests/test_file_download_locator_policy.py
@@ -153,6 +153,15 @@ class TestFileDownloadLocatorPolicy(unittest.TestCase):
         self.assertIn("other", refs)
         self.assertNotIn("legacy-file://ignored/path", refs)
 
+    def test_extracts_inline_legacy_attachment_ref_from_raw_payload(self):
+        module = _load_handler()
+
+        refs = module._legacy_inline_attachment_refs(
+            '{"f_FDWB":"228e3e4f51e8713919fecb4f08b4a485","f_FDWB_FJ":"附件(1)","other_FJ":"not-an-attachment"}'
+        )
+
+        self.assertEqual(refs, ["228e3e4f51e8713919fecb4f08b4a485"])
+
     def test_resolves_legacy_userfile_path_when_url_keeps_uploadfile_prefix(self):
         module = _load_handler()
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary

- Let `file.download` extract legacy BillIds from inline direct-acceptance payload fields where `field_FJ` is a valid `附件(n)` display label.
- Keep the extraction generic for old-system rows such as `f_FDWB=...` plus `f_FDWB_FJ=附件(1)`.
- Add a focused unit test for inline attachment reference extraction.

## Root Cause

The visible-field fix converted `方单` values such as `f_FDWB` to display as `附件(1)`, but the download handler still only looked at `attachment_ref`, `line_attachment_ref`, and a few standard legacy id fields. For `方单`, the actual BillId is embedded in `raw_payload.f_FDWB`, so clicking `附件(1)` could not locate the old-system file and returned `附件不存在`.

## Validation

- `python3 addons/smart_core/tests/test_file_download_locator_policy.py`
- `python3 addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py`
- `python3 -m py_compile addons/smart_core/handlers/file_download.py addons/smart_core/tests/test_file_download_locator_policy.py addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py`
- Daily server HTTP login as `wutao`: `file.download` for `sc.legacy.direct.acceptance.fact` `res_id=16952` returns `结算单（鹿为）20260129.pdf`, `application/pdf`, non-empty data.
- Daily server browser click on `方单 / FDGL-20260201-001 / 附件(1)`: no alert dialogs, `file.download` 200, PDF preview popup opened.