### PR TITLE
Close out user business data enrichment tools

### DIFF
--- a/scripts/migration/direct_project_business_data_gap_probe.py
+++ b/scripts/migration/direct_project_business_data_gap_probe.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Read-only data gap probe for the direct-project business menu supplement."""
+
+from __future__ import annotations
+
+import ast
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_DOCUMENT = "user:direct_project_business_menu:2026-05-30"
+OUTPUT_JSON_NAME = "direct_project_business_data_gap_probe_result_v1.json"
+OUTPUT_REPORT_NAME = "direct_project_business_data_gap_probe_report_v1.md"
+
+SCBS55_ONLINE_COUNTS = {
+    "施工合同": {"old_entry": "施工合同", "old_count": 182},
+    "报价单": {"old_entry": "报价单", "old_count": 126},
+    "材料结算单": {"old_entry": "材料结算单", "old_count": 1214},
+    "方单": {"old_entry": "方单", "old_count": 252},
+    "零星用工": {"old_entry": "零星用工", "old_count": 8769},
+    "分包方单": {"old_entry": "分包方单", "old_count": 721},
+    "机械台班记录": {"old_entry": "机械台班记录", "old_count": 17495},
+    "租入": {"old_entry": "租入", "old_count": 166},
+    "还租": {"old_entry": "还租", "old_count": 37},
+    "租赁结算单": {"old_entry": "租赁结算单", "old_count": 699},
+    "项目费用报销单": {"old_entry": "报销申请", "old_count": 9},
+    "管理人员工资表": {"old_entry": "管理人员工资表", "old_count": 233},
+    "油卡登记": {"old_entry": "油卡登记", "old_count": 8},
+    "充值登记": {"old_entry": "充值登记", "old_count": 32},
+    "加油登记": {"old_entry": "加油登记", "old_count": 500},
+    "支付申请": {"old_entry": "支付申请", "old_count": 2595},
+    "工程进度收款": {"old_entry": "到款确认表", "old_count": 220},
+    "往来单位付款": {"old_entry": "往来单位付款", "old_count": 10342},
+    "工程结算单": {"old_entry": "工程结算单", "old_count": 37},
+    "进项上报": {"old_entry": "进项上报", "old_count": 6389},
+}
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.append(Path("/mnt/artifacts/migration"))
+    candidates.append(Path(f"/tmp/direct_project_business_menu/{env.cr.dbname}"))  # noqa: F821
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".write_probe"
+            probe.write_text("ok\n", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except Exception:
+            continue
+    return Path(f"/tmp/direct_project_business_menu/{env.cr.dbname}")  # noqa: F821
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_domain(action) -> list[Any]:
+    if not action or not action.domain:
+        return []
+    try:
+        parsed = ast.literal_eval(action.domain)
+        return parsed if isinstance(parsed, list) else []
+    except Exception:
+        return []
+
+
+def search_count(model_name: str, domain: list[Any]) -> tuple[int, str]:
+    if not model_name or model_name not in env:  # noqa: F821
+        return 0, "missing_model"
+    try:
+        return env[model_name].sudo().with_context(active_test=False).search_count(domain), ""  # noqa: F821
+    except Exception as exc:  # noqa: BLE001
+        return 0, repr(exc)
+
+
+def status_for(row: dict[str, Any]) -> str:
+    if row["model_missing"]:
+        return "FAIL_MODEL_MISSING"
+    if not row["action_id"]:
+        return "FAIL_ACTION_MISSING"
+    if row["count_error"]:
+        return "FAIL_COUNT_ERROR"
+    if row["old_count"] is not None and row["delivered_count"] < row["old_count"]:
+        return "REVIEW_OLD_ONLINE_GAP"
+    if row["delivered_count"] == 0:
+        return "REVIEW_ZERO_DATA"
+    return "PASS"
+
+
+def report(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Direct Project Business Data Gap Probe v1",
+        "",
+        f"Status: {payload['status']}",
+        f"Database: {payload['database']}",
+        f"Source Document: {payload['source_document']}",
+        f"Generated At: {payload['generated_at']}",
+        "",
+        "| group | menu | model | action | delivered | old online | status |",
+        "| --- | --- | --- | ---: | ---: | ---: | --- |",
+    ]
+    for row in payload["rows"]:
+        old_count = "" if row["old_count"] is None else str(row["old_count"])
+        lines.append(
+            f"| {row['group']} | {row['name']} | {row['target_model']} | {row['action_id'] or ''} | "
+            f"{row['delivered_count']} | {old_count} | {row['status']} |"
+        )
+    lines.extend(["", "## Review Rows", "", "```json", json.dumps(payload["review_rows"], ensure_ascii=False, indent=2, sort_keys=True), "```", ""])
+    return "\n".join(lines)
+
+
+artifact_dir = artifact_root()
+Plan = env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False)  # noqa: F821
+rows = []
+
+for record in Plan.search([("source_document", "=", SOURCE_DOCUMENT)], order="priority_sequence"):
+    domain = parse_domain(record.target_action_id)
+    count, error = search_count(record.target_model, domain)
+    old = SCBS55_ONLINE_COUNTS.get(record.legacy_menu_name, {})
+    row = {
+        "group": record.legacy_menu_group,
+        "name": record.legacy_menu_name,
+        "business_domain": record.business_domain,
+        "target_model": record.target_model,
+        "model_missing": bool(record.target_model and record.target_model not in env),  # noqa: F821
+        "action_id": record.target_action_id.id if record.target_action_id else 0,
+        "action_name": record.target_action_id.name if record.target_action_id else "",
+        "action_domain": domain,
+        "delivered_count": count,
+        "count_error": error,
+        "old_reference_entry": old.get("old_entry", ""),
+        "old_count": old.get("old_count"),
+        "overlay_source": SOURCE_DOCUMENT,
+        "scbs55_baseline_preserved": True,
+    }
+    row["status"] = status_for(row)
+    rows.append(row)
+
+review_rows = [row for row in rows if row["status"] != "PASS"]
+payload = {
+    "status": "PASS" if not review_rows else "REVIEW",
+    "mode": "direct_project_business_data_gap_probe",
+    "database": env.cr.dbname,  # noqa: F821
+    "source_document": SOURCE_DOCUMENT,
+    "generated_at": datetime.now(timezone.utc).isoformat(),
+    "row_count": len(rows),
+    "pass_count": len(rows) - len(review_rows),
+    "review_count": len(review_rows),
+    "rows": rows,
+    "review_rows": review_rows,
+}
+write_json(artifact_dir / OUTPUT_JSON_NAME, payload)
+(artifact_dir / OUTPUT_REPORT_NAME).write_text(report(payload), encoding="utf-8")
+print("DIRECT_PROJECT_BUSINESS_DATA_GAP_PROBE=" + json.dumps({key: payload[key] for key in ("status", "database", "row_count", "pass_count", "review_count")}, ensure_ascii=False, sort_keys=True))

--- a/scripts/migration/direct_project_business_menu_plan_write.py
+++ b/scripts/migration/direct_project_business_menu_plan_write.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""Seed the direct-project business menu supplement beside the SCBS55 baseline."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_DOCUMENT = "user:direct_project_business_menu:2026-05-30"
+OUTPUT_JSON_NAME = "direct_project_business_menu_plan_write_result_v1.json"
+
+
+MENU_GROUPS: list[tuple[str, list[str]]] = [
+    ("合同类单据", ["施工合同", "分包合同", "租赁合同", "供货合同", "劳务合同", "机械合同（合同）"]),
+    ("材料管理类单据", ["材料计划", "报价单", "入库", "材料结算单", "库存统计表（新）"]),
+    ("劳务管理类单据", ["方单", "零星用工", "劳务结算"]),
+    ("分包管理类单据", ["分包方单", "分包结算单"]),
+    ("机械与租赁管理类单据", ["机械台班记录", "机械结算单", "租入", "还租", "租赁结算单"]),
+    (
+        "费用与资金管理类单据",
+        [
+            "项目费用报销单",
+            "管理人员工资表",
+            "油卡登记",
+            "充值登记",
+            "加油登记",
+            "支付申请",
+            "工程进度收款",
+            "往来单位付款",
+            "工程结算单",
+            "进项上报",
+            "总包进项上报",
+            "成本统计表（数据）",
+        ],
+    ),
+    ("项目管理类单据", ["施工日志（新）"]),
+]
+
+
+TARGETS: dict[str, dict[str, Any]] = {
+    "施工合同": {"model": "construction.contract", "domain": "合同", "aliases": ["SCBS55#3 施工合同"]},
+    "分包合同": {"model": "sc.subcontract.register", "domain": "分包", "fallback": "construction.contract"},
+    "租赁合同": {"model": "sc.material.rental.order", "domain": "租赁", "fallback": "construction.contract"},
+    "供货合同": {"model": "sc.expense.contract.ledger", "domain": "材料", "fallback": "sc.legacy.supplier.contract.pricing.fact"},
+    "劳务合同": {"model": "sc.labor.contract", "domain": "劳务", "fallback": "sc.legacy.labor.subcontract.fact"},
+    "机械合同（合同）": {"model": "sc.equipment.contract", "domain": "机械", "fallback": "sc.legacy.equipment.lease.fact"},
+    "材料计划": {"model": "project.material.plan", "domain": "材料"},
+    "报价单": {"model": "sc.material.rfq", "domain": "材料"},
+    "入库": {"model": "sc.material.inbound", "domain": "材料"},
+    "材料结算单": {"model": "sc.material.settlement", "domain": "材料"},
+    "库存统计表（新）": {"model": "sc.material.stock.summary", "domain": "材料", "aliases": ["SCBS55#46 库存统计表（新）"]},
+    "方单": {"model": "sc.labor.request", "domain": "劳务"},
+    "零星用工": {"model": "sc.labor.usage", "domain": "劳务"},
+    "劳务结算": {"model": "sc.labor.settlement", "domain": "劳务"},
+    "分包方单": {"model": "sc.subcontract.register", "domain": "分包"},
+    "分包结算单": {"model": "sc.subcontract.settlement", "domain": "分包"},
+    "机械台班记录": {"model": "sc.equipment.usage", "domain": "机械"},
+    "机械结算单": {"model": "sc.equipment.settlement", "domain": "机械"},
+    "租入": {"model": "sc.material.rental.order", "domain": "租赁"},
+    "还租": {"model": "sc.material.rental.order", "domain": "租赁"},
+    "租赁结算单": {"model": "sc.material.rental.settlement", "domain": "租赁"},
+    "项目费用报销单": {"model": "sc.expense.claim", "domain": "费用", "aliases": ["SCBS55#24 报销申请"]},
+    "管理人员工资表": {"model": "sc.hr.payroll.document", "domain": "薪资"},
+    "油卡登记": {"model": "sc.fund.account.operation", "domain": "资金", "action_name": "余额调整"},
+    "充值登记": {"model": "sc.fund.account.operation", "domain": "资金", "action_name": "余额调整"},
+    "加油登记": {"model": "sc.fund.account.operation", "domain": "资金", "action_name": "余额调整"},
+    "支付申请": {"model": "payment.request", "domain": "资金", "aliases": ["SCBS55#29 支付申请"]},
+    "工程进度收款": {"model": "sc.receipt.income", "domain": "收款", "aliases": ["SCBS55#35 到款确认表"]},
+    "往来单位付款": {"model": "sc.payment.execution", "domain": "付款", "aliases": ["SCBS55#31 往来单位付款"]},
+    "工程结算单": {"model": "sc.settlement.order", "domain": "结算"},
+    "进项上报": {"model": "sc.legacy.invoice.tax.fact", "domain": "税务", "aliases": ["SCBS55#42 进项上报"]},
+    "总包进项上报": {"model": "sc.general.contract.input.invoice", "domain": "税务", "fallback": "sc.legacy.invoice.tax.fact"},
+    "成本统计表（数据）": {"model": "sc.comprehensive.cost.summary", "domain": "报表", "aliases": ["SCBS55#48 成本统计表（综合）"]},
+    "施工日志（新）": {"model": "sc.construction.diary", "domain": "项目", "aliases": ["施工日志"]},
+}
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.append(Path("/mnt/artifacts/migration"))
+    candidates.append(Path(f"/tmp/direct_project_business_menu/{env.cr.dbname}"))  # noqa: F821
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            probe = candidate / ".write_probe"
+            probe.write_text("ok\n", encoding="utf-8")
+            probe.unlink()
+            return candidate
+        except Exception:
+            continue
+    return Path(f"/tmp/direct_project_business_menu/{env.cr.dbname}")  # noqa: F821
+
+
+def ensure_allowed_db() -> None:
+    allowlist = {
+        item.strip()
+        for item in os.getenv("MIGRATION_REPLAY_DB_ALLOWLIST", env.cr.dbname).split(",")  # noqa: F821
+        if item.strip()
+    }
+    if env.cr.dbname not in allowlist:  # noqa: F821
+        raise RuntimeError({"db_name_not_allowed_for_replay": env.cr.dbname, "allowlist": sorted(allowlist)})  # noqa: F821
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def action_for(model: str, menu_name: str):
+    Action = env["ir.actions.act_window"].sudo()  # noqa: F821
+    action = Action.search([("res_model", "=", model), ("name", "=", menu_name)], order="id", limit=1)
+    return action or Action.search([("res_model", "=", model)], order="id", limit=1)
+
+
+def target_action_for(target: dict[str, Any], model: str, menu_name: str):
+    action_name = target.get("action_name")
+    if action_name:
+        Action = env["ir.actions.act_window"].sudo()  # noqa: F821
+        action = Action.search([("res_model", "=", model), ("name", "=", action_name)], order="id", limit=1)
+        if action:
+            return action
+    if menu_name == "管理人员工资表":
+        Action = env["ir.actions.act_window"].sudo()  # noqa: F821
+        action = Action.search([("res_model", "=", model), ("name", "=", "工资登记")], order="id", limit=1)
+        if action:
+            return action
+    return action_for(model, menu_name)
+
+
+ensure_allowed_db()
+artifact_dir = artifact_root()
+Plan = env["sc.legacy.user.priority.menu.plan"].sudo().with_context(active_test=False)  # noqa: F821
+IrModel = env["ir.model"].sudo()  # noqa: F821
+
+created = 0
+updated = 0
+missing_models: list[dict[str, str]] = []
+missing_actions: list[dict[str, str]] = []
+sequence = 10
+
+for group, names in MENU_GROUPS:
+    for name in names:
+        target = TARGETS[name]
+        target_model = target["model"]
+        model_record = IrModel.search([("model", "=", target_model)], limit=1)
+        fallback_model = target.get("fallback")
+        if not model_record and fallback_model:
+            target_model = fallback_model
+            model_record = IrModel.search([("model", "=", target_model)], limit=1)
+        action = target_action_for(target, target_model, name) if model_record else env["ir.actions.act_window"].browse()  # noqa: F821
+        status = "runtime_spec_landed" if model_record and action else "view_gap_audit_required"
+        if not model_record:
+            missing_models.append({"name": name, "target_model": target_model})
+        elif not action:
+            missing_actions.append({"name": name, "target_model": target_model})
+        values = {
+            "priority_sequence": sequence,
+            "source_document": SOURCE_DOCUMENT,
+            "legacy_menu_group": group,
+            "legacy_menu_name": name,
+            "business_domain": target["domain"],
+            "target_model": target_model if model_record else "",
+            "target_model_id": model_record.id if model_record else False,
+            "target_action_id": action.id if action else False,
+            "candidate_models_json": [
+                {"model": target["model"], "role": "primary", "exists": bool(IrModel.search([("model", "=", target["model"])], limit=1))},
+                *(
+                    [{"model": fallback_model, "role": "fallback", "exists": bool(model_record)}]
+                    if fallback_model and fallback_model != target["model"]
+                    else []
+                ),
+            ],
+            "list_field_contract": [],
+            "search_contract": {
+                "source": "user_direct_project_business_menu",
+                "related_scbs55_entries": target.get("aliases", []),
+                "menu_set": "direct_project",
+                "must_not_overwrite_scbs55": True,
+            },
+            "form_section_contract": [],
+            "surface_contract_status": status,
+            "runtime_gap_summary": "" if status == "runtime_spec_landed" else "direct_project_menu_target_missing_or_action_missing",
+            "current_round_action": "specialized_carrier_exists" if status == "runtime_spec_landed" else "next_topic_required",
+            "target_iteration": "direct_project_business_data_enrichment_20260530",
+            "old_system_path": f"直营项目系统菜单/{group}/{name}",
+            "legacy_source_tables": "",
+            "legacy_field_list": "",
+            "extracted_evidence": "User-provided direct-project menu supplement; seeded as an overlay beside SCBS55, not a replacement.",
+            "next_development_topic": "" if status == "runtime_spec_landed" else f"补齐{name}承载模型或独立 action/domain",
+            "next_scope": "补旧系统字段/数据采集、目标投影和用户可见验收。" if status != "runtime_spec_landed" else "",
+            "replay_status": "pending",
+            "active": True,
+        }
+        existing = Plan.search(
+            [
+                ("source_document", "=", SOURCE_DOCUMENT),
+                ("legacy_menu_group", "=", group),
+                ("legacy_menu_name", "=", name),
+            ],
+            limit=1,
+        )
+        if existing:
+            existing.write(values)
+            updated += 1
+        else:
+            Plan.create(values)
+            created += 1
+        sequence += 10
+
+env.cr.commit()  # noqa: F821
+
+payload = {
+    "status": "PASS" if not missing_models and not missing_actions else "REVIEW",
+    "mode": "direct_project_business_menu_plan_write",
+    "database": env.cr.dbname,  # noqa: F821
+    "source_document": SOURCE_DOCUMENT,
+    "expected_rows": sum(len(names) for _, names in MENU_GROUPS),
+    "created": created,
+    "updated": updated,
+    "missing_models": missing_models,
+    "missing_actions": missing_actions,
+    "decision": "direct_project_menu_overlay_landed_without_overwriting_scbs55",
+}
+write_json(artifact_dir / OUTPUT_JSON_NAME, payload)
+print("DIRECT_PROJECT_BUSINESS_MENU_PLAN_WRITE=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))

--- a/scripts/migration/scbs55_finance_surfaces_online_patch.py
+++ b/scripts/migration/scbs55_finance_surfaces_online_patch.py
@@ -123,6 +123,10 @@ def write_payload(record, payload: dict[str, str]) -> None:
     )
 
 
+def safe_vals(model, vals: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in vals.items() if key in model._fields}
+
+
 def project_for(row: dict[str, Any]):
     Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
     legacy_project_id = clean(row.get("XMID") or row.get("XMID$CWGL_FYBX_CB"))
@@ -245,10 +249,10 @@ def import_expense(seq: int, rows: list[dict[str, Any]]) -> dict[str, Any]:
             "active": True,
         }
         if rec:
-            rec.write(vals)
+            rec.write(safe_vals(Claim, vals))
             updated += 1
         else:
-            rec = Claim.create(vals)
+            rec = Claim.create(safe_vals(Claim, vals))
             created += 1
         write_payload(rec, visible_values(seq, row))
     stale = Claim.search([("legacy_source_model", "=", spec["surface"]), ("legacy_record_id", "not in", list(seen) or ["__none__"])])
@@ -296,10 +300,10 @@ def import_receipt(seq: int, rows: list[dict[str, Any]]) -> dict[str, Any]:
             "active": True,
         }
         if rec:
-            rec.write(vals)
+            rec.write(safe_vals(Receipt, vals))
             updated += 1
         else:
-            rec = Receipt.create(vals)
+            rec = Receipt.create(safe_vals(Receipt, vals))
             created += 1
         write_payload(rec, visible_values(seq, row))
     stale = Receipt.search([("legacy_source_model", "=", spec["surface"]), ("legacy_record_id", "not in", list(seen) or ["__none__"])])
@@ -349,10 +353,10 @@ def import_fund_operation(seq: int, rows: list[dict[str, Any]]) -> dict[str, Any
             "active": True,
         }
         if rec:
-            rec.write(vals)
+            rec.write(safe_vals(Operation, vals))
             updated += 1
         else:
-            rec = Operation.create(vals)
+            rec = Operation.create(safe_vals(Operation, vals))
             created += 1
         write_payload(rec, visible_values(seq, row))
     stale = Operation.search([("legacy_source_model", "=", spec["surface"]), ("legacy_record_id", "not in", list(seen) or ["__none__"])])
@@ -376,7 +380,9 @@ for seq in sorted(SPECS):
     elif seq == 32:
         created, updated, stale_hidden, final_count = import_fund_operation(seq, rows)
     domain = [("legacy_source_model", "=", spec["surface"])]
-    Action.browse(spec["action_id"]).write({"domain": repr(domain)})
+    action = Action.browse(spec["action_id"]).exists()
+    if action:
+        action.write({"domain": repr(domain)})
     results.append(
         {
             "seq": seq,

--- a/scripts/migration/scbsly_direct_project_gap_projection_write.py
+++ b/scripts/migration/scbsly_direct_project_gap_projection_write.py
@@ -1,0 +1,385 @@
+#!/usr/bin/env python3
+"""Project direct-project SCBSLY gap rows into existing business carriers.
+
+The source is the direct-project overlay, not the SCBS55 baseline.  Every row is
+tagged with an ``online_old_scbsly:*`` source so this can add data beside 55
+coverage without replacing or relabeling prior replay records.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import zlib
+from pathlib import Path
+from typing import Any
+
+
+FULL_ROWS_DIR = Path(os.getenv("SCBSLY_DIRECT_FULL_ROWS_DIR", "/mnt/artifacts/migration/scbsly_direct_20260530/full_rows"))
+OUTPUT_JSON_NAME = "scbsly_direct_project_gap_projection_write_result_v1.json"
+
+
+SPECS: list[dict[str, Any]] = [
+    {"table": "CGXBJ_CGXJD", "menu": "报价单", "model": "sc.material.rfq", "source_key": "legacy_fact"},
+    {"table": "T_JS_CLJSD", "menu": "材料结算单", "model": "sc.material.settlement", "source_key": "legacy_fact"},
+    {"table": "LW_Base_FDGL", "menu": "方单", "model": "sc.labor.request", "source_key": "legacy_fact"},
+    {"table": "SGGL_LWGL_LXYG", "menu": "零星用工", "model": "sc.labor.usage", "source_key": "legacy_fact"},
+    {"table": "SGGL_FBGL_FBFD", "menu": "分包方单", "model": "sc.subcontract.register", "source_key": "legacy_fact"},
+    {"table": "T_ZL_MachineShift", "menu": "机械台班记录", "model": "sc.equipment.usage", "source_key": "legacy_fact"},
+    {"table": "T_ZL_ZRD", "menu": "租入", "model": "sc.material.rental.order", "source_key": "legacy_fact"},
+    {"table": "T_ZL_HZD", "menu": "还租", "model": "sc.material.rental.order", "source_key": "legacy_fact"},
+    {"table": "T_ZL_ZLJSD", "menu": "租赁结算单", "model": "sc.material.rental.settlement", "source_key": "legacy_fact"},
+    {"table": "T_ZL_ZLJSD_JX", "menu": "租赁结算单", "model": "sc.material.rental.settlement", "source_key": "legacy_fact"},
+    {"table": "GLFY_GLRYGZB", "menu": "管理人员工资表", "model": "sc.hr.payroll.document", "source_key": "legacy_source"},
+    {"table": "D_LYXM_BG_BX_YKDJ", "menu": "油卡登记", "model": "sc.fund.account.operation", "source_key": "legacy_source"},
+    {"table": "D_LYXM_BG_BX_CZDJ", "menu": "充值登记", "model": "sc.fund.account.operation", "source_key": "legacy_source"},
+    {"table": "D_LYXM_BG_BX_JYDJ", "menu": "加油登记", "model": "sc.fund.account.operation", "source_key": "legacy_source"},
+    {"table": "D_LYXM_XMGL_XM_GCJSD", "menu": "工程结算单", "model": "sc.settlement.order", "source_key": "legacy_fact"},
+]
+
+
+def artifact_root() -> Path:
+    env_root = os.getenv("MIGRATION_ARTIFACT_ROOT")
+    candidates = [Path(env_root)] if env_root else []
+    candidates.extend([Path("/mnt/artifacts/migration"), Path("/tmp")])
+    for candidate in candidates:
+        try:
+            candidate.mkdir(parents=True, exist_ok=True)
+            return candidate
+        except Exception:
+            continue
+    return Path("/tmp")
+
+
+def clean(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def first(row: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        value = row.get(key)
+        if value not in (None, ""):
+            return value
+    return ""
+
+
+def to_float(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def to_date(value: Any):
+    text = clean(value)
+    return text[:10] if len(text) >= 10 else False
+
+
+def source_model(table: str) -> str:
+    return f"online_old_scbsly:{table}"
+
+
+def row_id(row: dict[str, Any]) -> str:
+    detail_keys = sorted(key for key in row if key.startswith(("Id$", "ID$")))
+    return clean(first(row, *detail_keys)) or clean(first(row, "Id", "ID", "id", "DJBH")) or clean(row.get("RowIndex"))
+
+
+def legacy_fact_id(table: str, row: dict[str, Any]) -> int:
+    token = f"{table}:{row_id(row)}".encode("utf-8")
+    return zlib.crc32(token) & 0x7FFFFFFF
+
+
+def safe_vals(model_name: str, vals: dict[str, Any]) -> dict[str, Any]:
+    fields = env[model_name]._fields  # noqa: F821
+    return {key: value for key, value in vals.items() if key in fields}
+
+
+def project_id(cache: dict[str, int | bool], row: dict[str, Any]):
+    legacy_id = clean(first(row, "XMID", "f_XMID"))
+    name = clean(first(row, "XMMC", "ProjectName", "f_GCMC"))
+    key = legacy_id or "__name__:" + name
+    if key in cache:
+        return cache[key]
+    Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+    project = False
+    if legacy_id:
+        project = Project.search([("legacy_project_id", "=", legacy_id)], limit=1)
+    if not project and name:
+        project = Project.search([("name", "=", name)], limit=1)
+    if not project:
+        project = Project.search([], order="id", limit=1)
+    cache[key] = project.id if project else False
+    return cache[key]
+
+
+def partner_id(cache: dict[str, int | bool], name: Any, supplier: bool = False):
+    key = clean(name) or ("旧系统未填供应商" if supplier else "")
+    if not key:
+        return False
+    if key in cache:
+        return cache[key]
+    Partner = env["res.partner"].sudo().with_context(active_test=False)  # noqa: F821
+    partner = Partner.search([("name", "=", key)], limit=1)
+    vals = {"name": key}
+    if supplier:
+        vals["supplier_rank"] = 1
+    if not partner:
+        partner = Partner.create(vals)
+    elif supplier and partner.supplier_rank <= 0:
+        partner.write({"supplier_rank": 1})
+    cache[key] = partner.id
+    return cache[key]
+
+
+def user_id(cache: dict[str, int | bool], legacy_id: Any, name: Any):
+    legacy = clean(legacy_id)
+    label = clean(name)
+    key = legacy or "__name__:" + label
+    if key in cache:
+        return cache[key]
+    user = False
+    if legacy:
+        profile = env["sc.legacy.user.profile"].sudo().search([("legacy_user_id", "=", legacy)], limit=1)  # noqa: F821
+        user = profile.user_id if profile else False
+    if not user and label:
+        user = env["res.users"].sudo().with_context(active_test=False).search([("name", "=", label)], limit=1)  # noqa: F821
+    cache[key] = user.id if user else False
+    return cache[key]
+
+
+def note_for(table: str, menu: str, row: dict[str, Any]) -> str:
+    return "\n".join(
+        [
+            f"旧系统直营项目菜单数据补充：{menu}",
+            f"source_table={table}",
+            f"legacy_record_id={row_id(row)}",
+            f"legacy_document_no={clean(first(row, 'DJBH', 'f_ZRDH', 'f_HZDH'))}",
+            f"legacy_document_state={clean(row.get('DJZT'))}",
+            f"legacy_project_id={clean(first(row, 'XMID', 'f_XMID'))}",
+            f"legacy_project_name={clean(first(row, 'XMMC', 'ProjectName', 'f_GCMC'))}",
+            f"legacy_payload={json.dumps(row, ensure_ascii=False, sort_keys=True)}",
+        ]
+    )
+
+
+def exists(model_name: str, spec: dict[str, Any], table: str, row: dict[str, Any]):
+    Model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+    if spec["source_key"] == "legacy_source":
+        domain = [("legacy_source_table", "=", table), ("legacy_source_id", "=", row_id(row))]
+        if "legacy_source_model" in Model._fields:
+            domain = [("legacy_source_model", "=", source_model(table)), ("legacy_record_id" if "legacy_record_id" in Model._fields else "legacy_source_id", "=", row_id(row))]
+        return Model.search(domain, limit=1)
+    return Model.search([("legacy_fact_model", "=", source_model(table)), ("legacy_fact_id", "=", legacy_fact_id(table, row))], limit=1)
+
+
+def base_legacy_vals(model_name: str, spec: dict[str, Any], table: str, row: dict[str, Any]) -> dict[str, Any]:
+    if spec["source_key"] == "legacy_source":
+        return safe_vals(
+            model_name,
+            {
+                "legacy_source_model": source_model(table),
+                "legacy_source_table": table,
+                "legacy_record_id": row_id(row),
+                "legacy_source_id": row_id(row),
+                "legacy_document_state": clean(row.get("DJZT")),
+                "legacy_document_no": clean(first(row, "DJBH", "f_ZRDH", "f_HZDH")),
+                "creator_legacy_user_id": clean(first(row, "LRRID", "CZRID", "DJRID", "ZYGLRID")),
+                "creator_name": clean(first(row, "LRR", "CZR", "DJR", "ZYGLR")),
+                "created_time": clean(row.get("LRSJ")) or False,
+            },
+        )
+    return safe_vals(
+        model_name,
+        {
+            "legacy_fact_model": source_model(table),
+            "legacy_fact_id": legacy_fact_id(table, row),
+            "legacy_fact_type": f"direct_project:{spec['menu']}",
+        },
+    )
+
+
+def vals_for(spec: dict[str, Any], row: dict[str, Any], caches: dict[str, dict[str, int | bool]]) -> dict[str, Any]:
+    table = spec["table"]
+    menu = spec["menu"]
+    model = spec["model"]
+    project = project_id(caches["project"], row)
+    partner_name = first(row, "XJDW", "GYDW", "f_LWDW", "SGDWMC", "FBS", "ZLDW", "f_SupplierName", "JSDW", "D_LYXM_SKDWMC", "FBR")
+    partner = partner_id(caches["partner"], partner_name, supplier=True)
+    doc_no = clean(first(row, "DJBH", "f_ZRDH", "f_HZDH")) or f"{menu}-{row_id(row)}"
+    date = to_date(first(row, "DJRQ", "XJSJ", "JSRQ", "f_LRSJ", "LRSJ", "f_DJRQ", "CZRQ", "JYRQ"))
+    note = note_for(table, menu, row)
+    vals: dict[str, Any]
+
+    if model == "sc.material.rfq":
+        vals = {"name": doc_no, "project_id": project, "selected_supplier_id": partner, "rfq_date": date, "contact_name": clean(row.get("LXR")), "contact_phone": clean(row.get("LXDH")), "state": "draft", "note": note}
+    elif model == "sc.material.settlement":
+        vals = {"name": doc_no, "project_id": project, "supplier_id": partner, "settlement_date": date, "state": "draft", "note": note}
+    elif model == "sc.labor.request":
+        vals = {"name": doc_no, "project_id": project, "request_date": date, "contractor_id": partner, "state": "draft", "note": note}
+    elif model == "sc.labor.usage":
+        vals = {
+            "name": doc_no,
+            "project_id": project,
+            "usage_date": date,
+            "labor_team": clean(first(row, "SGDWMC", "ZRDW", "SGY$SGGL_LWGL_LXYG_CB")) or "旧系统班组",
+            "contractor_id": partner,
+            "work_content": clean(first(row, "SGNR$SGGL_LWGL_LXYG_CB", "BZ", "BT")) or "旧系统零星用工",
+            "worker_qty": to_float(first(row, "RS$SGGL_LWGL_LXYG_CB"), 1.0) or 1.0,
+            "work_hours": to_float(first(row, "GSHJ$SGGL_LWGL_LXYG_CB", "GRHJ$SGGL_LWGL_LXYG_CB"), 1.0),
+            "foreman_name": clean(first(row, "ZDR", "LRR")),
+            "state": "draft",
+            "note": note,
+        }
+    elif model == "sc.subcontract.register":
+        vals = {"name": doc_no, "project_id": project, "register_date": date, "subcontract_scope": clean(first(row, "FBNR", "BT", "BZ")) or "旧系统分包方单", "subcontractor_id": partner, "state": "draft", "note": note}
+    elif model == "sc.equipment.usage":
+        vals = {
+            "name": doc_no,
+            "project_id": project,
+            "usage_date": date,
+            "equipment_name": clean(first(row, "JXMC$T_ZL_MachineShift_CB", "BZ")) or "旧系统机械",
+            "equipment_code": clean(row.get("JXID$T_ZL_MachineShift_CB")),
+            "usage_location": clean(first(row, "SGBW", "SGBW$T_ZL_MachineShift_CB", "XMMC")) or "旧系统施工部位",
+            "operator_name": clean(first(row, "D_LYXM_CYM", "LRR")) or "旧系统操作员",
+            "usage_qty": 1.0,
+            "usage_hours": to_float(first(row, "GZSJ$T_ZL_MachineShift_CB"), 1.0) or 1.0,
+            "supplier_id": partner,
+            "state": "draft",
+            "note": note,
+        }
+    elif model == "sc.material.rental.order":
+        vals = {"name": doc_no, "project_id": project, "supplier_id": partner, "rental_date": date, "state": "returned" if table == "T_ZL_HZD" else "draft", "note": note}
+    elif model == "sc.material.rental.settlement":
+        vals = {"name": doc_no, "project_id": project, "supplier_id": partner, "settlement_date": date, "state": "draft", "note": note}
+    elif model == "sc.hr.payroll.document":
+        amount = to_float(first(row, "BCSFGZZE", "BCYFGZZE"))
+        vals = {"name": doc_no, "fact_type": "salary_registration", "project_id": project, "business_date": date, "amount": amount, "gross_amount": amount, "net_salary": amount, "legacy_document_no": doc_no, "legacy_document_state": clean(row.get("DJZT")), "legacy_source_table": table, "legacy_source_id": row_id(row), "legacy_visible_note": note}
+    elif model == "sc.fund.account.operation":
+        amount = to_float(first(row, "CSJE", "CZZE", "JYJE"))
+        vals = {
+            "name": doc_no,
+            "operation_type": "balance_adjustment",
+            "operation_date": date,
+            "project_id": project,
+            "amount": amount,
+            "before_balance": 0.0,
+            "after_balance": amount if table != "D_LYXM_BG_BX_JYDJ" else 0.0,
+            "operation_reason": f"{menu}:{clean(first(row, 'YKKH', 'CZKH$D_LYXM_BG_BX_CZDJCB', 'JYKH', 'BZ')) or doc_no}",
+            "state": "draft",
+            "note": note,
+        }
+        if vals["before_balance"] == vals["after_balance"]:
+            vals["after_balance"] = vals["before_balance"] + amount + 0.01
+    elif model == "sc.settlement.order":
+        customer = partner_id(caches["partner"], first(row, "FBR", "CBR"), supplier=False)
+        vals = {
+            "name": doc_no,
+            "project_id": project,
+            "partner_id": customer,
+            "settlement_unit_id": customer,
+            "legacy_counterparty_name": clean(first(row, "FBR", "CBR")),
+            "title": clean(first(row, "BT", "HTMC")) or doc_no,
+            "document_date": date,
+            "settlement_type": "in",
+            "settlement_stage": "final",
+            "date_settlement": date,
+            "approved_amount": to_float(first(row, "SDJE", "SSJE", "JSJE")),
+            "submitted_amount": to_float(first(row, "SSJE", "JSJE")),
+            "state": "draft",
+            "settlement_description": note,
+        }
+    else:
+        raise RuntimeError(f"unsupported model: {model}")
+
+    vals.update(base_legacy_vals(model, spec, table, row))
+    handler = user_id(caches["user"], first(row, "LRRID", "CZRID", "DJRID"), first(row, "LRR", "CZR", "DJR"))
+    if handler:
+        vals.update(safe_vals(model, {"owner_id": handler, "requester_id": handler, "recorder_id": handler, "entry_user_id": handler, "handler_id": handler}))
+    return safe_vals(model, vals)
+
+
+def load_rows(spec: dict[str, Any]) -> list[dict[str, Any]]:
+    pattern = f"scbsly_direct_full_rows_{spec['table']}_{spec['menu']}_*.json.gz"
+    paths = sorted(FULL_ROWS_DIR.glob(pattern))
+    if not paths:
+        return []
+    with gzip.open(paths[0], "rt", encoding="utf-8") as handle:
+        return json.load(handle).get("rows") or []
+
+
+def ensure_allowed_db() -> None:
+    allowlist = {item.strip() for item in os.getenv("MIGRATION_REPLAY_DB_ALLOWLIST", env.cr.dbname).split(",") if item.strip()}  # noqa: F821
+    if env.cr.dbname not in allowlist:  # noqa: F821
+        raise RuntimeError({"db_name_not_allowed_for_direct_projection": env.cr.dbname, "allowlist": sorted(allowlist)})  # noqa: F821
+
+
+ensure_allowed_db()
+caches = {"project": {}, "partner": {}, "user": {}}
+results: list[dict[str, Any]] = []
+rebuild = os.getenv("SCBSLY_DIRECT_REBUILD") == "1"
+
+for spec in SPECS:
+    model_name = spec["model"]
+    rows = load_rows(spec)
+    created = 0
+    skipped_existing = 0
+    blocked = 0
+    errors: list[dict[str, str]] = []
+    Model = env[model_name].sudo().with_context(active_test=False)  # noqa: F821
+    if rebuild:
+        with env.cr.savepoint():  # noqa: F821
+            if spec["source_key"] == "legacy_source":
+                if "legacy_source_model" in Model._fields:
+                    Model.search([("legacy_source_model", "=", source_model(spec["table"]))]).unlink()
+                else:
+                    Model.search([("legacy_source_table", "=", spec["table"])]).unlink()
+            else:
+                Model.search([("legacy_fact_model", "=", source_model(spec["table"]))]).unlink()
+    for row in rows:
+        try:
+            with env.cr.savepoint():  # noqa: F821
+                if exists(model_name, spec, spec["table"], row):
+                    skipped_existing += 1
+                    continue
+                vals = vals_for(spec, row, caches)
+                if "project_id" in Model._fields and not vals.get("project_id") and Model._fields["project_id"].required:
+                    blocked += 1
+                    errors.append({"id": row_id(row), "error": "missing_required_project"})
+                    continue
+                Model.create(vals)
+                created += 1
+        except Exception as exc:  # noqa: BLE001
+            blocked += 1
+            if len(errors) < 20:
+                errors.append({"id": row_id(row), "error": repr(exc)})
+    results.append(
+        {
+            "table": spec["table"],
+            "menu": spec["menu"],
+            "model": model_name,
+            "source_model": source_model(spec["table"]),
+            "input_rows": len(rows),
+            "created": created,
+            "skipped_existing": skipped_existing,
+            "blocked": blocked,
+            "errors": errors,
+        }
+    )
+
+env.cr.commit()  # noqa: F821
+
+payload = {
+    "status": "PASS" if all(not item["blocked"] and item["input_rows"] for item in results) else "REVIEW",
+    "database": env.cr.dbname,  # noqa: F821
+    "mode": "scbsly_direct_project_gap_projection_write",
+    "full_rows_dir": str(FULL_ROWS_DIR),
+    "results": results,
+    "created_total": sum(item["created"] for item in results),
+    "skipped_existing_total": sum(item["skipped_existing"] for item in results),
+    "blocked_total": sum(item["blocked"] for item in results),
+    "source_boundary": "online_old_scbsly overlay only; SCBS55 sources are not overwritten",
+}
+out = artifact_root() / OUTPUT_JSON_NAME
+out.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+print("SCBSLY_DIRECT_PROJECT_GAP_PROJECTION_WRITE=" + json.dumps({key: payload[key] for key in ("status", "database", "created_total", "skipped_existing_total", "blocked_total")}, ensure_ascii=False, sort_keys=True))

--- a/scripts/migration/scbsly_supplier_payment_online_patch.py
+++ b/scripts/migration/scbsly_supplier_payment_online_patch.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Mirror SCBSLY current-user supplier payment rows into payment execution."""
+
+from __future__ import annotations
+
+import gzip
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+
+INPUT = Path("/tmp/scbs_55_old_live_full_rows_seq031_supplier_payment.json.gz")
+SURFACE = "online_old_scbly:T_FK_SUPPLIER:list881"
+TABLE = "T_FK_SUPPLIER"
+
+
+def clean(value: object) -> str:
+    if value in (None, False):
+        return ""
+    text = re.sub(r"\s+", " ", str(value).replace("\u3000", " ").strip())
+    return "" if text in {"False", "false", "None", "NULL"} else text
+
+
+def parse_date(value: object):
+    text = clean(value)
+    if not text:
+        return False
+    for fmt in ("%Y-%m-%d", "%Y/%m/%d", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(text[:10], fmt).date()
+        except ValueError:
+            continue
+    return False
+
+
+def parse_dt(value: object):
+    text = clean(value)
+    if not text:
+        return False
+    for fmt in ("%Y-%m-%d %H:%M:%S", "%Y-%m-%d", "%m/%d/%Y %H:%M:%S", "%m/%d/%Y"):
+        try:
+            return datetime.strptime(text[:19] if "%H" in fmt else text[:10], fmt)
+        except ValueError:
+            continue
+    return False
+
+
+def amount(value: object) -> float:
+    text = clean(value)
+    if not text:
+        return 0.0
+    try:
+        return abs(float(text))
+    except ValueError:
+        return 0.0
+
+
+def safe_vals(model, vals: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in vals.items() if key in model._fields}
+
+
+def project_for(row: dict[str, Any]):
+    Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+    legacy_project_id = clean(row.get("f_XMID") or row.get("XMID"))
+    if legacy_project_id and "legacy_project_id" in Project._fields:
+        project = Project.search([("legacy_project_id", "=", legacy_project_id)], limit=1)
+        if project:
+            return project
+    name = clean(row.get("D_BQJT_XMMC") or row.get("TSXMMC") or row.get("f_LYXM") or row.get("f_BM"))
+    if name:
+        project = Project.search([("name", "ilike", name[:60])], limit=1)
+        if project:
+            return project
+    return Project.search([], limit=1)
+
+
+def partner_for(row: dict[str, Any]):
+    Partner = env["res.partner"].sudo().with_context(active_test=False)  # noqa: F821
+    legacy_id = clean(row.get("f_SupplierID"))
+    if legacy_id and "legacy_partner_id" in Partner._fields:
+        partner = Partner.search([("legacy_partner_id", "=", legacy_id)], limit=1)
+        if partner:
+            return partner
+    name = clean(row.get("f_SupplierName") or row.get("HM"))
+    if name:
+        partner = Partner.search([("name", "=", name)], limit=1)
+        if partner:
+            return partner
+        return Partner.create({"name": name, "supplier_rank": 1})
+    return Partner.browse()
+
+
+def ensure_payload_table() -> None:
+    env.cr.execute(  # noqa: F821
+        """
+        CREATE TABLE IF NOT EXISTS sc_p1_legacy_visible_alias_payload (
+            model varchar NOT NULL,
+            res_id integer NOT NULL,
+            payload jsonb NOT NULL DEFAULT '{}'::jsonb,
+            write_date timestamp without time zone NOT NULL DEFAULT now(),
+            PRIMARY KEY (model, res_id)
+        )
+        """
+    )
+
+
+def write_payload(record, row: dict[str, Any]) -> None:
+    payload = {
+        "单据状态": clean(row.get("DJZT")),
+        "推送结果": clean(row.get("TSJG") or row.get("D_SCBSJS_IsPush")),
+        "金蝶单据编号": clean(row.get("OTHER_SYSTEM_CODE")),
+        "单据编号": clean(row.get("DJBH")),
+        "項目名称": clean(row.get("D_BQJT_XMMC") or row.get("TSXMMC") or row.get("f_LYXM") or row.get("f_BM")),
+        "供应商名称": clean(row.get("f_SupplierName")),
+        "付款日期": clean(row.get("f_FKRQ"))[:10],
+        "付款金额": str(amount(row.get("f_FKJE"))),
+        "备注": clean(row.get("f_BZ") or row.get("BZ")),
+        "其他备注": clean(row.get("Remark")),
+        "付款方式名称": clean(row.get("f_FKFSMC")),
+        "填写人": clean(row.get("f_TXR")),
+        "开户行": clean(row.get("KHH")),
+        "账户": clean(row.get("ZH")),
+        "付款账户": clean(row.get("FKZH")),
+        "付款账户名称": clean(row.get("FKZHMC")),
+        "支付申请单号": clean(row.get("ZFSQDH")),
+        "附件": clean(row.get("FJ") or row.get("f_FJ")),
+    }
+    env.cr.execute(  # noqa: F821
+        """
+        INSERT INTO sc_p1_legacy_visible_alias_payload(model, res_id, payload, write_date)
+        VALUES (%s, %s, %s::jsonb, now())
+        ON CONFLICT (model, res_id)
+        DO UPDATE SET payload = EXCLUDED.payload, write_date = now()
+        """,
+        [record._name, record.id, json.dumps(payload, ensure_ascii=False)],
+    )
+
+
+with gzip.open(INPUT, "rt", encoding="utf-8") as handle:
+    rows = json.load(handle)["rows"]
+
+ensure_payload_table()
+Payment = env["sc.payment.execution"].sudo().with_context(active_test=False)  # noqa: F821
+created = updated = reused_existing_key = 0
+seen: set[str] = set()
+
+for row in rows:
+    key = clean(row.get("Id") or row.get("ID"))
+    if not key:
+        continue
+    seen.add(key)
+    record = Payment.search([("legacy_source_model", "=", SURFACE), ("legacy_record_id", "=", key)], limit=1)
+    if not record:
+        record = Payment.search([("legacy_record_id", "=", key), ("payment_family", "in", ["往来单位付款", "SCBS供应商付款"])], limit=1)
+        if record:
+            reused_existing_key += 1
+    project = project_for(row)
+    partner = partner_for(row)
+    vals = {
+        "name": clean(row.get("DJBH")) or key,
+        "source_origin": "legacy",
+        "source_kind": "actual_outflow",
+        "state": "legacy_confirmed",
+        "project_id": project.id,
+        "partner_id": partner.id if partner else False,
+        "date_payment": parse_date(row.get("f_FKRQ")),
+        "document_no": clean(row.get("DJBH")),
+        "payment_family": "往来单位付款",
+        "payment_method": clean(row.get("f_FKFSMC")),
+        "bank_account": clean(row.get("FKZH")),
+        "payment_account_name": clean(row.get("FKZHMC")),
+        "payment_account_no": clean(row.get("FKZH")),
+        "receipt_account_name": clean(row.get("HM")),
+        "receipt_account_no": clean(row.get("ZH")),
+        "receipt_bank_name": clean(row.get("KHH")),
+        "planned_amount": amount(row.get("f_FKJE")),
+        "paid_amount": amount(row.get("f_FKJE")),
+        "invoice_amount": amount(row.get("f_FPJE")),
+        "currency_id": env.company.currency_id.id,  # noqa: F821
+        "legacy_source_model": SURFACE,
+        "legacy_source_table": TABLE,
+        "legacy_record_id": key,
+        "legacy_document_state": clean(row.get("DJZT")),
+        "legacy_attachment_ref": clean(row.get("FJ") or row.get("f_FJ")),
+        "legacy_visible_document_no": clean(row.get("DJBH")),
+        "legacy_visible_project_name": clean(row.get("D_BQJT_XMMC") or row.get("TSXMMC") or row.get("f_LYXM") or row.get("f_BM")),
+        "legacy_visible_supplier_name": clean(row.get("f_SupplierName")),
+        "legacy_visible_payment_date": clean(row.get("f_FKRQ"))[:10],
+        "legacy_visible_note": clean(row.get("f_BZ") or row.get("BZ")),
+        "legacy_visible_other_note": clean(row.get("Remark")),
+        "legacy_visible_payment_method": clean(row.get("f_FKFSMC")),
+        "legacy_visible_receipt_bank_name": clean(row.get("KHH")),
+        "legacy_visible_receipt_account_no": clean(row.get("ZH")),
+        "legacy_visible_payment_account_no": clean(row.get("FKZH")),
+        "legacy_visible_payment_account_name": clean(row.get("FKZHMC")),
+        "legacy_visible_request_no": clean(row.get("ZFSQDH")),
+        "creator_legacy_user_id": clean(row.get("LRRID")),
+        "creator_name": clean(row.get("f_LRR") or row.get("LRR")),
+        "created_time": parse_dt(row.get("f_LRSJ") or row.get("LRSJ")),
+        "note": "SCBSLY old visible supplier payment mirror; old_key=%s; attachment=%s" % (key, clean(row.get("FJ") or row.get("f_FJ"))),
+        "active": True,
+    }
+    if record:
+        record.write(safe_vals(Payment, vals))
+        updated += 1
+    else:
+        record = Payment.create(safe_vals(Payment, vals))
+        created += 1
+    write_payload(record, row)
+
+stale = Payment.search([("legacy_source_model", "=", SURFACE), ("legacy_record_id", "not in", list(seen) or ["__none__"])])
+stale_count = len(stale)
+if stale:
+    stale.write({"legacy_source_model": f"{SURFACE}:hidden", "active": False})
+
+env.cr.commit()  # noqa: F821
+final_count = Payment.search_count([("legacy_source_model", "=", SURFACE)])
+action_count = Payment.search_count([("source_kind", "=", "actual_outflow"), ("payment_family", "in", ["往来单位付款", "SCBS供应商付款"])])
+payload = {
+    "status": "PASS" if final_count == len(rows) else "REVIEW",
+    "old_rows": len(rows),
+    "created": created,
+    "updated": updated,
+    "reused_existing_key": reused_existing_key,
+    "stale_hidden": stale_count,
+    "final_count": final_count,
+    "direct_action_count": action_count,
+    "surface": SURFACE,
+}
+print("SCBSLY_SUPPLIER_PAYMENT_ONLINE_PATCH=" + json.dumps(payload, ensure_ascii=False, sort_keys=True))

--- a/scripts/verify/direct_project_business_browser_acceptance.js
+++ b/scripts/verify/direct_project_business_browser_acceptance.js
@@ -1,0 +1,269 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const { createRequire } = require('module');
+
+const requireBase = fs.existsSync(path.join(process.cwd(), 'frontend/apps/web/package.json'))
+  ? path.join(process.cwd(), 'frontend/apps/web/package.json')
+  : path.join(process.cwd(), 'package.json');
+const requireFromRoot = createRequire(requireBase);
+const { chromium } = requireFromRoot('playwright');
+
+const SOURCE_DOCUMENT = 'user:direct_project_business_menu:2026-05-30';
+const FRONTEND_URL = process.env.FRONTEND_URL || 'http://127.0.0.1:18081';
+const DB_NAME = process.env.DB_NAME || 'sc_demo';
+const LOGIN = process.env.E2E_LOGIN || 'wutao';
+const PASSWORD = process.env.E2E_PASSWORD || '123456';
+const ARTIFACTS_DIR = process.env.ARTIFACTS_DIR || 'artifacts';
+const BROWSER_EXECUTABLE_PATH = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE || '';
+const ts = new Date().toISOString().replace(/[-:]/g, '').replace(/\..+$/, '');
+const OUT_DIR = path.join(ARTIFACTS_DIR, 'browser', 'direct-project-business', ts);
+
+const SCREENSHOT_NAMES = new Set([
+  '报价单',
+  '零星用工',
+  '机械台班记录',
+  '管理人员工资表',
+  '油卡登记',
+  '工程结算单',
+]);
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function normalize(value) {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function writeJson(name, payload) {
+  ensureDir(OUT_DIR);
+  fs.writeFileSync(path.join(OUT_DIR, name), JSON.stringify(payload, null, 2) + '\n', 'utf8');
+}
+
+function writeMarkdown(report) {
+  const lines = [
+    '# Direct Project Business Browser Acceptance',
+    '',
+    `- ok: ${report.ok}`,
+    `- frontend_url: ${report.frontend_url}`,
+    `- db_name: ${report.db_name}`,
+    `- source_document: ${report.source_document}`,
+    `- checked_count: ${report.summary.checked_count}`,
+    `- pass_count: ${report.summary.pass_count}`,
+    `- fail_count: ${report.summary.fail_count}`,
+    `- fatal_console_error_count: ${report.summary.fatal_console_error_count}`,
+    '',
+    '| seq | group | menu | action | visible rows | status | screenshot |',
+    '| ---: | --- | --- | ---: | ---: | --- | --- |',
+  ];
+  for (const row of report.rows) {
+    lines.push(
+      `| ${row.priority_sequence} | ${row.group} | ${row.name} | ${row.action_id} | ${row.row_count} | ${row.status} | ${row.screenshot || ''} |`,
+    );
+  }
+  fs.writeFileSync(path.join(OUT_DIR, 'report.md'), lines.join('\n') + '\n', 'utf8');
+}
+
+function meaningfulConsoleErrors(messages) {
+  return messages.filter((message) => {
+    const text = normalize(message);
+    if (!text) return false;
+    if (/favicon\.ico/.test(text)) return false;
+    if (/Failed to load resource: the server responded with a status of 404/.test(text)) return false;
+    return true;
+  });
+}
+
+async function login(page) {
+  await page.goto(`${FRONTEND_URL}/login?db=${encodeURIComponent(DB_NAME)}&t=${Date.now()}`, {
+    waitUntil: 'networkidle',
+    timeout: 45000,
+  });
+  const inputs = page.locator('input');
+  await inputs.nth(0).fill(LOGIN);
+  await inputs.nth(1).fill(PASSWORD);
+  const dbInput = inputs.nth(2);
+  if (await dbInput.isEditable().catch(() => false)) {
+    await dbInput.fill(DB_NAME);
+  }
+  await page.getByRole('button', { name: /^登录$/ }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 45000 });
+  await page.waitForLoadState('networkidle', { timeout: 30000 }).catch(() => undefined);
+}
+
+async function authToken(page) {
+  return page.evaluate((dbName) => sessionStorage.getItem(`sc_auth_token:${dbName}`) || '', DB_NAME);
+}
+
+async function intent(page, intentName, params) {
+  const token = await authToken(page);
+  return page.evaluate(async ({ dbName, tokenValue, intentName, params }) => {
+    const response = await fetch(`/api/v1/intent?db=${encodeURIComponent(dbName)}`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: tokenValue ? `Bearer ${tokenValue}` : '',
+        'X-Trace-Id': `direct-project-browser-${Date.now()}`,
+      },
+      body: JSON.stringify({ intent: intentName, params }),
+    });
+    const body = await response.json().catch(() => ({}));
+    if (!response.ok || body.ok === false) {
+      throw new Error(body?.error?.message || body?.message || `${intentName} failed`);
+    }
+    return body.data || {};
+  }, { dbName: DB_NAME, tokenValue: token, intentName, params });
+}
+
+async function fetchPlanRows(page) {
+  const data = await intent(page, 'api.data', {
+    op: 'list',
+    model: 'sc.legacy.user.priority.menu.plan',
+    domain: [['source_document', '=', SOURCE_DOCUMENT]],
+    fields: [
+      'priority_sequence',
+      'legacy_menu_group',
+      'legacy_menu_name',
+      'target_action_id',
+      'target_model',
+      'surface_contract_status',
+    ],
+    order: 'priority_sequence',
+    limit: 80,
+    context: { active_test: false },
+  });
+  return (Array.isArray(data.records) ? data.records : [])
+    .map((row) => {
+      const action = row.target_action_id;
+      return {
+        priority_sequence: Number(row.priority_sequence || 0),
+        group: normalize(row.legacy_menu_group),
+        name: normalize(row.legacy_menu_name),
+        model: normalize(row.target_model),
+        action_id: Array.isArray(action) ? Number(action[0] || 0) : Number(action || 0),
+        surface_contract_status: normalize(row.surface_contract_status),
+      };
+    })
+    .filter((row) => row.action_id > 0 && row.model);
+}
+
+async function waitForList(page) {
+  await page.waitForFunction(() => {
+    const text = String(document.body?.textContent || '');
+    if (/页面加载失败|页面渲染失败|System exception|NAV_MENU_NO_ACTION/.test(text)) return true;
+    if (/没有匹配记录|暂无数据|0 条/.test(text)) return true;
+    return Boolean(document.querySelector('table.flat-table tbody tr, table.group-table tbody tr, .table table tbody tr, table tbody tr'));
+  }, null, { timeout: 45000 });
+  const bodyText = normalize(await page.locator('body').innerText({ timeout: 5000 }).catch(() => ''));
+  if (/页面加载失败|页面渲染失败|System exception|NAV_MENU_NO_ACTION/.test(bodyText)) {
+    throw new Error(bodyText.slice(0, 500));
+  }
+}
+
+async function visibleRowCount(page) {
+  return page.evaluate(() => {
+    const tables = Array.from(document.querySelectorAll('table.flat-table, table.group-table, .table table, table'))
+      .filter((table) => {
+        const rect = table.getBoundingClientRect();
+        return rect.width > 0 && rect.height > 0;
+      });
+    return tables.reduce((count, table) => count + table.querySelectorAll('tbody tr').length, 0);
+  });
+}
+
+async function bodyProbe(page) {
+  return page.evaluate(() => {
+    const text = String(document.body?.textContent || '').replace(/\s+/g, ' ').trim();
+    const title = String(document.querySelector('h1,h2,.page-title,.action-title')?.textContent || '').replace(/\s+/g, ' ').trim();
+    return { title, text: text.slice(0, 800) };
+  });
+}
+
+async function run() {
+  ensureDir(OUT_DIR);
+  const launchOptions = { headless: true, args: ['--no-sandbox'] };
+  if (BROWSER_EXECUTABLE_PATH) launchOptions.executablePath = BROWSER_EXECUTABLE_PATH;
+  const browser = await chromium.launch(launchOptions);
+  const page = await browser.newPage({ viewport: { width: 1440, height: 960 }, locale: 'zh-CN' });
+  const consoleErrors = [];
+  page.on('console', (msg) => {
+    if (msg.type() === 'error') consoleErrors.push(msg.text());
+  });
+  page.on('pageerror', (err) => consoleErrors.push(err.message));
+
+  const report = {
+    ok: false,
+    frontend_url: FRONTEND_URL,
+    db_name: DB_NAME,
+    login: LOGIN,
+    source_document: SOURCE_DOCUMENT,
+    artifact_dir: OUT_DIR,
+    rows: [],
+    summary: { checked_count: 0, pass_count: 0, fail_count: 0, fatal_console_error_count: 0 },
+  };
+
+  try {
+    await login(page);
+    const rows = await fetchPlanRows(page);
+    if (rows.length !== 34) throw new Error(`expected 34 direct-project plan rows, got ${rows.length}`);
+    for (const plan of rows) {
+      const row = {
+        ...plan,
+        url: `${FRONTEND_URL}/a/${plan.action_id}?db=${encodeURIComponent(DB_NAME)}&direct_project_acceptance=${Date.now()}`,
+        row_count: 0,
+        status: 'FAIL',
+        errors: [],
+        screenshot: '',
+        body_probe: {},
+      };
+      try {
+        await page.goto(row.url, { waitUntil: 'domcontentloaded', timeout: 45000 });
+        await page.waitForLoadState('networkidle', { timeout: 45000 }).catch(() => undefined);
+        await waitForList(page);
+        row.row_count = await visibleRowCount(page);
+        row.body_probe = await bodyProbe(page);
+        if (row.row_count < 1) row.errors.push('no_visible_rows');
+        if (SCREENSHOT_NAMES.has(plan.name)) {
+          const fileName = `${String(plan.priority_sequence).padStart(3, '0')}_${plan.name.replace(/[^\w\u4e00-\u9fa5]+/g, '_')}.png`;
+          await page.screenshot({ path: path.join(OUT_DIR, fileName), fullPage: true });
+          row.screenshot = fileName;
+        }
+        row.status = row.errors.length ? 'FAIL' : 'PASS';
+      } catch (err) {
+        row.errors.push(err && err.message ? err.message : String(err));
+        const fileName = `${String(plan.priority_sequence).padStart(3, '0')}_${plan.name.replace(/[^\w\u4e00-\u9fa5]+/g, '_')}_failure.png`;
+        await page.screenshot({ path: path.join(OUT_DIR, fileName), fullPage: true }).catch(() => undefined);
+        row.screenshot = fileName;
+      }
+      report.rows.push(row);
+    }
+    const fatalConsoleErrors = meaningfulConsoleErrors(consoleErrors);
+    report.summary.checked_count = report.rows.length;
+    report.summary.pass_count = report.rows.filter((row) => row.status === 'PASS').length;
+    report.summary.fail_count = report.rows.filter((row) => row.status !== 'PASS').length;
+    report.summary.fatal_console_error_count = fatalConsoleErrors.length;
+    report.fatal_console_errors = fatalConsoleErrors;
+    report.ok = report.summary.fail_count === 0 && fatalConsoleErrors.length === 0;
+    writeJson('summary.json', report);
+    writeMarkdown(report);
+    if (!report.ok) {
+      throw new Error(`direct project browser acceptance failed: fail_count=${report.summary.fail_count}, fatal_console_errors=${fatalConsoleErrors.length}`);
+    }
+    console.log(`[direct_project_business_browser_acceptance] PASS artifacts=${OUT_DIR}`);
+  } catch (err) {
+    report.ok = false;
+    report.error = err && err.message ? err.message : String(err);
+    writeJson('summary.json', report);
+    writeMarkdown(report);
+    console.error(`[direct_project_business_browser_acceptance] FAIL ${report.error}`);
+    console.error(`[direct_project_business_browser_acceptance] artifacts=${OUT_DIR}`);
+    process.exitCode = 1;
+  } finally {
+    await browser.close().catch(() => undefined);
+  }
+}
+
+run();

--- a/scripts/verify/scbsly_current_user_menu_dump.py
+++ b/scripts/verify/scbsly_current_user_menu_dump.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Dump the current user's SCBSLY menu tree without storing credentials."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import parse_qs, urlparse
+
+import requests
+
+
+BASE_URL = os.getenv("OLD_SCBS_BASE_URL", "https://www.builderp.cn/SCBSLY_V2").rstrip("/")
+ARTIFACT_ROOT = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", "artifacts/migration"))
+OUTPUT_JSON = ARTIFACT_ROOT / "scbsly_current_user_menu_dump_v1.json"
+OUTPUT_REPORT = ARTIFACT_ROOT / "scbsly_current_user_menu_dump_v1.md"
+
+
+def clean(value: object) -> str:
+    return str(value or "").strip()
+
+
+def md5(value: str) -> str:
+    return hashlib.md5(value.encode("utf-8")).hexdigest()
+
+
+def config_id_from_link(link: str) -> str:
+    query = parse_qs(urlparse(link).query)
+    values = query.get("ConfigId") or query.get("configId") or query.get("configid") or []
+    return clean(values[0]) if values else ""
+
+
+def login(session: requests.Session) -> dict[str, Any]:
+    username = os.getenv("OLD_SCBS_USERNAME")
+    password = os.getenv("OLD_SCBS_PASSWORD")
+    if not username or not password:
+        raise RuntimeError("OLD_SCBS_USERNAME and OLD_SCBS_PASSWORD are required")
+    payload = {
+        "Type": "Common",
+        "Param": {
+            "UserName": username,
+            "IsEncrypt": False,
+            "Password": password,
+            "PasswordMd5": md5(password),
+            "VerificationCodeKey": "",
+            "VerificationCode": "",
+            "EncryptLockKey": "",
+            "PhoneNumber": "",
+            "SMSVerificationCodeKey": "",
+            "SMSVerificationCode": "",
+        },
+    }
+    response = session.post(f"{BASE_URL}/api/System/UserApi/Login", json=payload, timeout=60)
+    response.raise_for_status()
+    body = response.json()
+    if str(body.get("Code")) != "10000" or not body.get("Data", {}).get("Token"):
+        raise RuntimeError({"old_login_failed": {"Code": body.get("Code"), "Msg": body.get("Msg")}})
+    return body["Data"]
+
+
+def api_post(session: requests.Session, token: str, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+    response = session.post(f"{BASE_URL}/api/{path}", json=payload, headers={"Token": token}, timeout=60)
+    response.raise_for_status()
+    body = response.json()
+    if str(body.get("Code")) != "10000":
+        raise RuntimeError({"old_post_failed": path, "Code": body.get("Code"), "Msg": body.get("Msg")})
+    return body
+
+
+def parent_key(menu: dict[str, Any]) -> str:
+    return clean(menu.get("PARENT_ID") or menu.get("PARENTID") or menu.get("PARENT_MENU_ID"))
+
+
+def menu_key(menu: dict[str, Any]) -> str:
+    return clean(menu.get("ID") or menu.get("MENU_ID") or menu.get("MenuId"))
+
+
+def menu_name(menu: dict[str, Any]) -> str:
+    return clean(menu.get("MENU_NAME") or menu.get("DEFAULT_NAME") or menu.get("NAME"))
+
+
+def build_paths(menus: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_id = {menu_key(menu): menu for menu in menus if menu_key(menu)}
+    rows: list[dict[str, Any]] = []
+    for menu in menus:
+        names = [menu_name(menu)]
+        seen = {menu_key(menu)}
+        current = menu
+        while parent_key(current) and parent_key(current) in by_id and parent_key(current) not in seen:
+            current = by_id[parent_key(current)]
+            seen.add(menu_key(current))
+            names.append(menu_name(current))
+        names = [name for name in reversed(names) if name]
+        link = clean(menu.get("LINK_URL"))
+        rows.append(
+            {
+                "id": menu_key(menu),
+                "parent_id": parent_key(menu),
+                "name": menu_name(menu),
+                "path": "/".join(names),
+                "link_url": link,
+                "config_id": config_id_from_link(link),
+                "raw": {
+                    key: menu.get(key)
+                    for key in ("ID", "MENU_ID", "MENU_NAME", "DEFAULT_NAME", "PARENT_ID", "LINK_URL", "ICON")
+                    if key in menu
+                },
+            }
+        )
+    return sorted(rows, key=lambda item: (item["path"], item["id"]))
+
+
+def report(payload: dict[str, Any]) -> str:
+    lines = [
+        "# SCBSLY Current User Menu Dump v1",
+        "",
+        f"Status: {payload['status']}",
+        f"Base URL: {payload['base_url']}",
+        f"Old User: {payload['old_user'].get('UserName')} / {payload['old_user'].get('PersonName')}",
+        f"Generated At: {payload['generated_at']}",
+        "",
+        "| path | config_id | link |",
+        "| --- | --- | --- |",
+    ]
+    for row in payload["menus"]:
+        lines.append(f"| {row['path']} | {row['config_id']} | {row['link_url']} |")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    session = requests.Session()
+    user = login(session)
+    home = api_post(session, user["Token"], "HomeApi/GetCommonHomeInfo", {})
+    menus = build_paths(home.get("Data", {}).get("MenuInfoArr") or [])
+    payload = {
+        "status": "PASS",
+        "mode": "scbsly_current_user_menu_dump",
+        "base_url": BASE_URL,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "old_user": {
+            key: user.get(key)
+            for key in ("UserId", "UserName", "PersonName", "ProjectId", "ProjectName", "CompanyId", "CompanyName")
+        },
+        "menu_count": len(menus),
+        "menus": menus,
+    }
+    OUTPUT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    OUTPUT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    OUTPUT_REPORT.write_text(report(payload), encoding="utf-8")
+    print("SCBSLY_CURRENT_USER_MENU_DUMP=" + json.dumps({"status": payload["status"], "menu_count": len(menus), "output": str(OUTPUT_JSON)}, ensure_ascii=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/scbsly_direct_config_full_row_dump.py
+++ b/scripts/verify/scbsly_direct_config_full_row_dump.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Dump full rows for direct-project SCBSLY config IDs.
+
+This complements the SCBS55 CSV-based dumper.  Direct-project menu entries are
+discovered from the live SCBSLY menu/config surface, so they are supplied from a
+JSON manifest instead of the fixed 55-row acceptance CSV.
+"""
+
+from __future__ import annotations
+
+import gzip
+import json
+import os
+import time
+from pathlib import Path
+from typing import Any
+
+import requests
+
+from scbs_55_old_system_list_count_probe import api_get, api_post, list_payload, login
+
+
+INPUT_JSON = Path(
+    os.getenv(
+        "SCBSLY_DIRECT_CONFIG_COUNTS_JSON",
+        "artifacts/migration/scbsly_direct_20260530/direct_unresolved_config_counts.json",
+    )
+)
+DUMP_DIR = Path(os.getenv("SCBSLY_DIRECT_FULL_DUMP_DIR", "artifacts/migration/scbsly_direct_20260530/full_rows"))
+PAGE_SIZE = int(os.getenv("SCBSLY_DIRECT_FULL_DUMP_PAGE_SIZE", "500"))
+NAME_FILTER = {
+    item.strip()
+    for item in os.getenv("SCBSLY_DIRECT_FULL_DUMP_NAMES", "").replace("，", ",").split(",")
+    if item.strip()
+}
+TABLE_FILTER = {
+    item.strip()
+    for item in os.getenv("SCBSLY_DIRECT_FULL_DUMP_TABLES", "").replace("，", ",").split(",")
+    if item.strip()
+}
+INCLUDE_ZERO = os.getenv("SCBSLY_DIRECT_FULL_DUMP_INCLUDE_ZERO", "").lower() in {"1", "true", "yes"}
+
+
+def selected(row: dict[str, Any]) -> bool:
+    if row.get("status") != "PASS":
+        return False
+    if not INCLUDE_ZERO and not int(row.get("count") or 0):
+        return False
+    if NAME_FILTER and str(row.get("name") or "") not in NAME_FILTER:
+        return False
+    if TABLE_FILTER and str(row.get("table") or "") not in TABLE_FILTER:
+        return False
+    return True
+
+
+def path_for(row: dict[str, Any]) -> Path:
+    name = str(row.get("name") or "unknown").replace("/", "_").replace("\\", "_")
+    table = str(row.get("table") or "unknown").replace("/", "_").replace("\\", "_")
+    config_id = str(row.get("config_id") or "")[:8]
+    return DUMP_DIR / f"scbsly_direct_full_rows_{table}_{name}_{config_id}.json.gz"
+
+
+def main() -> int:
+    rows = json.loads(INPUT_JSON.read_text(encoding="utf-8")).get("rows") or []
+    targets = [row for row in rows if selected(row)]
+    if not targets:
+        raise RuntimeError({"no_selected_direct_configs": str(INPUT_JSON)})
+
+    session = requests.Session()
+    user = login(session)
+    token = user["Token"]
+    DUMP_DIR.mkdir(parents=True, exist_ok=True)
+    manifest: list[dict[str, Any]] = []
+
+    for row in targets:
+        item = {
+            "name": row.get("name") or "",
+            "config_id": row.get("config_id") or "",
+            "main_table": row.get("table") or "",
+            "expected_count": int(row.get("count") or 0),
+            "row_count": 0,
+            "path": "",
+            "status": "FAIL",
+            "error": "",
+        }
+        try:
+            config = api_get(session, token, f"LowCode/FormApi/GetConfigById?Id={item['config_id']}&LoadInitData=true")["Data"]
+            detail = json.loads(config.get("DETAIL_CONFIG") or "{}")
+            other = detail.get("OtherConfig") or {}
+            path = "LowCode/FormApi/ListByTableName"
+            payload = list_payload(config)
+            if other.get("ListApi"):
+                path = str(other["ListApi"]).removeprefix("/api/")
+            elif other.get("ListProcedure"):
+                payload["Procedure"] = other["ListProcedure"]
+                path = "LowCode/FormApi/ListByProcedure"
+
+            full_rows: list[dict[str, Any]] = []
+            page_index = 1
+            data_count: int | None = None
+            while True:
+                payload["PageIndex"] = page_index
+                payload["PageSize"] = PAGE_SIZE
+                body = api_post(session, token, path, payload)
+                page_rows = body.get("Data") or []
+                if data_count is None:
+                    data_count = int(body.get("DataCount") or 0)
+                    item["expected_count"] = data_count
+                full_rows.extend(page_rows)
+                print(
+                    "[direct-full-dump] table=%s name=%s page=%s got=%s total=%s expected=%s"
+                    % (item["main_table"], item["name"], page_index, len(page_rows), len(full_rows), data_count),
+                    flush=True,
+                )
+                if not page_rows or len(full_rows) >= (data_count or 0):
+                    break
+                page_index += 1
+                time.sleep(0.15)
+
+            out_path = path_for(row)
+            with gzip.open(out_path, "wt", encoding="utf-8") as handle:
+                json.dump(
+                    {
+                        "name": item["name"],
+                        "config_id": item["config_id"],
+                        "main_table": item["main_table"],
+                        "old_user": {
+                            key: user.get(key)
+                            for key in ("UserId", "UserName", "PersonName", "ProjectId", "ProjectName")
+                        },
+                        "rows": full_rows,
+                    },
+                    handle,
+                    ensure_ascii=False,
+                )
+            item["row_count"] = len(full_rows)
+            item["path"] = str(out_path)
+            item["status"] = "PASS" if len(full_rows) == (data_count or 0) else "COUNT_MISMATCH"
+        except Exception as exc:  # noqa: BLE001
+            item["error"] = str(exc)
+        manifest.append(item)
+        print(
+            "[direct-full-dump] table=%s name=%s status=%s count=%s path=%s error=%s"
+            % (item["main_table"], item["name"], item["status"], item["row_count"], item["path"], item["error"][:160]),
+            flush=True,
+        )
+
+    manifest_path = DUMP_DIR / "scbsly_direct_full_rows_manifest.json"
+    manifest_path.write_text(json.dumps({"rows": manifest}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return 0 if manifest and all(row["status"] == "PASS" for row in manifest) else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- guard SCBS55 finance surface replay writes against fields/actions missing on the target runtime
- add direct-project business menu/data gap probes, projection writer, and browser acceptance check
- add SCBSLY current-user menu/config row dump helpers and supplier payment online patch script

## Validation
- `python3 -m py_compile scripts/migration/scbs55_finance_surfaces_online_patch.py scripts/migration/direct_project_business_data_gap_probe.py scripts/migration/direct_project_business_menu_plan_write.py scripts/migration/scbsly_direct_project_gap_projection_write.py scripts/migration/scbsly_supplier_payment_online_patch.py scripts/verify/scbsly_current_user_menu_dump.py scripts/verify/scbsly_direct_config_full_row_dump.py`
- `node --check scripts/verify/direct_project_business_browser_acceptance.js`
- `git diff --check`