### PR TITLE
Tighten legacy attachment availability

### DIFF
--- a/addons/smart_core/handlers/file_download.py
+++ b/addons/smart_core/handlers/file_download.py
@@ -372,9 +372,14 @@ class FileDownloadHandler(BaseIntentHandler):
             "attachment_ref",
             "attachment_links",
             "line_attachment_ref",
+            "legacy_pid",
+            "legacy_header_id",
+            "legacy_contract_id",
             "legacy_record_id",
             "legacy_source_id",
             "legacy_file_id",
+            "contract_no",
+            "document_no",
         ):
             if field not in fields:
                 continue

--- a/addons/smart_core/tests/test_file_download_locator_policy.py
+++ b/addons/smart_core/tests/test_file_download_locator_policy.py
@@ -162,6 +162,32 @@ class TestFileDownloadLocatorPolicy(unittest.TestCase):
 
         self.assertEqual(refs, ["228e3e4f51e8713919fecb4f08b4a485"])
 
+    def test_uses_legacy_carrier_fields_as_attachment_refs(self):
+        module = _load_handler()
+
+        class _Record:
+            _fields = {
+                "legacy_pid": object(),
+                "legacy_contract_id": object(),
+                "contract_no": object(),
+                "document_no": object(),
+                "raw_payload": object(),
+            }
+            legacy_pid = "17799398042030000"
+            legacy_contract_id = "7508903432694e2897fe74484e2236e6"
+            contract_no = "GYSHT-20210926-003"
+            document_no = "202109170844-1"
+            raw_payload = ""
+
+        handler = module.FileDownloadHandler(env=_Env())
+
+        refs = handler._legacy_attachment_refs(_Record())
+
+        self.assertIn("17799398042030000", refs)
+        self.assertIn("7508903432694e2897fe74484e2236e6", refs)
+        self.assertIn("GYSHT-20210926-003", refs)
+        self.assertIn("202109170844-1", refs)
+
     def test_resolves_legacy_userfile_path_when_url_keeps_uploadfile_prefix(self):
         module = _load_handler()
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/scripts/migration/legacy_attachment_text_availability_cleanup.py
+++ b/scripts/migration/legacy_attachment_text_availability_cleanup.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Hide legacy attachment count labels when no downloadable file exists.
+
+Run in Odoo shell. Set APPLY=1 to write.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from urllib.request import Request, urlopen
+
+
+APPLY = os.environ.get("APPLY") == "1"
+CHECK_ONLINE = os.environ.get("CHECK_ONLINE") == "1"
+ONLINE_WORKERS = int(os.environ.get("ONLINE_WORKERS") or "32")
+ONLINE_TIMEOUT = float(os.environ.get("ONLINE_TIMEOUT") or "5")
+ONLINE_LIMIT = int(os.environ.get("ONLINE_LIMIT") or "0")
+ONLINE_BASE = os.environ.get("SC_ONLINE_LEGACY_BASE_URL") or "https://www.builderp.cn/SCBSLY_V2"
+ATTACHMENT_LABEL_RE = re.compile(r"^附件\([1-9]\d*\)$")
+
+SPECS = {
+    "sc.legacy.self.funding.fact": {
+        "table": "sc_legacy_self_funding_fact",
+        "ref_fields": ("legacy_record_id", "legacy_header_id", "legacy_pid", "document_no"),
+    },
+    "sc.legacy.supplier.contract.pricing.fact": {
+        "table": "sc_legacy_supplier_contract_pricing_fact",
+        "ref_fields": ("legacy_contract_id", "contract_no", "document_no"),
+    },
+}
+
+
+def clean(value):
+    return str(value or "").strip()
+
+
+def online_has_file(ref: str) -> bool:
+    if not ref:
+        return False
+    url = f"{ONLINE_BASE.rstrip('/')}/api/System/FileApi/GetFileByBillId?BillId={ref}"
+    try:
+        request = Request(url, headers={"User-Agent": "Mozilla/5.0"})
+        with urlopen(request, timeout=ONLINE_TIMEOUT) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+    except Exception:
+        return False
+    rows = payload.get("Data") if isinstance(payload, dict) else None
+    if not isinstance(rows, list):
+        return False
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        if str(row.get("DEL") or "0") not in ("0", "False", "false", ""):
+            continue
+        if clean(row.get("ATTR_PATH")):
+            return True
+    return False
+
+
+def online_hits(refs: set[str]) -> set[str]:
+    hits: set[str] = set()
+    checked = 0
+    failed = 0
+    ref_values = sorted(refs)
+    if ONLINE_LIMIT > 0:
+        ref_values = ref_values[:ONLINE_LIMIT]
+    with ThreadPoolExecutor(max_workers=ONLINE_WORKERS) as pool:
+        future_map = {pool.submit(online_has_file, ref): ref for ref in ref_values}
+        for future in as_completed(future_map):
+            ref = future_map[future]
+            checked += 1
+            try:
+                if future.result():
+                    hits.add(ref)
+            except Exception:
+                failed += 1
+                continue
+    return hits, checked, failed
+
+
+def file_index_hits(refs: set[str]) -> set[str]:
+    if not refs or "sc.legacy.file.index" not in env:  # noqa: F821
+        return set()
+    FileIndex = env["sc.legacy.file.index"].sudo().with_context(active_test=False)  # noqa: F821
+    hits: set[str] = set()
+    ref_list = sorted(refs)
+    for index in range(0, len(ref_list), 800):
+        chunk = ref_list[index:index + 800]
+        rows = FileIndex.search_read(
+            [
+                ("active", "=", True),
+                "|",
+                "|",
+                "|",
+                "|",
+                ("bill_id", "in", chunk),
+                ("legacy_pid", "in", chunk),
+                ("business_id", "in", chunk),
+                ("legacy_file_id", "in", chunk),
+                ("legacy_file_key", "in", chunk),
+            ],
+            ["bill_id", "legacy_pid", "business_id", "legacy_file_id", "legacy_file_key"],
+        )
+        for row in rows:
+            for field in ("bill_id", "legacy_pid", "business_id", "legacy_file_id", "legacy_file_key"):
+                value = clean(row.get(field))
+                if value in refs:
+                    hits.add(value)
+    return hits
+
+
+report = {"apply": APPLY, "models": {}}
+
+for model_name, spec in SPECS.items():
+    if model_name not in env:  # noqa: F821
+        continue
+    Model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+    records = Model.search([("attachment_text", "=like", "附件(%)")])
+    rows = []
+    all_refs: set[str] = set()
+    for rec in records:
+        if not ATTACHMENT_LABEL_RE.match(clean(rec.attachment_text)):
+            continue
+        refs = []
+        for field in spec["ref_fields"]:
+            value = clean(getattr(rec, field, ""))
+            if value:
+                refs.append(value)
+                all_refs.add(value)
+        rows.append((rec, list(dict.fromkeys(refs))))
+
+    local_hits = file_index_hits(all_refs)
+    if CHECK_ONLINE:
+        remote_hits, online_checked, online_failed = online_hits(all_refs - local_hits)
+    else:
+        remote_hits, online_checked, online_failed = set(), 0, 0
+    usable_refs = local_hits | remote_hits
+    to_clear = [rec for rec, refs in rows if not any(ref in usable_refs for ref in refs)]
+    clear_ids = {rec.id for rec in to_clear}
+
+    if APPLY and to_clear:
+        for index in range(0, len(to_clear), 500):
+            Model.browse([rec.id for rec in to_clear[index:index + 500]]).write({"attachment_text": False})
+        env.cr.commit()  # noqa: F821
+
+    report["models"][model_name] = {
+        "candidate_rows": len(rows),
+        "candidate_refs": len(all_refs),
+        "local_hit_refs": len(local_hits),
+        "online_hit_refs": len(remote_hits),
+        "online_check_enabled": CHECK_ONLINE,
+        "online_checked_refs": online_checked,
+        "online_failed_refs": online_failed,
+        "online_limit_refs": ONLINE_LIMIT,
+        "online_timeout_seconds": ONLINE_TIMEOUT,
+        "kept_rows": len(rows) - len(to_clear),
+        "cleared_rows": len(to_clear),
+        "sample_cleared": [
+            {
+                "id": rec.id,
+                "document_no": clean(getattr(rec, "document_no", "")),
+                "refs": refs,
+            }
+            for rec, refs in [(rec, refs) for rec, refs in rows if rec.id in clear_ids][:20]
+        ],
+    }
+
+print(json.dumps(report, ensure_ascii=False, indent=2))


### PR DESCRIPTION
## Summary
- expand legacy attachment fallback refs to cover self-funding and supplier contract pricing carriers
- add a cleanup script to hide legacy attachment labels with no deployed file index
- cover the added carrier fields in file download locator tests

## Verification
- `python3 addons/smart_core/tests/test_file_download_locator_policy.py`
- `python3 addons/smart_construction_core/tests/test_legacy_direct_acceptance_attachment_display.py`
- `python3 -m py_compile addons/smart_core/handlers/file_download.py addons/smart_core/tests/test_file_download_locator_policy.py scripts/migration/legacy_attachment_text_availability_cleanup.py`
- server cleanup dry-run after apply: self-funding 225 kept / 0 cleared, supplier pricing 8 kept / 0 cleared
- server full download audit: self-funding 225/225 ok, supplier pricing 8/8 ok