### PR TITLE
Guard product menu runtime overlays

### DIFF
--- a/addons/smart_core/controllers/platform_menu_api.py
+++ b/addons/smart_core/controllers/platform_menu_api.py
@@ -246,9 +246,28 @@ def _is_business_config_user(env) -> bool:
 
 
 def _apply_user_menu_config(env, nav_fact: dict) -> tuple[dict, dict]:
+    try:
+        raw = env["ir.config_parameter"].sudo().get_param("smart_core.nav.user_menu_config.enabled", "")
+    except Exception:
+        raw = ""
+    if str(raw or "").strip().lower() not in {"1", "true", "yes", "on"}:
+        return nav_fact, {
+            "applied": False,
+            "reason": "disabled",
+            "smart_core.nav.user_menu_config.enabled": str(raw or "").strip() or "0",
+            "applied_count": 0,
+            "hidden_count": 0,
+            "renamed_count": 0,
+            "reordered_count": 0,
+            "moved_count": 0,
+        }
     if "ui.menu.config.policy" not in env:
-        return nav_fact, {"applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
-    return env["ui.menu.config.policy"].apply_runtime_overlay(nav_fact, user=env.user)
+        return nav_fact, {"applied": False, "applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
+    overlaid, stats = env["ui.menu.config.policy"].apply_runtime_overlay(nav_fact, user=env.user)
+    if not isinstance(stats, dict):
+        stats = {}
+    stats.setdefault("applied", True)
+    return overlaid, stats
 
 
 class PlatformMenuAPI(http.Controller):

--- a/addons/smart_core/handlers/system_init.py
+++ b/addons/smart_core/handlers/system_init.py
@@ -641,14 +641,32 @@ def _filter_nav_by_release_gate(nav: list[dict], gate: dict) -> tuple[list[dict]
 
 def _apply_user_menu_config_to_delivery_nav(env, nav: list[dict]) -> tuple[list[dict], dict]:
     if not isinstance(nav, list):
-        return [], {"applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
+        return [], {"applied": False, "applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
+    try:
+        raw = env["ir.config_parameter"].sudo().get_param("smart_core.nav.user_menu_config.enabled", "")
+    except Exception:
+        raw = ""
+    if str(raw or "").strip().lower() not in {"1", "true", "yes", "on"}:
+        return nav, {
+            "applied": False,
+            "reason": "disabled",
+            "smart_core.nav.user_menu_config.enabled": str(raw or "").strip() or "0",
+            "applied_count": 0,
+            "hidden_count": 0,
+            "renamed_count": 0,
+            "reordered_count": 0,
+            "moved_count": 0,
+        }
     try:
         policy_model = env["ui.menu.config.policy"]
     except Exception:
-        return nav, {"applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
+        return nav, {"applied": False, "applied_count": 0, "hidden_count": 0, "renamed_count": 0, "reordered_count": 0}
     overlaid, stats = policy_model.apply_runtime_overlay({"tree": nav, "flat": []}, user=env.user)
     next_nav = overlaid.get("tree") if isinstance(overlaid, dict) and isinstance(overlaid.get("tree"), list) else nav
-    return next_nav, stats if isinstance(stats, dict) else {}
+    if not isinstance(stats, dict):
+        stats = {}
+    stats.setdefault("applied", True)
+    return next_nav, stats
 
 
 def _user_data_acceptance_nav_only_enabled(env) -> bool:

--- a/scripts/verify/construction_product_menu_release_audit.py
+++ b/scripts/verify/construction_product_menu_release_audit.py
@@ -7,6 +7,7 @@ import json
 PRODUCT_KEYS = ("construction.standard", "construction.preview")
 VISIBLE_CHECK_USERS = ("wutao", "demo_role_project_read", "sc_fx_pm")
 ALLOWED_HIDDEN_RELEASE_DOMAINS = {"internal_config"}
+TRUTHY_VALUES = {"1", "true", "yes", "on"}
 
 
 def _text(value):
@@ -15,6 +16,24 @@ def _text(value):
 
 def _external_id(record):
     return record.get_external_id().get(record.id, "") if record else ""
+
+
+def _assert_product_navigation_mode():
+    Param = env["ir.config_parameter"].sudo()  # noqa: F821
+    acceptance_only = Param.get_param("smart_core.nav.user_data_acceptance_only", "")
+    user_menu_config = Param.get_param("smart_core.nav.user_menu_config.enabled", "")
+    if _text(acceptance_only).lower() in TRUTHY_VALUES:
+        raise AssertionError(
+            "smart_core.nav.user_data_acceptance_only must be disabled for full product menu release"
+        )
+    if _text(user_menu_config).lower() in TRUTHY_VALUES:
+        raise AssertionError(
+            "smart_core.nav.user_menu_config.enabled must be disabled for full product menu release"
+        )
+    return {
+        "smart_core.nav.user_data_acceptance_only": _text(acceptance_only) or "0",
+        "smart_core.nav.user_menu_config.enabled": _text(user_menu_config) or "0",
+    }
 
 
 def _released_policy_menus(product_key):
@@ -106,6 +125,7 @@ def _assert_menu_runtime(menu_row, visible_by_login):
 
 
 def main():
+    runtime_mode = _assert_product_navigation_mode()
     visible_by_login = _visible_menu_ids_by_login()
     product_counts = {}
     hidden_counts = {}
@@ -128,6 +148,7 @@ def main():
                 "status": "PASS",
                 "db": env.cr.dbname,  # noqa: F821
                 "products": product_counts,
+                "runtime_mode": runtime_mode,
                 "allowed_hidden_internal_menu_counts": hidden_counts,
                 "unique_released_menu_count": len(audited),
                 "visible_users": sorted(visible_by_login),


### PR DESCRIPTION
## Summary
- gate `ui.menu.config.policy` runtime overlays behind `smart_core.nav.user_menu_config.enabled`
- keep full product menu release mode from being narrowed by legacy user-menu config policies
- extend construction product menu release audit to fail when runtime narrowing switches are enabled

## Verification
- `python3 -m py_compile addons/smart_core/handlers/system_init.py addons/smart_core/controllers/platform_menu_api.py scripts/verify/construction_product_menu_release_audit.py`
- `DB_NAME=sc_demo DB=sc_demo make verify.construction_product_menu.release`