### PR TITLE
Avoid project scope on menu list requests

### DIFF
--- a/frontend/apps/web/src/api/intents.ts
+++ b/frontend/apps/web/src/api/intents.ts
@@ -65,6 +65,24 @@ function buildHeaders(intent: string, traceId: string) {
 function withCurrentProjectContext(session: ReturnType<typeof useSessionStore>, payload: IntentPayload): IntentPayload {
   const intent = String(payload.intent || '').trim();
   const skip = new Set(['login', 'auth.login', 'auth.logout', 'session.bootstrap', 'sys.intents', 'project.context.search']);
+  const params = (payload.params && typeof payload.params === 'object' && !Array.isArray(payload.params))
+    ? { ...(payload.params as Record<string, unknown>) }
+    : payload.params;
+  const paramsContext = (params && typeof params === 'object' && !Array.isArray(params)
+    && (params as Record<string, unknown>).context
+    && typeof (params as Record<string, unknown>).context === 'object'
+    && !Array.isArray((params as Record<string, unknown>).context))
+    ? (params as Record<string, unknown>).context as Record<string, unknown>
+    : {};
+  const isMenuListRequest = intent === 'api.data'
+    && params
+    && typeof params === 'object'
+    && !Array.isArray(params)
+    && ['list', 'read'].includes(String((params as Record<string, unknown>).op || '').trim())
+    && Number(paramsContext.menu_id || 0) > 0;
+  if (isMenuListRequest) {
+    return payload;
+  }
   const projectId = Number(session.projectContext?.selected?.id || 0);
   const companyId = Number(session.projectContext?.company_id || session.projectContext?.selected?.company_id || 0);
   const operationStrategy = String(
@@ -79,16 +97,13 @@ function withCurrentProjectContext(session: ReturnType<typeof useSessionStore>, 
     ...(operationStrategy ? { operation_strategy: operationStrategy } : {}),
     ...(projectId ? { current_project_id: projectId } : {}),
   };
-  const params = (payload.params && typeof payload.params === 'object' && !Array.isArray(payload.params))
-    ? { ...(payload.params as Record<string, unknown>) }
-    : payload.params;
   if (params && typeof params === 'object' && !Array.isArray(params)) {
     const paramsRecord = params as Record<string, unknown>;
-    const paramsContext = (paramsRecord.context && typeof paramsRecord.context === 'object' && !Array.isArray(paramsRecord.context))
+    const requestContext = (paramsRecord.context && typeof paramsRecord.context === 'object' && !Array.isArray(paramsRecord.context))
       ? paramsRecord.context as Record<string, unknown>
       : {};
     paramsRecord.context = {
-      ...paramsContext,
+      ...requestContext,
       ...(companyId ? { company_id: companyId } : {}),
       ...(operationStrategy ? { operation_strategy: operationStrategy } : {}),
       ...(projectId ? { current_project_id: projectId } : {}),


### PR DESCRIPTION
## Summary
- stop injecting the selected project context into `api.data` list/read requests that already carry a menu context
- keep explicit project-scoped routes and non-menu project requests unchanged
- fixes the custom frontend case where `财务中心 / 收支 / 收入` + `公司直营` was emptied by a selected joint project

## Server execution
- rebuilt `frontend/apps/web` and deployed the generated static assets to the daily-dev nginx mount `frontend/apps/web/dist-dev`
- nginx reloaded on `root@1.95.85.92`, DB `sc_demo`

## Verification
- `pnpm -C frontend/apps/web typecheck`
- `pnpm -C frontend/apps/web build`
- Playwright browser verification against `http://1.95.85.92:18081`: with cached selected joint project `current_project_id=71`, opening `/a/778?menu_id=539&preset_filter=operation_direct` sends no `current_project_id` and returns `total=639`