### PR TITLE
Release construction product menus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -609,6 +609,9 @@ verify.business.finance_document_tier_runtime_smoke: check-compose-project check
 verify.contract_product_menu.release: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/contract_product_menu_release_audit.py
 
+verify.construction_product_menu.release: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/construction_product_menu_release_audit.py
+
 verify.tender_optional_scope_metadata.probe: check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/tender_optional_scope_metadata_probe.py
 

--- a/addons/smart_construction_core/models/support/product_policy_sync.py
+++ b/addons/smart_construction_core/models/support/product_policy_sync.py
@@ -34,6 +34,12 @@ USER_ACCEPTANCE_MENU_KEY_TOKENS = (
     "user_acceptance",
 )
 
+INTERNAL_CONFIG_ONLY_GROUP_XMLIDS = {
+    "base.group_no_one",
+    "smart_core.group_smart_core_admin",
+    "smart_construction_core.group_sc_cap_config_admin",
+}
+
 
 def _text(value):
     return str(value or "").strip()
@@ -54,7 +60,86 @@ class ScProductPolicy(models.Model):
         service = ProductPolicyCatalogSyncService(self.env)
         for product_key in ("construction.standard", "construction.preview"):
             policy = service.sync_policy(product_key=product_key, preserve_state=True, preserve_access_level=True)
-            self._apply_formal_contract_product_menu_domain(policy)
+            self._release_all_construction_product_menus(policy)
+        return True
+
+    @api.model
+    def _release_all_construction_product_menus(self, policy):
+        if not policy:
+            return False
+
+        def _menu_key(row):
+            return _text(row.get("menu_xmlid") or row.get("page_key") or row.get("menu_key"))
+
+        def _menu_group_xmlids(row):
+            key = _menu_key(row)
+            menu = self.env.ref(key, raise_if_not_found=False) if key else False
+            if not menu:
+                return set()
+            return {_text(xmlid) for xmlid in menu.groups_id.get_external_id().values() if _text(xmlid)}
+
+        def _is_internal_config_only(row):
+            group_xmlids = _menu_group_xmlids(row)
+            return bool(group_xmlids) and group_xmlids.issubset(INTERNAL_CONFIG_ONLY_GROUP_XMLIDS)
+
+        def _release_domain(row):
+            key = _menu_key(row)
+            if key in FORMAL_CONTRACT_PRODUCT_MENU_XMLIDS:
+                return "contract"
+            if key in FORMAL_SETTLEMENT_PRODUCT_MENU_XMLIDS:
+                return "settlement"
+            if _is_user_acceptance_menu_key(key):
+                return "user_acceptance"
+            group_key = _text(row.get("group_key"))
+            if group_key.startswith("construction."):
+                return group_key.split(".", 1)[1] or "construction"
+            return "construction"
+
+        def _apply_release_state(rows):
+            out = []
+            for row in rows or []:
+                if not isinstance(row, dict):
+                    continue
+                next_row = dict(row)
+                if _is_internal_config_only(next_row):
+                    next_row.update(
+                        {
+                            "enabled": False,
+                            "release_state": "hidden",
+                            "access_level": "internal",
+                            "release_domain": "internal_config",
+                            "policy_note": "hidden_from_user_product_release_config_admin_only",
+                        }
+                    )
+                else:
+                    next_row.update(
+                        {
+                            "enabled": True,
+                            "release_state": "released",
+                            "access_level": "public",
+                            "release_domain": _release_domain(next_row),
+                            "policy_note": "released_as_construction_product_menu",
+                        }
+                    )
+                out.append(next_row)
+            return out
+
+        menu_groups = []
+        for group in policy.menu_groups or []:
+            if not isinstance(group, dict):
+                continue
+            next_group = dict(group)
+            next_group["menus"] = _apply_release_state(group.get("menus"))
+            menu_groups.append(next_group)
+
+        policy.write(
+            {
+                "menu_groups": menu_groups,
+                "scenes": _apply_release_state(policy.scenes),
+                "capabilities": _apply_release_state(policy.capabilities),
+                "note": "all construction user-facing menu pages are released as product menus; config-admin-only internal pages remain hidden",
+            }
+        )
         return True
 
     @api.model

--- a/scripts/verify/construction_product_menu_release_audit.py
+++ b/scripts/verify/construction_product_menu_release_audit.py
@@ -1,0 +1,142 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+
+
+PRODUCT_KEYS = ("construction.standard", "construction.preview")
+VISIBLE_CHECK_USERS = ("wutao", "demo_role_project_read", "sc_fx_pm")
+ALLOWED_HIDDEN_RELEASE_DOMAINS = {"internal_config"}
+
+
+def _text(value):
+    return str(value or "").strip()
+
+
+def _external_id(record):
+    return record.get_external_id().get(record.id, "") if record else ""
+
+
+def _released_policy_menus(product_key):
+    policy = env["sc.product.policy"].sudo().search([("product_key", "=", product_key)], limit=1)  # noqa: F821
+    if not policy:
+        raise AssertionError("missing product policy: %s" % product_key)
+    if not policy.active or policy.access_level != "public":
+        raise AssertionError("%s must be active public" % product_key)
+
+    rows = []
+    hidden = []
+    allowed_hidden = []
+    for group in policy.menu_groups or []:
+        if not isinstance(group, dict):
+            continue
+        for menu in group.get("menus") or []:
+            if not isinstance(menu, dict):
+                continue
+            if menu.get("enabled") and menu.get("release_state") == "released":
+                rows.append(menu)
+            else:
+                item = {
+                    "group": _text(group.get("group_label") or group.get("group_key")),
+                    "menu": _text(menu.get("menu_xmlid") or menu.get("page_key") or menu.get("menu_key")),
+                    "enabled": bool(menu.get("enabled")),
+                    "release_state": _text(menu.get("release_state")),
+                    "release_domain": _text(menu.get("release_domain")),
+                    "access_level": _text(menu.get("access_level")),
+                }
+                if item["release_domain"] in ALLOWED_HIDDEN_RELEASE_DOMAINS:
+                    allowed_hidden.append(item)
+                else:
+                    hidden.append(item)
+    if hidden:
+        raise AssertionError("%s still has hidden product menus: %s" % (product_key, hidden[:20]))
+    if not rows:
+        raise AssertionError("%s has no released menus" % product_key)
+    return rows, allowed_hidden
+
+
+def _visible_menu_ids_by_login():
+    out = {}
+    for login in VISIBLE_CHECK_USERS:
+        user = env["res.users"].sudo().search([("login", "=", login)], limit=1)  # noqa: F821
+        if not user:
+            continue
+        out[login] = set(env["ir.ui.menu"].with_user(user)._visible_menu_ids())  # noqa: F821
+    if not out:
+        raise AssertionError("no verification users exist: %s" % (VISIBLE_CHECK_USERS,))
+    return out
+
+
+def _assert_menu_runtime(menu_row, visible_by_login):
+    menu_xmlid = _text(menu_row.get("menu_xmlid") or menu_row.get("page_key") or menu_row.get("menu_key"))
+    if not menu_xmlid:
+        raise AssertionError("released menu is missing menu_xmlid/page_key: %s" % menu_row)
+    menu = env.ref(menu_xmlid, raise_if_not_found=False)  # noqa: F821
+    if not menu:
+        raise AssertionError("released menu xmlid does not resolve: %s" % menu_xmlid)
+    if hasattr(menu, "active") and not bool(menu.active):
+        raise AssertionError("released menu is inactive: %s" % menu_xmlid)
+    if not menu.action:
+        raise AssertionError("released menu has no action: %s" % menu_xmlid)
+    action_id = int(menu_row.get("action_id") or 0)
+    if action_id and int(menu.action.id or 0) != action_id:
+        raise AssertionError(
+            "released menu action drift: %s policy=%s actual=%s"
+            % (menu_xmlid, action_id, int(menu.action.id or 0))
+        )
+    res_model = _text(getattr(menu.action, "res_model", "")) or _text(menu_row.get("res_model"))
+    if not res_model:
+        raise AssertionError("released menu action has no res_model: %s" % menu_xmlid)
+    if res_model not in env:  # noqa: F821
+        raise AssertionError("released menu action model missing: %s -> %s" % (menu_xmlid, res_model))
+    visible_logins = [login for login, visible_ids in visible_by_login.items() if int(menu.id) in visible_ids]
+    if not visible_logins:
+        raise AssertionError(
+            "released menu is not visible to verification users: %s groups=%s"
+            % (menu_xmlid, sorted(_external_id(group) for group in menu.groups_id))
+        )
+    return {
+        "menu_xmlid": menu_xmlid,
+        "label": _text(menu.name),
+        "path": _text(menu_row.get("visible_menu_path")),
+        "action_id": int(menu.action.id or 0),
+        "res_model": res_model,
+        "visible_logins": visible_logins,
+    }
+
+
+def main():
+    visible_by_login = _visible_menu_ids_by_login()
+    product_counts = {}
+    hidden_counts = {}
+    audited = {}
+    seen = set()
+    for product_key in PRODUCT_KEYS:
+        rows, allowed_hidden = _released_policy_menus(product_key)
+        product_counts[product_key] = len(rows)
+        hidden_counts[product_key] = len(allowed_hidden)
+        for row in rows:
+            menu_xmlid = _text(row.get("menu_xmlid") or row.get("page_key") or row.get("menu_key"))
+            if menu_xmlid in seen:
+                continue
+            audited[menu_xmlid] = _assert_menu_runtime(row, visible_by_login)
+            seen.add(menu_xmlid)
+
+    print(
+        json.dumps(
+            {
+                "status": "PASS",
+                "db": env.cr.dbname,  # noqa: F821
+                "products": product_counts,
+                "allowed_hidden_internal_menu_counts": hidden_counts,
+                "unique_released_menu_count": len(audited),
+                "visible_users": sorted(visible_by_login),
+                "sample_menus": list(audited.values())[:20],
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+
+
+main()

--- a/scripts/verify/contract_product_menu_release_audit.py
+++ b/scripts/verify/contract_product_menu_release_audit.py
@@ -128,9 +128,6 @@ def main():
         missing = [xmlid for xmlid in REQUIRED_RELEASED_MENU_XMLIDS if xmlid not in keys]
         if missing:
             raise AssertionError("%s missing released formal pages: %s" % (product_key, missing))
-        unexpected = sorted(key for key in keys - set(REQUIRED_RELEASED_MENU_XMLIDS) if not _is_user_acceptance_key(key))
-        if unexpected:
-            raise AssertionError("%s released non-formal-domain pages: %s" % (product_key, unexpected[:20]))
         product_results[product_key] = len(keys)
 
     for login in VISIBLE_CHECK_USERS:


### PR DESCRIPTION
## Summary
- release all user-facing Smart Construction menu pages through construction product policies
- keep platform-admin, config-admin-only, and technical menus hidden from user product release
- add a full construction product menu runtime audit and keep the contract/settlement audit compatible with broader product releases

## Validation
- `python3 -m py_compile addons/smart_construction_core/models/support/product_policy_sync.py scripts/verify/construction_product_menu_release_audit.py scripts/verify/contract_product_menu_release_audit.py`
- `git diff --check`
- `CODEX_NEED_UPGRADE=1 CODEX_MODULES=smart_core,smart_construction_core,smart_construction_scene MODULE=smart_core,smart_construction_core,smart_construction_scene DB_NAME=sc_demo DB=sc_demo make mod.upgrade`
- `DB_NAME=sc_demo DB=sc_demo make verify.construction_product_menu.release`
- `DB_NAME=sc_demo DB=sc_demo make verify.contract_product_menu.release`