### PR TITLE
Fallback to source legacy file path

### DIFF
--- a/addons/smart_core/handlers/file_download.py
+++ b/addons/smart_core/handlers/file_download.py
@@ -276,7 +276,7 @@ class FileDownloadHandler(BaseIntentHandler):
         )
         if not file_index:
             return ""
-        return file_index.preview_path or file_index.file_path or ""
+        return _legacy_file_index_relative_path(file_index)
 
     def _legacy_attachment_for_record(self, model: str, res_id: int):
         if "sc.legacy.file.index" not in self.env:
@@ -305,7 +305,7 @@ class FileDownloadHandler(BaseIntentHandler):
         )
         if not file_index:
             return self._online_legacy_attachment_for_refs(model, res_id, legacy_refs)
-        path = (file_index.preview_path or file_index.file_path or "").strip()
+        path = _legacy_file_index_relative_path(file_index)
         if not path:
             return self._online_legacy_attachment_for_refs(model, res_id, legacy_refs)
         url = LEGACY_FILE_URL_PREFIX + path.lstrip("/")
@@ -464,6 +464,18 @@ def _is_online_legacy_file_url(url: str) -> bool:
         return False
     base_url = os.environ.get("SC_ONLINE_LEGACY_BASE_URL", DEFAULT_ONLINE_LEGACY_BASE_URL).rstrip("/")
     return clean.startswith(f"{base_url}/Api/System/FileApi/ShowFileById/")
+
+
+def _legacy_file_index_relative_path(file_index) -> str:
+    values = [
+        str(getattr(file_index, "preview_path", "") or "").strip(),
+        str(getattr(file_index, "file_path", "") or "").strip(),
+    ]
+    values = [value for value in values if value]
+    for value in values:
+        if _resolve_legacy_file_path(value):
+            return value
+    return values[0] if values else ""
 
 
 def _read_online_legacy_file_url(url: str, fallback_name: str = "", fallback_mimetype: str = "") -> dict[str, Any]:

--- a/addons/smart_core/tests/test_file_download_locator_policy.py
+++ b/addons/smart_core/tests/test_file_download_locator_policy.py
@@ -226,6 +226,30 @@ class TestFileDownloadLocatorPolicy(unittest.TestCase):
                 else:
                     os.environ["SC_LEGACY_FILE_ROOTS"] = old_value
 
+    def test_file_index_path_falls_back_when_preview_file_missing(self):
+        module = _load_handler()
+
+        class _FileIndex:
+            preview_path = "UploadFile/UserFile/2026/missing-preview.html"
+            file_path = "UploadFile/UserFile/2026/source.pdf"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            target = Path(tmpdir) / "UserFile" / "2026" / "source.pdf"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"x")
+            old_value = os.environ.get("SC_LEGACY_FILE_ROOTS")
+            os.environ["SC_LEGACY_FILE_ROOTS"] = tmpdir
+            try:
+                self.assertEqual(
+                    module._legacy_file_index_relative_path(_FileIndex()),
+                    "UploadFile/UserFile/2026/source.pdf",
+                )
+            finally:
+                if old_value is None:
+                    os.environ.pop("SC_LEGACY_FILE_ROOTS", None)
+                else:
+                    os.environ["SC_LEGACY_FILE_ROOTS"] = old_value
+
     def test_rejects_legacy_path_traversal(self):
         module = _load_handler()
 


### PR DESCRIPTION
## Summary
- choose an existing legacy file index path when preview and source paths are both present
- fall back to `file_path` when `preview_path` points to a missing preview file
- cover the fallback in file download locator tests

## Verification
- `python3 addons/smart_core/tests/test_file_download_locator_policy.py`
- `python3 -m py_compile addons/smart_core/handlers/file_download.py addons/smart_core/tests/test_file_download_locator_policy.py`
- production sampling found missing preview HTML paths, while source files are available through the legacy attachment mount