### PR TITLE
Align engineering progress income with acceptance data

### DIFF
--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -597,8 +597,8 @@
         <field name="res_model">sc.receipt.income</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_receipt_income_search"/>
-        <field name="domain">[('source_kind', '=', 'receipt_income'), ('receipt_type', '=', '工程进度收款')]</field>
-        <field name="context">{'default_source_kind': 'receipt_income', 'default_receipt_type': '工程进度收款', 'default_income_category': '工程进度款收入', 'search_default_group_project': 1}</field>
+        <field name="domain">[('source_kind', '=', 'receipt_income'), ('legacy_source_model', '=', 'sc.legacy.receipt.income.fact'), ('legacy_source_table', '=', 'C_JFHKLR')]</field>
+        <field name="context">{'default_source_kind': 'receipt_income', 'default_receipt_type': '正常类型收款', 'default_income_category': '工程进度款收入', 'search_default_group_project': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),
             ref('smart_construction_core.group_sc_cap_finance_read'),

--- a/scripts/migration/engineering_progress_receipt_formal_projection_write.py
+++ b/scripts/migration/engineering_progress_receipt_formal_projection_write.py
@@ -177,11 +177,11 @@ env.cr.execute(  # noqa: F821
       'legacy_confirmed',
       f.project_id,
       project.company_id,
-      COALESCE(f.partner_id, partner_match.id),
+      f.partner_id,
       f.operation_strategy,
       COALESCE(f.document_date, f.created_time::date, CURRENT_DATE),
       NULLIF(f.document_no, ''),
-      '工程进度收款',
+      NULLIF(f.receipt_type, ''),
       NULLIF(f.receipt_type, ''),
       NULLIF(f.receipt_subtype, ''),
       NULLIF(f.income_category, ''),
@@ -212,15 +212,6 @@ env.cr.execute(  # noqa: F821
       NOW()
     FROM sc_legacy_receipt_income_fact f
     JOIN project_project project ON project.id = f.project_id
-    LEFT JOIN LATERAL (
-      SELECT rp.id
-      FROM res_partner rp
-      WHERE rp.active
-        AND NULLIF(f.legacy_partner_name, '') IS NOT NULL
-        AND rp.name = f.legacy_partner_name
-      ORDER BY rp.id
-      LIMIT 1
-    ) partner_match ON TRUE
     WHERE f.legacy_source_table = %s
       AND f.source_family = %s
       AND f.operation_strategy IN ('direct', 'joint')


### PR DESCRIPTION
## Summary
- switch the formal engineering progress income action to source-based filtering
- project formal receipt rows from the accepted legacy receipt type and partner relation without name fallback

## Verification
- `python3 - <<'PY' ... ET.parse('addons/smart_construction_core/views/menu_business_taxonomy.xml') ... PY`
- `python3 -m py_compile scripts/migration/engineering_progress_receipt_formal_projection_write.py`