### PR TITLE
Filter engineering progress income by source family

### DIFF
--- a/addons/smart_construction_core/models/core/receipt_income.py
+++ b/addons/smart_construction_core/models/core/receipt_income.py
@@ -27,6 +27,7 @@ class ScReceiptIncome(models.Model):
         required=True,
         index=True,
     )
+    source_family = fields.Char(string="来源类别", index=True, readonly=True)
     state = fields.Selection(
         [
             ("draft", "草稿"),

--- a/addons/smart_construction_core/views/menu_business_taxonomy.xml
+++ b/addons/smart_construction_core/views/menu_business_taxonomy.xml
@@ -597,7 +597,7 @@
         <field name="res_model">sc.receipt.income</field>
         <field name="view_mode">tree,form</field>
         <field name="search_view_id" ref="smart_construction_core.view_sc_receipt_income_search"/>
-        <field name="domain">[('source_kind', '=', 'receipt_income'), ('legacy_source_model', '=', 'sc.legacy.receipt.income.fact'), ('legacy_source_table', '=', 'C_JFHKLR')]</field>
+        <field name="domain">[('source_kind', '=', 'receipt_income'), ('legacy_source_model', '=', 'sc.legacy.receipt.income.fact'), ('legacy_source_table', '=', 'C_JFHKLR'), ('source_family', '=', 'engineering_progress_receipt_visible')]</field>
         <field name="context">{'default_source_kind': 'receipt_income', 'default_receipt_type': '正常类型收款', 'default_income_category': '工程进度款收入', 'search_default_group_project': 1}</field>
         <field name="groups_id" eval="[(6, 0, [
             ref('smart_construction_core.group_sc_cap_business_initiator'),

--- a/scripts/migration/engineering_progress_receipt_formal_projection_write.py
+++ b/scripts/migration/engineering_progress_receipt_formal_projection_write.py
@@ -162,7 +162,7 @@ superseded_old_active = env.cr.rowcount  # noqa: F821
 env.cr.execute(  # noqa: F821
     """
     INSERT INTO sc_receipt_income (
-      name, source_origin, source_kind, state, project_id, company_id, partner_id,
+      name, source_origin, source_kind, source_family, state, project_id, company_id, partner_id,
       operation_strategy,
       date_receipt, document_no, receipt_type, legacy_receipt_type, legacy_receipt_subtype,
       income_category, payment_method, receiving_account, amount, currency_id,
@@ -174,6 +174,7 @@ env.cr.execute(  # noqa: F821
       COALESCE(NULLIF(f.document_no, ''), 'LEGACY-ENGINEERING-RECEIPT-' || f.legacy_record_id),
       'legacy',
       'receipt_income',
+      f.source_family,
       'legacy_confirmed',
       f.project_id,
       project.company_id,
@@ -221,6 +222,7 @@ env.cr.execute(  # noqa: F821
       name = EXCLUDED.name,
       source_origin = EXCLUDED.source_origin,
       source_kind = EXCLUDED.source_kind,
+      source_family = EXCLUDED.source_family,
       state = EXCLUDED.state,
       project_id = EXCLUDED.project_id,
       company_id = EXCLUDED.company_id,


### PR DESCRIPTION
## Summary
- add `source_family` to formal receipt income records
- write the accepted engineering-progress source family during formal projection
- filter the formal engineering progress income action by source family so it matches the acceptance surface exactly

## Verification
- XML parse for `menu_business_taxonomy.xml`
- `python3 -m py_compile addons/smart_construction_core/models/core/receipt_income.py scripts/migration/engineering_progress_receipt_formal_projection_write.py`