### PR TITLE
Keep engineering progress visible values identical to acceptance

### DIFF
--- a/addons/smart_construction_core/models/core/receipt_income.py
+++ b/addons/smart_construction_core/models/core/receipt_income.py
@@ -95,6 +95,7 @@ class ScReceiptIncome(models.Model):
     legacy_document_state_label = fields.Char(string="历史状态名称", index=True, readonly=True)
     legacy_residual_reason = fields.Char(string="残余原因", index=True, readonly=True)
     legacy_attachment_ref = fields.Char(string="历史附件引用", readonly=True)
+    legacy_note = fields.Text(string="历史备注", readonly=True)
     creator_legacy_user_id = fields.Char(string="历史录入人ID", index=True, readonly=True)
     creator_name = fields.Char(string="历史录入人", index=True, readonly=True)
     created_time = fields.Datetime(string="历史录入时间", index=True, readonly=True)

--- a/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
+++ b/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
@@ -1505,6 +1505,33 @@ def _alias_value(record, label):
     payload = _legacy_visible_alias_payload(record)
     if payload and label in payload:
         return _normalize_payload_alias_value(label, payload.get(label))
+    if (
+        record._name == 'sc.receipt.income'
+        and _format_alias_value(record, 'source_family') == 'engineering_progress_receipt_visible'
+    ):
+        strict_sources = {
+            '单据状态': 'legacy_document_state_label',
+            '状态': 'legacy_document_state_label',
+            '项目名称': 'legacy_project_name',
+            '往来单位': 'legacy_partner_name',
+            '承包单位': 'legacy_company_name',
+            '施工管理合同': 'legacy_contract_no',
+            '单据编号': 'document_no',
+            '填写人': 'creator_name',
+            '收款账户': 'receiving_account',
+            '进账金额': 'amount',
+            '收入类别': 'income_category',
+            '收款时间': 'date_receipt',
+            '备注': 'legacy_note',
+            '附件': 'legacy_attachment_ref',
+            '录入人': 'creator_name',
+            '录入时间': 'created_time',
+        }
+        field_name = strict_sources.get(label)
+        if field_name:
+            return _format_alias_value(record, field_name)
+        if label in strict_sources:
+            return ''
     if record._name == 'sc.business.entity':
         strict_sources = {
             '单据状态': None,

--- a/addons/smart_construction_core/views/core/receipt_income_views.xml
+++ b/addons/smart_construction_core/views/core/receipt_income_views.xml
@@ -70,6 +70,7 @@
                     <field name="amount" sum="收款金额"/>
                     <field name="legacy_document_state_label" optional="show"/>
                     <field name="legacy_attachment_ref" optional="show"/>
+                    <field name="legacy_note" optional="show"/>
                     <field name="deducted_invoice_amount" sum="已抵发票金额"/>
                     <field name="deducted_tax_amount" sum="已抵税额"/>
                     <field name="settlement_amount" sum="结算金额"/>
@@ -154,6 +155,7 @@
                             <field name="legacy_document_state" readonly="1"/>
                             <field name="legacy_document_state_label" readonly="1"/>
                             <field name="legacy_attachment_ref" readonly="1"/>
+                            <field name="legacy_note" readonly="1"/>
                             <field name="creator_legacy_user_id" readonly="1"/>
                             <field name="creator_name" readonly="1"/>
                             <field name="created_time" readonly="1"/>

--- a/scripts/migration/engineering_progress_receipt_formal_projection_write.py
+++ b/scripts/migration/engineering_progress_receipt_formal_projection_write.py
@@ -168,7 +168,7 @@ env.cr.execute(  # noqa: F821
       date_receipt, document_no, receipt_type, legacy_receipt_type, legacy_receipt_subtype,
       income_category, payment_method, receiving_account, amount, currency_id,
       legacy_source_model, legacy_source_table, legacy_record_id, legacy_document_state,
-      legacy_document_state_label, legacy_attachment_ref, creator_legacy_user_id, creator_name, created_time,
+      legacy_document_state_label, legacy_attachment_ref, legacy_note, creator_legacy_user_id, creator_name, created_time,
       note, active, create_uid, write_uid, create_date, write_date
     )
     SELECT
@@ -207,6 +207,7 @@ env.cr.execute(  # noqa: F821
         ELSE NULLIF(f.legacy_state::varchar, '')
       END,
       NULLIF(f.legacy_attachment_ref, ''),
+      NULLIF(f.note, ''),
       NULLIF(f.creator_legacy_user_id, ''),
       NULLIF(f.creator_name, ''),
       f.created_time,
@@ -258,6 +259,7 @@ env.cr.execute(  # noqa: F821
       legacy_document_state = EXCLUDED.legacy_document_state,
       legacy_document_state_label = EXCLUDED.legacy_document_state_label,
       legacy_attachment_ref = EXCLUDED.legacy_attachment_ref,
+      legacy_note = EXCLUDED.legacy_note,
       creator_legacy_user_id = EXCLUDED.creator_legacy_user_id,
       creator_name = EXCLUDED.creator_name,
       created_time = EXCLUDED.created_time,
@@ -439,9 +441,9 @@ for field_name, formal_expr, source_expr in [
     ("legacy_attachment_ref", "COALESCE(NULLIF(income.legacy_attachment_ref, ''), '')", "COALESCE(NULLIF(fact.legacy_attachment_ref, ''), '')"),
     ("creator_name", "COALESCE(NULLIF(income.creator_name, ''), '')", "COALESCE(NULLIF(fact.creator_name, ''), '')"),
     ("created_time", "income.created_time", "fact.created_time"),
-    ("note_contains_source_note", "COALESCE(income.note, '')", "COALESCE(fact.note, '')"),
+    ("legacy_note", "COALESCE(NULLIF(income.legacy_note, ''), '')", "COALESCE(NULLIF(fact.note, ''), '')"),
 ]:
-    comparator = "POSITION(COALESCE(fact.note, '') IN COALESCE(income.note, '')) = 0" if field_name == "note_contains_source_note" else f"({formal_expr}) IS DISTINCT FROM ({source_expr})"
+    comparator = f"({formal_expr}) IS DISTINCT FROM ({source_expr})"
     field_mismatches[field_name] = int(
         scalar(
             f"""


### PR DESCRIPTION
## Summary
- add `legacy_note` as a formal carrying field for accepted receipt notes
- project and gate `legacy_note` exactly from the accepted source
- make P1 visible aliases for engineering progress receipts read accepted carrying fields without formal-model fallback

## Verification
- XML parse for `receipt_income_views.xml`
- `python3 -m py_compile addons/smart_construction_core/models/core/receipt_income.py addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py scripts/migration/engineering_progress_receipt_formal_projection_write.py`