### PR TITLE
Preserve action window metadata in V2 contracts

### DIFF
--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import logging
 import hashlib
+import ast
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
@@ -268,6 +269,11 @@ class UiContractV2Handler(BaseIntentHandler):
             "record": source_record,
             "source_meta": ui_meta,
         })
+        self._inject_action_window_contract(
+            source_contract,
+            params=params,
+            ui_params=ui_params,
+        )
         self._inject_current_form_settings_action(
             source_contract,
             params=params,
@@ -325,6 +331,80 @@ class UiContractV2Handler(BaseIntentHandler):
                 "source_authority": self.source_authority_contract(),
             },
         )
+
+    def _inject_action_window_contract(
+        self,
+        source_contract: dict[str, Any],
+        *,
+        params: dict[str, Any],
+        ui_params: dict[str, Any],
+    ) -> None:
+        head = source_contract.get("head") if isinstance(source_contract.get("head"), dict) else {}
+        raw_action_id = (
+            params.get("action_id")
+            or params.get("actionId")
+            or ui_params.get("action_id")
+            or ui_params.get("actionId")
+            or source_contract.get("action_id")
+            or source_contract.get("actionId")
+            or head.get("action_id")
+        )
+        action_id, action_error = parse_positive_int(raw_action_id, allow_empty=True)
+        if action_error or not action_id:
+            return
+        try:
+            Action = self.env["ir.actions.act_window"].sudo()
+            action = Action.browse(action_id)
+        except Exception:
+            _logger.debug("ui.contract.v2 action metadata lookup skipped", exc_info=True)
+            return
+        try:
+            if not action.exists():
+                return
+        except Exception:
+            return
+
+        action_name = str(getattr(action, "name", "") or "").strip()
+        action_model = str(getattr(action, "res_model", "") or "").strip()
+        action_domain_raw = getattr(action, "domain", None)
+        action_context_raw = getattr(action, "context", None)
+        action_domain = _safe_eval_action_value(action_domain_raw, [])
+        action_context = _safe_eval_action_value(action_context_raw, {})
+
+        source_contract["action_id"] = action_id
+        if action_model:
+            source_contract["model"] = action_model
+        if action_name:
+            source_contract["title"] = action_name
+            head = source_contract.get("head") if isinstance(source_contract.get("head"), dict) else {}
+            head = dict(head)
+            head["title"] = action_name
+            head["action_id"] = action_id
+            source_contract["head"] = head
+
+        if isinstance(action_domain, list):
+            if not source_contract.get("domain"):
+                source_contract["domain"] = deepcopy(action_domain)
+            head = source_contract.get("head") if isinstance(source_contract.get("head"), dict) else {}
+            head = dict(head)
+            head.setdefault("domain", deepcopy(action_domain))
+            source_contract["head"] = head
+        if isinstance(action_domain_raw, str) and action_domain_raw.strip():
+            if not source_contract.get("domain_raw"):
+                source_contract["domain_raw"] = action_domain_raw
+
+        if isinstance(action_context, dict):
+            current_context = source_contract.get("context") if isinstance(source_contract.get("context"), dict) else {}
+            merged_context = dict(action_context)
+            merged_context.update(current_context)
+            source_contract["context"] = merged_context
+            head = source_contract.get("head") if isinstance(source_contract.get("head"), dict) else {}
+            head = dict(head)
+            head.setdefault("context", deepcopy(merged_context))
+            source_contract["head"] = head
+        if isinstance(action_context_raw, str) and action_context_raw.strip():
+            if not source_contract.get("context_raw"):
+                source_contract["context_raw"] = action_context_raw
 
     def _inject_current_form_settings_action(
         self,
@@ -1647,6 +1727,25 @@ def _ensure_source_form_contract(source_contract: dict[str, Any]) -> dict[str, A
         form = {}
         views["form"] = form
     return form
+
+
+def _safe_eval_action_value(value: Any, default: Any) -> Any:
+    if value in (None, False, ""):
+        return default
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if not text:
+        return default
+    try:
+        from odoo.tools.safe_eval import safe_eval
+
+        return safe_eval(text)
+    except Exception:
+        try:
+            return ast.literal_eval(text)
+        except Exception:
+            return default
 
 
 def _allowed_models_from_hook(env, hook_name: str) -> set[str]:

--- a/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
+++ b/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
@@ -223,6 +223,48 @@ class TestUiContractV2Boundaries(unittest.TestCase):
             {"id": 42, "name": "ACME"},
         )
 
+    def test_action_open_injects_action_window_domain_context_and_title(self):
+        class _Action:
+            id = 949
+            name = "工程进度款收入登记"
+            res_model = "sc.receipt.income"
+            domain = "[('source_kind', '=', 'receipt_income'), ('receipt_type', '=', '工程进度收款')]"
+            context = "{'default_source_kind': 'receipt_income', 'default_receipt_type': '工程进度收款'}"
+
+            def exists(self):
+                return True
+
+        class _ActionModel:
+            def sudo(self):
+                return self
+
+            def browse(self, action_id):
+                self.action_id = action_id
+                return _Action()
+
+        class _Env:
+            def __getitem__(self, model):
+                if model != "ir.actions.act_window":
+                    raise KeyError(model)
+                return _ActionModel()
+
+        handler = self.module.UiContractV2Handler(env=_Env())
+
+        result = handler.handle(payload={"params": {"op": "action_open", "action_id": 949}})
+
+        self.assertTrue(result.ok)
+        source = self.module._captured["assembler_source"]
+        self.assertEqual(source["action_id"], 949)
+        self.assertEqual(source["model"], "sc.receipt.income")
+        self.assertEqual(source["title"], "工程进度款收入登记")
+        self.assertEqual(source["head"]["title"], "工程进度款收入登记")
+        self.assertEqual(
+            source["domain"],
+            [("source_kind", "=", "receipt_income"), ("receipt_type", "=", "工程进度收款")],
+        )
+        self.assertEqual(source["context"]["default_receipt_type"], "工程进度收款")
+        self.assertEqual(source["domain_raw"], _Action.domain)
+
     def test_business_list_profile_keeps_contract_ledger_fields_visible(self):
         handler = self.module.UiContractV2Handler(env=object())
         columns = [{"name": f"field_{index}"} for index in range(24)]


### PR DESCRIPTION
## Summary
- inject `ir.actions.act_window` title/model/domain/context into `ui.contract.v2` action-open source contracts
- keep action domain/context available to the V2 data source assembler so frontend list loads honor menu action semantics
- add a focused boundary test for action-open metadata projection

## Verification
- `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `python3 addons/smart_core/tests/test_ui_contract_v2_boundaries.py TestUiContractV2Boundaries.test_action_open_injects_action_window_domain_context_and_title -v`

Note: full direct file run still has an existing unrelated `test_business_list_profile_keeps_contract_ledger_fields_visible` expectation mismatch (`31 != 24`).