### PR TITLE
[codex] Add business action coverage audit

### DIFF
--- a/docs/audit/business_action_coverage_audit_2026-06-09.md
+++ b/docs/audit/business_action_coverage_audit_2026-06-09.md
@@ -1,0 +1,33 @@
+# Business Action Coverage Audit 2026-06-09
+
+## Scope
+
+在业务闭环专项之后，继续验证用户确认正式菜单中的高频办理入口是否具备可执行的正式模型动作。
+
+本轮覆盖：
+
+- 付款执行：确认、登记付款、付款申请联动完成、付款台账生成
+- 收入登记：确认、登记收款、收款申请联动完成
+- 公司财务支出/费用单：提交、批准、完成、付款申请联动完成
+- 发票登记：确认、登记
+- 抵扣登记：确认、抵扣
+- 项目管理人员工资登记：提交、完成、月份规则拦截
+- 资金账户操作：确认、完成
+
+## Command
+
+```bash
+DB_NAME=sc_demo scripts/ops/validate_business_action_coverage.sh
+```
+
+## Result
+
+```text
+BUSINESS_ACTION_COVERAGE_AUDIT: {"audit": "business_action_coverage_audit", "coverage": {"expense_claim": {"claim": 271739, "payment_request": 35836, "settlement": 2776}, "fund_account_operation": {"operation": 90358, "source_account": 2653, "target_account": 2654}, "hr_payroll": {"payroll": 11196}, "invoice_registration": {"invoice": 774904}, "payment_execution": {"execution": 170323, "payment_request": 35834, "settlement": 2775}, "receipt_income": {"payment_request": 35835, "receipt": 351015}, "tax_deduction": {"deduction": 10238}}, "failures": [], "status": "PASS"}
+```
+
+## Notes
+
+- 脚本只创建专项审计数据并调用正式模型动作，不修改菜单体系，不覆盖用户已确认数据。
+- 付款执行、费用支出类付款按正式规则补齐结算单锚点后再生成付款台账。
+- 审计过程中保留负向校验：重复确认、未补齐锚点、无效工资月份等场景必须被业务模型拦截。

--- a/scripts/ops/validate_business_action_coverage.sh
+++ b/scripts/ops/validate_business_action_coverage.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/business_action_coverage_audit.py"

--- a/scripts/verify/business_action_coverage_audit.py
+++ b/scripts/verify/business_action_coverage_audit.py
@@ -1,0 +1,461 @@
+# -*- coding: utf-8 -*-
+import json
+import sys
+import traceback
+
+from odoo import fields
+from odoo.exceptions import UserError, ValidationError
+
+
+def _ensure_groups(env):
+    user = env.user.sudo()
+    for xmlid in (
+        "smart_construction_core.group_sc_cap_project_manager",
+        "smart_construction_core.group_sc_cap_finance_user",
+        "smart_construction_core.group_sc_cap_finance_manager",
+        "smart_construction_core.group_sc_cap_material_manager",
+    ):
+        group = env.ref(xmlid, raise_if_not_found=False)
+        if group and group.id not in user.groups_id.ids:
+            user.write({"groups_id": [(4, group.id)]})
+
+
+def _token():
+    return env["ir.sequence"].sudo().next_by_code("sc.business.fact") or str(fields.Datetime.now())
+
+
+def _expect_state(label, record, expected, failures):
+    record.invalidate_recordset()
+    if record.state != expected:
+        failures.append("%s: expected state=%s, got %s" % (label, expected, record.state))
+        return False
+    return True
+
+
+def _expect_exception(label, func, failures):
+    try:
+        with env.cr.savepoint():
+            func()
+    except (UserError, ValidationError):
+        return True
+    except Exception as err:
+        failures.append("%s: expected business exception, got %s: %s" % (label, type(err).__name__, err))
+        return False
+    failures.append("%s: expected business exception, got success" % label)
+    return False
+
+
+def _approve_if_needed(record, table_name):
+    record.invalidate_recordset()
+    if record.state != "draft":
+        return
+    if "validation_status" in record._fields:
+        env.cr.execute(
+            "UPDATE %s SET validation_status=%%s WHERE id=%%s" % table_name,
+            ("validated", record.id),
+        )
+        record.invalidate_recordset()
+    if hasattr(record, "action_on_tier_approved"):
+        record.action_on_tier_approved()
+
+
+def _partner(name):
+    return env["res.partner"].create({"name": "%s %s" % (name, _token())})
+
+
+def _project(name, funding=False):
+    project = env["project.project"].create(
+        {
+            "name": "%s %s" % (name, _token()),
+            "manager_id": env.user.id,
+            "funding_enabled": bool(funding),
+            "company_id": env.company.id,
+        }
+    )
+    if funding:
+        env["project.funding.baseline"].create(
+            {
+                "project_id": project.id,
+                "total_amount": 100000.0,
+                "state": "active",
+            }
+        )
+    return project
+
+
+def _department():
+    return env["hr.department"].create({"name": "BAC Audit Dept %s" % _token()})
+
+
+def _tax(name, tax_use):
+    return env["account.tax"].sudo().create(
+        {
+            "name": "%s %s" % (name, _token()),
+            "amount": 0.0,
+            "amount_type": "percent",
+            "type_tax_use": tax_use,
+            "price_include": False,
+            "company_id": env.company.id,
+        }
+    )
+
+
+def _contract(project, partner, direction):
+    return env["construction.contract"].create(
+        {
+            "subject": "BAC Audit Contract %s %s" % (direction, _token()),
+            "type": direction,
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "company_id": env.company.id,
+            "currency_id": env.company.currency_id.id,
+            "tax_id": _tax("BAC Audit Tax", "sale" if direction == "out" else "purchase").id,
+        }
+    )
+
+
+def _purchase_order(partner, amount):
+    uom = env.ref("uom.product_uom_unit", raise_if_not_found=False) or env["uom.uom"].sudo().search([], limit=1)
+    product = env["product.product"].sudo().create(
+        {
+            "name": "BAC Audit Service %s" % _token(),
+            "type": "service",
+            "uom_id": uom.id,
+            "uom_po_id": uom.id,
+        }
+    )
+    return env["purchase.order"].create(
+        {
+            "partner_id": partner.id,
+            "company_id": env.company.id,
+            "currency_id": env.company.currency_id.id,
+            "state": "purchase",
+            "order_line": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": product.name,
+                        "product_id": product.id,
+                        "product_qty": 1.0,
+                        "product_uom": uom.id,
+                        "price_unit": amount,
+                        "date_planned": fields.Datetime.now(),
+                    },
+                )
+            ],
+        }
+    )
+
+
+def _settlement(project, partner, contract, amount):
+    po = _purchase_order(partner, amount)
+    settlement = env["sc.settlement.order"].create(
+        {
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "contract_id": contract.id,
+            "settlement_type": "out",
+            "purchase_order_ids": [(6, 0, po.ids)],
+            "company_id": env.company.id,
+            "currency_id": env.company.currency_id.id,
+            "line_ids": [
+                (
+                    0,
+                    0,
+                    {
+                        "name": "BAC Audit Settlement Line",
+                        "contract_id": contract.id,
+                        "qty": 1.0,
+                        "price_unit": amount,
+                    },
+                )
+            ],
+        }
+    )
+    settlement.action_submit()
+    env.flush_all()
+    env.cr.execute(
+        "UPDATE sc_settlement_order SET validation_status=%s WHERE id=%s",
+        ("validated", settlement.id),
+    )
+    settlement.invalidate_recordset()
+    if settlement.validation_status != "validated":
+        settlement.write({"validation_status": "validated"})
+        settlement.invalidate_recordset()
+    settlement.action_on_tier_approved()
+    settlement.invalidate_recordset()
+    return settlement
+
+
+def _payment_request(project, partner, contract, amount, request_type, settlement=False):
+    request = env["payment.request"].sudo().create(
+        {
+            "name": "BAC Audit Payment Request %s" % _token(),
+            "type": request_type,
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "contract_id": contract.id if contract else False,
+            "settlement_id": settlement.id if settlement else False,
+            "currency_id": env.company.currency_id.id,
+            "amount": amount,
+        }
+    )
+    env.cr.execute(
+        "UPDATE payment_request SET state=%s, validation_status=%s WHERE id=%s",
+        ("approved", "validated", request.id),
+    )
+    request.invalidate_recordset()
+    return request
+
+
+def _run_payment_execution(failures):
+    project = _project("BAC Payment Execution Project", funding=True)
+    partner = _partner("BAC Payment Execution Partner")
+    contract = _contract(project, partner, "in")
+    settlement = _settlement(project, partner, contract, 120.0)
+    request = _payment_request(project, partner, contract, 120.0, "pay", settlement=settlement)
+    execution = env["sc.payment.execution"].sudo().create(
+        {
+            "payment_request_id": request.id,
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "contract_id": contract.id,
+            "planned_amount": 120.0,
+            "paid_amount": 120.0,
+        }
+    )
+    execution.action_confirm()
+    _approve_if_needed(execution, "sc_payment_execution")
+    _expect_state("payment_execution.confirm", execution, "confirmed", failures)
+    _expect_exception("payment_execution.confirm_again", execution.action_confirm, failures)
+    execution.action_paid()
+    _expect_state("payment_execution.paid", execution, "paid", failures)
+    request.invalidate_recordset()
+    if request.state != "done":
+        failures.append("payment_execution.request_done: expected done, got %s" % request.state)
+    ledger_count = env["payment.ledger"].search_count([("payment_request_id", "=", request.id)])
+    if ledger_count < 1:
+        failures.append("payment_execution.ledger: expected payment ledger")
+    return {"execution": execution.id, "payment_request": request.id, "settlement": settlement.id}
+
+
+def _run_receipt_income(failures):
+    project = _project("BAC Receipt Income Project")
+    partner = _partner("BAC Receipt Income Partner")
+    contract = _contract(project, partner, "out")
+    request = _payment_request(project, partner, contract, 160.0, "receive")
+    receipt = env["sc.receipt.income"].sudo().create(
+        {
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "contract_id": contract.id,
+            "payment_request_id": request.id,
+            "amount": 160.0,
+            "income_category": "业务收入",
+        }
+    )
+    _expect_exception(
+        "receipt_income.received_bad_partner",
+        lambda: (receipt.write({"partner_id": False}), receipt.action_received()),
+        failures,
+    )
+    receipt.write({"partner_id": partner.id})
+    receipt.action_confirm()
+    _approve_if_needed(receipt, "sc_receipt_income")
+    _expect_state("receipt_income.confirm", receipt, "confirmed", failures)
+    receipt.action_received()
+    _expect_state("receipt_income.received", receipt, "received", failures)
+    request.invalidate_recordset()
+    if request.state != "done":
+        failures.append("receipt_income.request_done: expected done, got %s" % request.state)
+    return {"receipt": receipt.id, "payment_request": request.id}
+
+
+def _run_expense_claim(failures):
+    project = _project("BAC Expense Claim Project", funding=True)
+    partner = _partner("BAC Expense Claim Partner")
+    contract = _contract(project, partner, "in")
+    settlement = _settlement(project, partner, contract, 80.0)
+    request = _payment_request(project, partner, contract, 80.0, "pay", settlement=settlement)
+    claim = env["sc.expense.claim"].sudo().create(
+        {
+            "claim_type": "expense",
+            "expense_type": "公司财务支出",
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "payment_request_id": request.id,
+            "amount": 80.0,
+            "approved_amount": 80.0,
+        }
+    )
+    _expect_exception("expense_claim.done_before_submit", claim.action_done, failures)
+    claim.action_submit()
+    if claim.state == "submit":
+        env.flush_all()
+        env.cr.execute(
+            "UPDATE sc_expense_claim SET validation_status=%s WHERE id=%s",
+            ("validated", claim.id),
+        )
+        claim.invalidate_recordset()
+        if claim.validation_status != "validated":
+            claim.write({"validation_status": "validated"})
+            claim.invalidate_recordset()
+        claim.action_on_tier_approved()
+    _expect_state("expense_claim.approved", claim, "approved", failures)
+    claim.action_done()
+    _expect_state("expense_claim.done", claim, "done", failures)
+    request.invalidate_recordset()
+    if request.state != "done":
+        failures.append("expense_claim.request_done: expected done, got %s" % request.state)
+    return {"claim": claim.id, "payment_request": request.id, "settlement": settlement.id}
+
+
+def _run_invoice_registration(failures):
+    project = _project("BAC Invoice Project")
+    partner = _partner("BAC Invoice Partner")
+    contract = _contract(project, partner, "in")
+    invoice = env["sc.invoice.registration"].create(
+        {
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "contract_id": contract.id,
+            "direction": "input",
+            "source_kind": "invoice_registration",
+            "invoice_no": "BAC-INV-%s" % _token(),
+            "invoice_date": fields.Date.today(),
+            "amount_total": 109.0,
+            "tax_amount": 9.0,
+        }
+    )
+    _expect_exception("invoice.register_before_confirm", invoice.action_register, failures)
+    invoice.action_confirm()
+    _approve_if_needed(invoice, "sc_invoice_registration")
+    _expect_state("invoice.confirm", invoice, "confirmed", failures)
+    invoice.action_register()
+    _expect_state("invoice.register", invoice, "registered", failures)
+    return {"invoice": invoice.id}
+
+
+def _run_tax_deduction(failures):
+    project = _project("BAC Tax Deduction Project")
+    partner = _partner("BAC Tax Deduction Partner")
+    deduction = env["sc.tax.deduction.registration"].create(
+        {
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "invoice_no": "BAC-TAX-%s" % _token(),
+            "invoice_amount_untaxed": 100.0,
+            "invoice_tax_amount": 9.0,
+            "invoice_amount_total": 109.0,
+        }
+    )
+    deduction.action_confirm()
+    _expect_state("tax_deduction.confirm", deduction, "confirmed", failures)
+    deduction.action_deduct()
+    _expect_state("tax_deduction.deduct", deduction, "deducted", failures)
+    if not deduction.deduction_confirm_date:
+        failures.append("tax_deduction.confirm_date: expected value")
+    return {"deduction": deduction.id}
+
+
+def _run_hr_payroll(failures):
+    department = _department()
+    payroll = env["sc.hr.payroll.document"].create(
+        {
+            "name": "BAC Payroll %s" % _token(),
+            "fact_type": "salary_registration",
+            "employee_name": "BAC Payroll Employee",
+            "department_id": department.id,
+            "period_year": 2026,
+            "period_month": 6,
+            "gross_amount": 9000.0,
+            "net_salary": 8000.0,
+        }
+    )
+    bad_payroll = env["sc.hr.payroll.document"].create(
+        {
+            "name": "BAC Payroll Bad %s" % _token(),
+            "fact_type": "salary_registration",
+            "employee_name": "BAC Payroll Bad",
+            "department_id": department.id,
+            "period_year": 2026,
+            "period_month": 13,
+            "gross_amount": 1.0,
+            "net_salary": 1.0,
+        }
+    )
+    _expect_exception("hr_payroll.invalid_month", bad_payroll.action_submit, failures)
+    payroll.action_submit()
+    _expect_state("hr_payroll.submit", payroll, "in_progress", failures)
+    payroll.action_done()
+    _expect_state("hr_payroll.done", payroll, "done", failures)
+    return {"payroll": payroll.id}
+
+
+def _run_fund_account_operation(failures):
+    project = _project("BAC Fund Operation Project")
+    Account = env["sc.fund.account"]
+    source = Account.create(
+        {
+            "name": "BAC Source Account %s" % _token(),
+            "account_no": "SRC-%s" % _token(),
+            "project_id": project.id,
+            "state": "active",
+        }
+    )
+    target = Account.create(
+        {
+            "name": "BAC Target Account %s" % _token(),
+            "account_no": "TGT-%s" % _token(),
+            "project_id": project.id,
+            "state": "active",
+        }
+    )
+    operation = env["sc.fund.account.operation"].create(
+        {
+            "operation_type": "transfer_between",
+            "project_id": project.id,
+            "source_account_id": source.id,
+            "target_account_id": target.id,
+            "amount": 200.0,
+            "operation_reason": "业务动作覆盖审计",
+        }
+    )
+    _expect_exception("fund_operation.done_before_confirm", operation.action_done, failures)
+    operation.action_confirm()
+    _expect_state("fund_operation.confirm", operation, "confirmed", failures)
+    operation.action_done()
+    _expect_state("fund_operation.done", operation, "done", failures)
+    return {"operation": operation.id, "source_account": source.id, "target_account": target.id}
+
+
+failures = []
+coverage = {}
+
+try:
+    _ensure_groups(env)
+    coverage["payment_execution"] = _run_payment_execution(failures)
+    coverage["receipt_income"] = _run_receipt_income(failures)
+    coverage["expense_claim"] = _run_expense_claim(failures)
+    coverage["invoice_registration"] = _run_invoice_registration(failures)
+    coverage["tax_deduction"] = _run_tax_deduction(failures)
+    coverage["hr_payroll"] = _run_hr_payroll(failures)
+    coverage["fund_account_operation"] = _run_fund_account_operation(failures)
+except Exception as err:
+    failures.append("unexpected error: %s" % err)
+    failures.append(traceback.format_exc())
+
+result = {
+    "audit": "business_action_coverage_audit",
+    "status": "PASS" if not failures else "FAIL",
+    "coverage": coverage,
+    "failures": failures,
+}
+print("BUSINESS_ACTION_COVERAGE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+if failures:
+    print("FAILURES:")
+    for failure in failures:
+        print("- %s" % failure)
+
+sys.exit(0 if not failures else 1)


### PR DESCRIPTION
## Summary

- Add a repeatable action coverage audit for high-frequency confirmed formal business entries.
- Cover payment execution, receipt income, expense claim, invoice registration, tax deduction, HR payroll, and fund account operation actions.
- Add an ops wrapper and audit evidence for the June 9, 2026 `sc_demo` run.

## Why

The previous audit proved two core business closure chains. This adds the next layer: high-frequency formal menu actions must be executable through the formal model methods, including validation of required anchors and invalid state transitions.

## Validation

- `python3 -m py_compile scripts/verify/business_action_coverage_audit.py`
- `bash -n scripts/ops/validate_business_action_coverage.sh`
- `DB_NAME=sc_demo scripts/ops/validate_business_action_coverage.sh`

The `sc_demo` runtime audit passed with no failures.