### PR TITLE
Add engineering progress income menu

### DIFF
--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -592,6 +592,20 @@
             ref('smart_construction_core.group_sc_cap_finance_manager')
         ])]"/>
     </record>
+    <record id="action_sc_receipt_income_engineering_progress" model="ir.actions.act_window">
+        <field name="name">工程进度款收入登记</field>
+        <field name="res_model">sc.receipt.income</field>
+        <field name="view_mode">tree,form</field>
+        <field name="search_view_id" ref="smart_construction_core.view_sc_receipt_income_search"/>
+        <field name="domain">[('source_kind', '=', 'receipt_income'), ('receipt_type', '=', '工程进度收款')]</field>
+        <field name="context">{'default_source_kind': 'receipt_income', 'default_receipt_type': '工程进度收款', 'default_income_category': '工程进度款收入', 'search_default_group_project': 1}</field>
+        <field name="groups_id" eval="[(6, 0, [
+            ref('smart_construction_core.group_sc_cap_business_initiator'),
+            ref('smart_construction_core.group_sc_cap_finance_read'),
+            ref('smart_construction_core.group_sc_cap_finance_user'),
+            ref('smart_construction_core.group_sc_cap_finance_manager')
+        ])]"/>
+    </record>
     <record id="action_sc_payment_execution_company_finance_expense" model="ir.actions.act_window">
         <field name="name">公司财务支出</field>
         <field name="res_model">sc.payment.execution</field>
@@ -1521,6 +1535,12 @@
               parent="smart_construction_core.menu_sc_income_expense_user_group"
               action="smart_construction_core.action_sc_receipt_income_user_income"
               sequence="10"
+              groups="smart_construction_core.group_sc_cap_business_initiator,smart_construction_core.group_sc_cap_finance_read,smart_construction_core.group_sc_cap_finance_user,smart_construction_core.group_sc_cap_finance_manager"/>
+    <menuitem id="menu_sc_engineering_progress_income"
+              name="工程进度款收入登记"
+              parent="smart_construction_core.menu_sc_income_expense_user_group"
+              action="smart_construction_core.action_sc_receipt_income_engineering_progress"
+              sequence="11"
               groups="smart_construction_core.group_sc_cap_business_initiator,smart_construction_core.group_sc_cap_finance_read,smart_construction_core.group_sc_cap_finance_user,smart_construction_core.group_sc_cap_finance_manager"/>
     <menuitem id="menu_sc_company_finance_expense"
               name="公司财务支出"


### PR DESCRIPTION
## Summary
- keep the existing 收入 entry as the broad income surface
- add a separate 工程进度款收入登记 formal menu/action under 财务中心 / 收支
- scope the new action to source_kind=receipt_income and receipt_type=工程进度收款

## Verification
- XML parsed with Python stdlib ElementTree
- data scope checked on sc_demo: 收入=15905, 工程进度款收入登记=3901, 公司直营=639
