### PR TITLE
Fix menu operation scope for formal receipts

### DIFF
--- a/frontend/apps/web/src/api/intents.ts
+++ b/frontend/apps/web/src/api/intents.ts
@@ -74,22 +74,45 @@ function withCurrentProjectContext(session: ReturnType<typeof useSessionStore>, 
     && !Array.isArray((params as Record<string, unknown>).context))
     ? (params as Record<string, unknown>).context as Record<string, unknown>
     : {};
+  const projectId = Number(session.projectContext?.selected?.id || 0);
+  const companyId = Number(session.projectContext?.company_id || session.projectContext?.selected?.company_id || 0);
+  const operationStrategy = String(
+    session.projectContext?.operation_strategy || session.projectContext?.selected?.operation_strategy || '',
+  ).trim();
   const isMenuListRequest = intent === 'api.data'
     && params
     && typeof params === 'object'
     && !Array.isArray(params)
     && ['list', 'read'].includes(String((params as Record<string, unknown>).op || '').trim())
     && Number(paramsContext.menu_id || 0) > 0;
-  if (isMenuListRequest) {
-    return payload;
-  }
-  const projectId = Number(session.projectContext?.selected?.id || 0);
-  const companyId = Number(session.projectContext?.company_id || session.projectContext?.selected?.company_id || 0);
-  const operationStrategy = String(
-    session.projectContext?.operation_strategy || session.projectContext?.selected?.operation_strategy || '',
-  ).trim();
   if ((!projectId && !companyId && !operationStrategy) || skip.has(intent)) {
     return payload;
+  }
+  if (isMenuListRequest) {
+    const context = {
+      ...(payload.context || {}),
+      ...(companyId ? { company_id: companyId } : {}),
+      ...(operationStrategy ? { operation_strategy: operationStrategy } : {}),
+    };
+    const paramsRecord = params as Record<string, unknown>;
+    const requestContext = (paramsRecord.context && typeof paramsRecord.context === 'object' && !Array.isArray(paramsRecord.context))
+      ? paramsRecord.context as Record<string, unknown>
+      : {};
+    // Menu actions are global lists: keep company/operation scope, but never narrow them to the selected project.
+    paramsRecord.context = {
+      ...requestContext,
+      ...(companyId ? { company_id: companyId } : {}),
+      ...(operationStrategy ? { operation_strategy: operationStrategy } : {}),
+    };
+    if (companyId) paramsRecord.company_id = companyId;
+    if (operationStrategy) paramsRecord.operation_strategy = operationStrategy;
+    delete paramsRecord.current_project_id;
+    delete (paramsRecord.context as Record<string, unknown>).current_project_id;
+    return {
+      ...payload,
+      context,
+      params,
+    };
   }
   const context = {
     ...(payload.context || {}),

--- a/scripts/migration/engineering_progress_receipt_formal_projection_write.py
+++ b/scripts/migration/engineering_progress_receipt_formal_projection_write.py
@@ -162,7 +162,7 @@ superseded_old_active = env.cr.rowcount  # noqa: F821
 env.cr.execute(  # noqa: F821
     """
     INSERT INTO sc_receipt_income (
-      name, source_origin, source_kind, state, project_id, partner_id,
+      name, source_origin, source_kind, state, project_id, company_id, partner_id,
       operation_strategy,
       date_receipt, document_no, receipt_type, legacy_receipt_type, legacy_receipt_subtype,
       income_category, payment_method, receiving_account, amount, currency_id,
@@ -176,6 +176,7 @@ env.cr.execute(  # noqa: F821
       'receipt_income',
       'legacy_confirmed',
       f.project_id,
+      project.company_id,
       COALESCE(f.partner_id, partner_match.id),
       f.operation_strategy,
       COALESCE(f.document_date, f.created_time::date, CURRENT_DATE),
@@ -210,6 +211,7 @@ env.cr.execute(  # noqa: F821
       NOW(),
       NOW()
     FROM sc_legacy_receipt_income_fact f
+    JOIN project_project project ON project.id = f.project_id
     LEFT JOIN LATERAL (
       SELECT rp.id
       FROM res_partner rp
@@ -230,6 +232,7 @@ env.cr.execute(  # noqa: F821
       source_kind = EXCLUDED.source_kind,
       state = EXCLUDED.state,
       project_id = EXCLUDED.project_id,
+      company_id = EXCLUDED.company_id,
       partner_id = EXCLUDED.partner_id,
       operation_strategy = EXCLUDED.operation_strategy,
       date_receipt = EXCLUDED.date_receipt,
@@ -261,9 +264,11 @@ env.cr.execute(  # noqa: F821
     """
     UPDATE sc_receipt_income income
        SET operation_strategy = fact.operation_strategy,
+           company_id = project.company_id,
            write_uid = 1,
            write_date = NOW()
       FROM sc_legacy_receipt_income_fact fact
+      JOIN project_project project ON project.id = fact.project_id
      WHERE fact.legacy_record_id = income.legacy_record_id
        AND fact.legacy_source_table = %s
        AND fact.source_family = %s
@@ -271,7 +276,10 @@ env.cr.execute(  # noqa: F821
        AND income.legacy_source_model = %s
        AND income.legacy_source_table = %s
        AND income.active
-       AND COALESCE(income.operation_strategy, '') <> COALESCE(fact.operation_strategy, '')
+       AND (
+         COALESCE(income.operation_strategy, '') <> COALESCE(fact.operation_strategy, '')
+         OR income.company_id IS DISTINCT FROM project.company_id
+       )
     """,
     [SOURCE_TABLE, SOURCE_FAMILY, SOURCE_MODEL, SOURCE_TABLE],
 )


### PR DESCRIPTION
## Summary
- keep company/operation scope on menu list requests while omitting selected project scope
- persist projected company_id for accepted engineering receipt formal income rows

## Verification
- pnpm -C frontend/apps/web typecheck
- pnpm -C frontend/apps/web build
- python3 -m py_compile scripts/migration/engineering_progress_receipt_formal_projection_write.py
- browser verified wutao on /a/778?menu_id=539&action_id=778: all=15905, company direct=639 with operation_strategy=direct and no current_project_id
