### PR TITLE
Flatten user data acceptance menu

### DIFF
--- a/addons/smart_core/handlers/system_init.py
+++ b/addons/smart_core/handlers/system_init.py
@@ -690,9 +690,6 @@ def _filter_nav_for_user_data_acceptance_only(env, nav: list[dict], *, force: bo
     old_acceptance_children = []
     direct_acceptance_children = []
     joint_acceptance_children = []
-    old_acceptance_groups = []
-    direct_acceptance_groups = []
-    joint_acceptance_groups = []
     acceptance_source_labels = {"old": [], "direct": [], "joint": []}
     required_joint_acceptance_menu_xmlids = [
         "smart_construction_core.menu_scbsly_joint_acceptance_self_funding_advance_income",
@@ -752,17 +749,19 @@ def _filter_nav_for_user_data_acceptance_only(env, nav: list[dict], *, force: bo
                 out.append(node)
         return out
 
-    def acceptance_group_from_source(group: dict, *, label: str, key: str, source: str) -> dict:
-        next_group = dict(group)
-        next_group["key"] = key
-        next_group["label"] = label
-        next_group["title"] = label
-        meta = dict(next_group.get("meta") if isinstance(next_group.get("meta"), dict) else {})
-        meta["group_key"] = key.replace("group:", "", 1)
-        meta["source"] = source
-        meta["acceptance_projection"] = True
-        next_group["meta"] = meta
-        return next_group
+    def mark_acceptance_projection(nodes: list[dict], *, source_bucket: str) -> list[dict]:
+        projected = []
+        for node in nodes or []:
+            if not isinstance(node, dict):
+                continue
+            next_node = dict(node)
+            meta = dict(next_node.get("meta") if isinstance(next_node.get("meta"), dict) else {})
+            meta["source"] = "user_data_acceptance_source_menu_projection"
+            meta["acceptance_projection"] = True
+            meta["acceptance_source_bucket"] = source_bucket
+            next_node["meta"] = meta
+            projected.append(next_node)
+        return projected
 
     def menu_leaf_from_xmlid(xmlid: str) -> dict | None:
         try:
@@ -892,15 +891,9 @@ def _filter_nav_for_user_data_acceptance_only(env, nav: list[dict], *, force: bo
                 continue
             if label in old_acceptance_group_labels:
                 acceptance_source_labels["old"].append(label)
-                old_acceptance_groups.append(
-                    acceptance_group_from_source(
-                        group,
-                        label="旧业务数据核对",
-                        key="group:legacy_business_data_acceptance",
-                        source="user_data_acceptance_source_menu_projection",
-                    )
+                old_acceptance_children.extend(
+                    mark_acceptance_projection(flatten_target_children(children), source_bucket="old")
                 )
-                old_acceptance_children.extend(flatten_target_children(children))
                 continue
             if label in acceptance_root_labels:
                 for child in children:
@@ -910,53 +903,31 @@ def _filter_nav_for_user_data_acceptance_only(env, nav: list[dict], *, force: bo
                     child_children = child.get("children") if isinstance(child.get("children"), list) else []
                     if child_label in joint_acceptance_group_labels or "联营" in child_label:
                         acceptance_source_labels["joint"].append(child_label or label)
-                        joint_acceptance_groups.append(
-                            acceptance_group_from_source(
-                                child,
-                                label="联营项目数据核对",
-                                key="group:joint_project_data_acceptance",
-                                source="user_data_acceptance_source_menu_projection",
-                            )
+                        joint_acceptance_children.extend(
+                            mark_acceptance_projection(flatten_target_children(child_children), source_bucket="joint")
                         )
-                        joint_acceptance_children.extend(flatten_target_children(child_children))
                     elif child_label in direct_acceptance_group_labels or "直营" in child_label:
                         acceptance_source_labels["direct"].append(child_label or label)
-                        direct_acceptance_groups.append(
-                            acceptance_group_from_source(
-                                child,
-                                label="直营项目数据核对",
-                                key="group:direct_project_data_acceptance",
-                                source="user_data_acceptance_source_menu_projection",
-                            )
+                        direct_acceptance_children.extend(
+                            mark_acceptance_projection(flatten_target_children(child_children), source_bucket="direct")
                         )
-                        direct_acceptance_children.extend(flatten_target_children(child_children))
                     else:
                         acceptance_source_labels["direct"].append(child_label or label)
-                        direct_acceptance_children.extend(flatten_target_children([child]))
+                        direct_acceptance_children.extend(
+                            mark_acceptance_projection(flatten_target_children([child]), source_bucket="direct")
+                        )
                 continue
             if label in direct_acceptance_group_labels:
                 acceptance_source_labels["direct"].append(label)
-                direct_acceptance_groups.append(
-                    acceptance_group_from_source(
-                        group,
-                        label="直营项目数据核对",
-                        key="group:direct_project_data_acceptance",
-                        source="user_data_acceptance_source_menu_projection",
-                    )
+                direct_acceptance_children.extend(
+                    mark_acceptance_projection(flatten_target_children(children), source_bucket="direct")
                 )
-                direct_acceptance_children.extend(flatten_target_children(children))
                 continue
             if label in joint_acceptance_group_labels:
                 acceptance_source_labels["joint"].append(label)
-                joint_acceptance_groups.append(
-                    acceptance_group_from_source(
-                        group,
-                        label="联营项目数据核对",
-                        key="group:joint_project_data_acceptance",
-                        source="user_data_acceptance_source_menu_projection",
-                    )
+                joint_acceptance_children.extend(
+                    mark_acceptance_projection(flatten_target_children(children), source_bucket="joint")
                 )
-                joint_acceptance_children.extend(flatten_target_children(children))
                 continue
 
     root_nodes = []
@@ -975,54 +946,9 @@ def _filter_nav_for_user_data_acceptance_only(env, nav: list[dict], *, force: bo
     settlement_product_completion_count = ensure_required_settlement_product_children()
 
     next_children = []
-    if old_acceptance_groups:
-        next_children.extend(old_acceptance_groups)
-    elif old_acceptance_children:
-        next_children.append(
-            {
-                "key": "group:legacy_business_data_acceptance",
-                "label": "旧业务数据核对",
-                "title": "旧业务数据核对",
-                "children": old_acceptance_children,
-                "meta": {
-                    "group_key": "legacy_business_data_acceptance",
-                    "source": "user_data_acceptance_only_runtime_filter",
-                    "source_labels": acceptance_source_labels["old"],
-                },
-            }
-        )
-    if direct_acceptance_groups:
-        next_children.extend(direct_acceptance_groups)
-    elif direct_acceptance_children:
-        next_children.append(
-            {
-                "key": "group:direct_project_data_acceptance",
-                "label": "直营项目数据核对",
-                "title": "直营项目数据核对",
-                "children": direct_acceptance_children,
-                "meta": {
-                    "group_key": "direct_project_data_acceptance",
-                    "source": "user_data_acceptance_only_runtime_filter",
-                    "source_labels": acceptance_source_labels["direct"],
-                },
-            }
-        )
-    if joint_acceptance_groups:
-        next_children.extend(joint_acceptance_groups)
-    elif joint_acceptance_children:
-        next_children.append(
-            {
-                "key": "group:joint_project_data_acceptance",
-                "label": "联营项目数据核对",
-                "title": "联营项目数据核对",
-                "children": joint_acceptance_children,
-                "meta": {
-                    "group_key": "joint_project_data_acceptance",
-                    "source": "user_data_acceptance_only_runtime_filter",
-                    "source_labels": acceptance_source_labels["joint"],
-                },
-            }
-        )
+    next_children.extend(old_acceptance_children)
+    next_children.extend(direct_acceptance_children)
+    next_children.extend(joint_acceptance_children)
 
     if not next_children:
         return [], {


### PR DESCRIPTION
## Summary
- flatten projected user data acceptance entries under `用户数据验收`
- keep source metadata for old/direct/joint acceptance entries without rendering the source groups
- remove the extra `旧业务数据核对` / `直营项目数据核对` display grouping from the acceptance projection

## Verification
- `python3 -m py_compile addons/smart_core/handlers/system_init.py`
- `git diff --check`