### PR TITLE
Add receiving account to engineering progress receipts

### DIFF
--- a/addons/smart_construction_core/models/support/legacy_engineering_progress_receipt.py
+++ b/addons/smart_construction_core/models/support/legacy_engineering_progress_receipt.py
@@ -25,6 +25,7 @@ class ScLegacyEngineeringProgressReceipt(models.Model):
     income_category = fields.Char(string="收入类别", readonly=True)
     state_label = fields.Char(string="状态", readonly=True)
     contract_no = fields.Char(string="施工管理合同", readonly=True)
+    receiving_account = fields.Char(string="收款账户", readonly=True)
     attachment_ref = fields.Char(string="附件", readonly=True)
     creator_name = fields.Char(string="历史录入人", readonly=True)
     created_time = fields.Datetime(string="历史录入时间", readonly=True)
@@ -60,6 +61,7 @@ class ScLegacyEngineeringProgressReceipt(models.Model):
                         ELSE f.legacy_state::varchar
                     END AS state_label,
                     f.legacy_contract_no::varchar AS contract_no,
+                    f.legacy_receiving_account::varchar AS receiving_account,
                     f.legacy_attachment_ref::varchar AS attachment_ref,
                     f.creator_name::varchar AS creator_name,
                     f.created_time AS created_time,

--- a/addons/smart_construction_core/models/support/legacy_receipt_income_fact.py
+++ b/addons/smart_construction_core/models/support/legacy_receipt_income_fact.py
@@ -27,6 +27,7 @@ class ScLegacyReceiptIncomeFact(models.Model):
     legacy_partner_name = fields.Char(string="旧库往来单位名称")
     legacy_company_name = fields.Char(string="旧库所属公司")
     legacy_contract_no = fields.Char(string="旧库施工管理合同")
+    legacy_receiving_account = fields.Char(string="旧库收款账户")
     legacy_attachment_ref = fields.Char(string="旧库附件")
     source_amount = fields.Float(string="原始金额")
     creator_legacy_user_id = fields.Char(string="历史录入人ID", index=True)

--- a/addons/smart_construction_core/views/support/legacy_engineering_progress_receipt_views.xml
+++ b/addons/smart_construction_core/views/support/legacy_engineering_progress_receipt_views.xml
@@ -40,6 +40,7 @@
                     <field name="amount" string="工程款收入" sum="工程款收入合计"/>
                     <field name="note" optional="show"/>
                     <field name="contract_no" string="施工管理合同" optional="show"/>
+                    <field name="receiving_account" string="收款账户" optional="show"/>
                     <field name="attachment_ref" string="附件" optional="show"/>
                     <field name="operation_strategy" optional="hide"/>
                     <field name="receipt_type" optional="hide"/>

--- a/scripts/migration/fresh_db_legacy_receipt_income_replay_adapter.py
+++ b/scripts/migration/fresh_db_legacy_receipt_income_replay_adapter.py
@@ -74,6 +74,7 @@ def main() -> int:
         "legacy_partner_name",
         "legacy_company_name",
         "legacy_contract_no",
+        "legacy_receiving_account",
         "legacy_attachment_ref",
         "source_amount",
         "note",

--- a/scripts/migration/fresh_db_legacy_receipt_income_replay_write.py
+++ b/scripts/migration/fresh_db_legacy_receipt_income_replay_write.py
@@ -147,6 +147,7 @@ for row in rows:
         "legacy_partner_name": clean(row.get("legacy_partner_name")),
         "legacy_company_name": clean(row.get("legacy_company_name")),
         "legacy_contract_no": clean(row.get("legacy_contract_no")),
+        "legacy_receiving_account": clean(row.get("legacy_receiving_account")),
         "legacy_attachment_ref": clean(row.get("legacy_attachment_ref")),
         "source_amount": as_float(row.get("source_amount", "")),
         "note": clean(row.get("note")),

--- a/scripts/migration/legacy_engineering_progress_receipt_visible_fields_backfill.py
+++ b/scripts/migration/legacy_engineering_progress_receipt_visible_fields_backfill.py
@@ -2,7 +2,8 @@
 """Backfill old-page visible fields for engineering-progress receipt facts.
 
 Run through ``odoo shell`` after exporting a CSV with columns:
-legacy_record_id, legacy_company_name, legacy_contract_no, legacy_attachment_ref.
+legacy_record_id, legacy_company_name, legacy_contract_no, legacy_receiving_account,
+legacy_attachment_ref.
 """
 
 from __future__ import annotations
@@ -49,6 +50,7 @@ def main() -> int:
         clean(row.get("legacy_record_id")): {
             "legacy_company_name": clean(row.get("legacy_company_name")),
             "legacy_contract_no": clean(row.get("legacy_contract_no")),
+            "legacy_receiving_account": clean(row.get("legacy_receiving_account")),
             "legacy_attachment_ref": clean(row.get("legacy_attachment_ref")),
         }
         for row in rows

--- a/scripts/migration/legacy_receipt_income_asset_generator.py
+++ b/scripts/migration/legacy_receipt_income_asset_generator.py
@@ -130,6 +130,7 @@ def write_xml(path: Path, records: list[dict[str, str]]) -> None:
         add_text(record, "legacy_partner_name", row["legacy_partner_name"])
         add_text(record, "legacy_company_name", row["legacy_company_name"])
         add_text(record, "legacy_contract_no", row["legacy_contract_no"])
+        add_text(record, "legacy_receiving_account", row["legacy_receiving_account"])
         add_text(record, "legacy_attachment_ref", row["legacy_attachment_ref"])
         add_text(record, "source_amount", row["source_amount"], True)
         add_text(record, "note", row["note"])
@@ -225,6 +226,7 @@ def build_records(asset_root: Path) -> tuple[list[dict[str, str]], dict[str, Any
             "legacy_partner_name": clean(row.get("partner_name")),
             "legacy_company_name": clean(row.get("company_name")),
             "legacy_contract_no": clean(row.get("contract_no")),
+            "legacy_receiving_account": clean(row.get("receiving_account")),
             "legacy_attachment_ref": clean(row.get("attachment_ref")),
             "source_amount": money(parse_amount(row.get("amount", ""))),
             "note": clean(row.get("note")),

--- a/scripts/migration/legacy_receipt_income_residual_screen.py
+++ b/scripts/migration/legacy_receipt_income_residual_screen.py
@@ -31,6 +31,7 @@ WITH src AS (
     CONVERT(nvarchar(max), f_SRLBName) AS income_category, CONVERT(nvarchar(max), f_BZ) AS note,
     CONVERT(nvarchar(max), SSGS) AS company_name,
     CONVERT(nvarchar(max), SGHTBH) AS contract_no,
+    CONVERT(nvarchar(max), SKZH) AS receiving_account,
     CONVERT(nvarchar(max), FJ) AS attachment_ref,
     CONVERT(nvarchar(max), PID) AS pid, 'customer_receipt' AS family, 'inflow' AS direction
   FROM dbo.C_JFHKLR
@@ -40,7 +41,7 @@ WITH src AS (
     CONVERT(nvarchar(max), SGD), CONVERT(nvarchar(max), COALESCE(NULLIF(KPSKQK_BQS, 0), NULLIF(BCKYZJYE_BQS, 0), NULLIF(SGDGCK_2, 0), NULLIF(YFSGDGCK_2, 0), NULLIF(SJZJ, 0))),
     CONVERT(nvarchar(max), SJ, 120), CONVERT(nvarchar(max), DJZT), CONVERT(nvarchar(max), DEL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL),
     CONVERT(nvarchar(max), '到款确认'), CONVERT(nvarchar(max), COALESCE(NULLIF(KPSKQK_BZ, ''), NULLIF(BCKYZJYE_BZ, ''), NULLIF(SQLCYE_BZ, ''))),
-    CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL),
+    CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL),
     CONVERT(nvarchar(max), pid), 'receipt_confirmation', 'inflow'
   FROM dbo.ZJGL_SZQR_DKQRB
   UNION ALL
@@ -48,7 +49,7 @@ WITH src AS (
     CONVERT(nvarchar(max), XMID), CONVERT(nvarchar(max), XMMC), CONVERT(nvarchar(max), FKDWID),
     CONVERT(nvarchar(max), FKDW), CONVERT(nvarchar(max), JZJE), CONVERT(nvarchar(max), SKSJ, 120),
     CONVERT(nvarchar(max), DJZT), CONVERT(nvarchar(max), DEL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), COALESCE(NULLIF(D_SCBSJS_CWSRLB, ''), NULLIF(SKLB, ''))),
-    CONVERT(nvarchar(max), BZ), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL),
+    CONVERT(nvarchar(max), BZ), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL), CONVERT(nvarchar(max), NULL),
     CONVERT(nvarchar(max), pid), 'company_financial_income', 'inflow'
   FROM dbo.C_CWSFK_GSCWSR
 )
@@ -70,6 +71,7 @@ SELECT CONCAT(
   ISNULL(REPLACE(REPLACE(REPLACE(note, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
   ISNULL(REPLACE(REPLACE(REPLACE(company_name, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
   ISNULL(REPLACE(REPLACE(REPLACE(contract_no, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
+  ISNULL(REPLACE(REPLACE(REPLACE(receiving_account, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
   ISNULL(REPLACE(REPLACE(REPLACE(attachment_ref, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
   ISNULL(REPLACE(REPLACE(REPLACE(pid, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
   ISNULL(REPLACE(REPLACE(REPLACE(family, @sep, ' '), CHAR(13), ' '), CHAR(10), ' '), ''), @sep,
@@ -83,7 +85,7 @@ SQL_COLUMNS = [
     "source_table", "legacy_id", "document_no", "project_id", "project_name",
     "partner_id", "partner_name", "amount", "document_date", "state", "deleted",
     "receipt_type", "receipt_subtype", "income_category", "note", "company_name",
-    "contract_no", "attachment_ref", "pid", "family", "direction",
+    "contract_no", "receiving_account", "attachment_ref", "pid", "family", "direction",
 ]
 
 

--- a/scripts/migration/scbs55_user_acceptance_replay.py
+++ b/scripts/migration/scbs55_user_acceptance_replay.py
@@ -366,6 +366,7 @@ def replay_engineering_progress(rows_by_key):
             "legacy_partner_name": clean(row.get("WLDWMC")),
             "legacy_company_name": clean(row.get("SSGS")),
             "legacy_contract_no": clean(row.get("SGHTBH")),
+            "legacy_receiving_account": clean(row.get("SKZH")),
             "legacy_attachment_ref": attachment_display(row),
             "source_amount": amount(row.get("f_JE")),
             "creator_legacy_user_id": clean(row.get("LRRID")),

--- a/scripts/migration/scbsly_direct_project_engineering_progress_receipt_replay.py
+++ b/scripts/migration/scbsly_direct_project_engineering_progress_receipt_replay.py
@@ -160,6 +160,7 @@ def values_for(row, project_cache, partner_cache, created_projects):
         "legacy_partner_name": clean(row.get("WLDWMC")),
         "legacy_company_name": clean(row.get("SSGS")),
         "legacy_contract_no": clean(row.get("SGHTBH")),
+        "legacy_receiving_account": clean(row.get("SKZH")),
         "legacy_attachment_ref": clean(row.get("f_FJ") or row.get("FJ")),
         "source_amount": amount(row.get("f_JE"), row.get("D_LYXM_JENR3")),
         "creator_legacy_user_id": clean(row.get("LRRID")),


### PR DESCRIPTION
## Summary
- Add legacy receiving account storage for receipt income facts
- Show `收款账户` on the engineering progress receipt acceptance list
- Map old-system `SKZH` in SCBS55 and SCBSLY engineering progress replay paths
- Carry the field through receipt income residual asset/replay helpers and the visible-field backfill script

## Verification
- `python3 -m py_compile ...` for touched Python files
- XML parse for `legacy_engineering_progress_receipt_views.xml`
- `git diff --check`
- Server `sc_demo` module upgrade completed
- Server verification: 3262 visible rows, `view_has_receiving_account=true`, `with_receiving_account=3169`, `blank_receiving_account=93`