### PR TITLE
[codex] Add business capability validation gate

### DIFF
--- a/docs/audit/business_capability_gate_2026-06-09.md
+++ b/docs/audit/business_capability_gate_2026-06-09.md
@@ -1,0 +1,39 @@
+# Business Capability Gate 2026-06-09
+
+## Scope
+
+汇总前三轮专项验收，形成一个正式业务办理能力总门禁。
+
+总门禁顺序执行：
+
+- `validate_business_flow_closure.sh`
+- `validate_business_action_coverage.sh`
+- `validate_field_operation_actions.sh`
+
+## Command
+
+```bash
+DB_NAME=sc_demo scripts/ops/validate_business_capability_gate.sh
+```
+
+## Coverage
+
+- 核心闭环：合同、结算、付款、材料采购、库存、材料结算
+- 财务动作：付款执行、收入、费用支出、发票、抵扣、工资、资金账户
+- 施工生产动作：劳务、机械、分包、周转材料、安全、质量
+
+## Policy
+
+- 仅允许在非生产环境运行，脚本调用 `guard_prod_forbid`。
+- 任意子验收失败时总门禁失败。
+- 脚本只创建专项审计数据并调用正式模型动作，不修改用户已确认菜单体系，不覆盖历史迁移数据。
+
+## Result
+
+```text
+BUSINESS_CAPABILITY_GATE_START: db=sc_demo started_at=2026-06-09T21:59:12+08:00
+BUSINESS_CAPABILITY_GATE_CHECK_PASS: business_flow_closure
+BUSINESS_CAPABILITY_GATE_CHECK_PASS: business_action_coverage
+BUSINESS_CAPABILITY_GATE_CHECK_PASS: field_operation_actions
+BUSINESS_CAPABILITY_GATE_RESULT: PASS db=sc_demo started_at=2026-06-09T21:59:12+08:00 finished_at=2026-06-09T21:59:29+08:00
+```

--- a/scripts/ops/validate_business_capability_gate.sh
+++ b/scripts/ops/validate_business_capability_gate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+checks=(
+  "business_flow_closure:scripts/ops/validate_business_flow_closure.sh"
+  "business_action_coverage:scripts/ops/validate_business_action_coverage.sh"
+  "field_operation_actions:scripts/ops/validate_field_operation_actions.sh"
+)
+
+started_at="$(date -Iseconds)"
+echo "BUSINESS_CAPABILITY_GATE_START: db=${DB_NAME} started_at=${started_at}"
+
+for check in "${checks[@]}"; do
+  name="${check%%:*}"
+  script="${check#*:}"
+  echo "BUSINESS_CAPABILITY_GATE_CHECK_START: ${name}"
+  DB_NAME="$DB_NAME" "$ROOT_DIR/$script"
+  echo "BUSINESS_CAPABILITY_GATE_CHECK_PASS: ${name}"
+done
+
+finished_at="$(date -Iseconds)"
+echo "BUSINESS_CAPABILITY_GATE_RESULT: PASS db=${DB_NAME} started_at=${started_at} finished_at=${finished_at}"


### PR DESCRIPTION
## Summary

- Add a single business capability gate that runs the three formal business runtime audits in order.
- Include audit documentation and the June 9, 2026 `sc_demo` PASS evidence.

## Why

The capability audits now cover core closure, finance-facing actions, and field operation actions. A single gate reduces the chance of missing one of the required checks during development server upgrades or release validation.

## Validation

- `bash -n scripts/ops/validate_business_capability_gate.sh`
- `DB_NAME=sc_demo scripts/ops/validate_business_capability_gate.sh`

The aggregate gate passed locally with all three child audits passing.