### PR TITLE
[codex] Add settlement usability coverage gate

### DIFF
--- a/docs/audit/formal_business_release_gate_2026-06-09.md
+++ b/docs/audit/formal_business_release_gate_2026-06-09.md
@@ -9,6 +9,7 @@
 - `user_confirmed_menu_surface_guard.py`
 - `user_confirmed_form_capability_audit.py`
 - `user_confirmed_form_data_alignment_audit.py`
+- `user_confirmed_settlement_usability_audit.py`
 - `validate_business_capability_gate.sh`
 
 ## Command
@@ -20,8 +21,8 @@ DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh
 ## Result
 
 - 数据库：`sc_demo`
-- 开始时间：`2026-06-09T23:37:45+08:00`
-- 结束时间：`2026-06-09T23:39:55+08:00`
+- 开始时间：`2026-06-10T00:00:44+08:00`
+- 结束时间：`2026-06-10T00:03:04+08:00`
 - 总结果：`PASS`
 
 子门禁结果：
@@ -29,6 +30,7 @@ DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh
 - 用户确认菜单面锁定：`PASS`
 - 用户确认表单能力：`PASS`
 - 用户确认表单数据对齐：`PASS`
+- 用户确认结算办理可用性：`PASS`
 - 正式业务办理能力：`PASS`
 
 ## Coverage
@@ -36,6 +38,7 @@ DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh
 - 用户确认菜单分组、可见菜单、禁止泄漏分组
 - 用户确认正式表单字段能力
 - 用户确认列表与正式表单数据值对齐
+- 用户确认结算单业务分类和核心可见字段可承接
 - 正式业务办理能力：核心单据办理、核心闭环、财务动作、施工生产动作
 
 ## Data Alignment
@@ -43,7 +46,7 @@ DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh
 - 用户确认正式菜单：`62`
 - 覆盖模型：`36`
 - 检查记录：`256844`
-- 检查正式字段：`831`
+- 检查正式字段：`861`
 - 不一致字段：`0`
 - 只读来源字段未承接：`0`
 - 严重度分布：`{"ok": 62}`
@@ -52,12 +55,14 @@ DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh
 
 - `scripts/ops/user_confirmed_formal_data_backfill.py`
 - `scripts/ops/user_confirmed_attachment_bind.py`
+- `scripts/ops/user_confirmed_settlement_usability_backfill.py`
 
 关键修复：
 
 - 把用户确认正式字段从验收面回填到正式表单字段。
 - 把历史附件引用绑定到正式 `attachment_ids`。
 - 将入库单正式主编号 `name` 对齐用户确认的入库单号 `legacy_visible_02`。
+- 将直管验收结算单的业务分类和验收可见字段回填到正式结算单。
 
 ## Policy
 

--- a/docs/audit/user_confirmed_settlement_usability_2026-06-10.md
+++ b/docs/audit/user_confirmed_settlement_usability_2026-06-10.md
@@ -1,0 +1,47 @@
+# User Confirmed Settlement Usability 2026-06-10
+
+## Scope
+
+专项补齐直管验收结算数据进入正式 `sc.settlement.order` 后的办理可用性字段。
+
+覆盖：
+
+- 材料结算单
+- 机械结算单
+- 劳务结算
+- 分包结算单
+- 工程结算单
+
+## Backfill
+
+```text
+USER_CONFIRMED_SETTLEMENT_USABILITY_BACKFILL: {"copied_fields": 337, "missing_fact_count": 0, "missing_fact_sample": [], "operation": "user_confirmed_settlement_usability_backfill", "settlement_count": 2593, "status": "PASS", "updated": 337, "updated_by_label": {"分包结算单": 12, "劳务结算": 85, "机械结算单": 62, "材料结算单": 178}}
+```
+
+前置回填已补齐 2593 条结算单的业务分类和验收可见字段。
+
+## Audit
+
+```text
+USER_CONFIRMED_SETTLEMENT_USABILITY_AUDIT: {"audit": "user_confirmed_settlement_usability_audit", "by_label": {"分包结算单": 88, "劳务结算": 576, "工程结算单": 37, "机械结算单": 669, "材料结算单": 1223}, "failures": [], "settlement_count": 2593, "status": "PASS"}
+```
+
+## Release Gate
+
+```text
+FORMAL_BUSINESS_RELEASE_GATE_RESULT: PASS db=sc_demo started_at=2026-06-10T00:00:44+08:00 finished_at=2026-06-10T00:03:04+08:00
+```
+
+关键数据对齐结果：
+
+- 用户确认正式菜单：`62`
+- 检查记录：`256844`
+- 检查字段：`861`
+- 不一致字段：`0`
+- 只读来源字段未承接：`0`
+
+## Policy
+
+- 不改用户已确认菜单体系。
+- 不覆盖用户已验收列表值。
+- 回填只针对直管验收结算单缺失的正式承接字段。

--- a/scripts/ops/user_confirmed_settlement_usability_backfill.py
+++ b/scripts/ops/user_confirmed_settlement_usability_backfill.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+"""Backfill direct-acceptance settlement visible fields into formal settlements.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/ops/user_confirmed_settlement_usability_backfill.py
+"""
+
+import json
+import sys
+import traceback
+
+
+SOURCE_PREFIX = "sc.legacy.direct.acceptance.fact"
+VISIBLE_FIELD_COUNT = 60
+VISIBLE_FALLBACKS = {
+    "材料结算单": {
+        "legacy_visible_04": ("title", "name"),
+        "legacy_visible_07": ("settlement_amount", "amount_total"),
+    },
+    "机械结算单": {
+        "legacy_visible_07": ("settlement_amount", "amount_total"),
+    },
+    "劳务结算": {
+        "legacy_visible_07": ("settlement_amount", "amount_total"),
+    },
+    "分包结算单": {
+        "legacy_visible_04": ("title", "name"),
+        "legacy_visible_06": ("settlement_amount", "amount_total"),
+    },
+    "工程结算单": {
+        "legacy_visible_07": ("settlement_amount", "amount_total"),
+    },
+}
+REQUESTED_AMOUNT_VISIBLE_FIELD_BY_LABEL = {
+    "材料结算单": "legacy_visible_12",
+    "机械结算单": "legacy_visible_12",
+    "劳务结算": "legacy_visible_12",
+    "分包结算单": "legacy_visible_11",
+}
+
+
+def _text(value):
+    value = "" if value is None or value is False else str(value)
+    return value.strip()
+
+
+def _fallback_value(settlement, field_names):
+    for field_name in field_names:
+        value = getattr(settlement, field_name, False)
+        if value not in (None, False, ""):
+            return value
+    return False
+
+
+def _money(value):
+    text = _text(value).replace(",", "").replace("￥", "").replace("¥", "")
+    if not text:
+        return None
+    match = __import__("re").search(r"-?\d+(?:\.\d+)?", text)
+    if not match:
+        return None
+    try:
+        return float(match.group(0))
+    except ValueError:
+        return None
+
+
+def _copy_visible_fields(settlement, fact):
+    vals = {}
+    label = settlement.legacy_acceptance_label or fact.acceptance_label
+    if not settlement.legacy_acceptance_label and label:
+        vals["legacy_acceptance_label"] = label
+    for index in range(1, VISIBLE_FIELD_COUNT + 1):
+        field_name = "legacy_visible_%02d" % index
+        if field_name not in settlement._fields or field_name not in fact._fields:
+            continue
+        if _text(getattr(settlement, field_name, False)):
+            continue
+        value = _text(getattr(fact, field_name, False))
+        if value:
+            vals[field_name] = value
+    for field_name, fallback_fields in VISIBLE_FALLBACKS.get(label or "", {}).items():
+        if field_name not in settlement._fields:
+            continue
+        if _text(vals.get(field_name)) or _text(getattr(settlement, field_name, False)):
+            continue
+        value = _fallback_value(settlement, fallback_fields)
+        if value not in (None, False, ""):
+            vals[field_name] = value
+    if not settlement.source_created_by and fact.creator_name:
+        vals["source_created_by"] = fact.creator_name
+    if not settlement.source_created_at and fact.created_time:
+        vals["source_created_at"] = fact.created_time
+    requested_field = REQUESTED_AMOUNT_VISIBLE_FIELD_BY_LABEL.get(label or "")
+    if requested_field:
+        requested_amount = _money(vals.get(requested_field) or getattr(settlement, requested_field, False))
+        if requested_amount is not None and settlement.requested_fund_amount != requested_amount:
+            vals["requested_fund_amount"] = requested_amount
+    return vals
+
+
+def main():
+    Settlement = env["sc.settlement.order"].sudo().with_context(active_test=False)  # noqa: F821
+    Fact = env["sc.legacy.direct.acceptance.fact"].sudo().with_context(active_test=False)  # noqa: F821
+    settlements = Settlement.search([("legacy_fact_model", "=ilike", SOURCE_PREFIX + "%")])
+    updated = 0
+    copied_fields = 0
+    missing_fact = []
+    by_label = {}
+
+    for settlement in settlements:
+        fact = Fact.browse(settlement.legacy_fact_id)
+        if not fact.exists():
+            missing_fact.append(settlement.id)
+            continue
+        vals = _copy_visible_fields(settlement, fact)
+        if not vals:
+            continue
+        settlement.write(vals)
+        updated += 1
+        copied_fields += len(vals)
+        label = vals.get("legacy_acceptance_label") or settlement.legacy_acceptance_label or fact.acceptance_label or ""
+        by_label[label] = by_label.get(label, 0) + 1
+
+    env.cr.commit()  # noqa: F821
+    result = {
+        "operation": "user_confirmed_settlement_usability_backfill",
+        "status": "PASS" if not missing_fact else "WARN",
+        "settlement_count": len(settlements),
+        "updated": updated,
+        "copied_fields": copied_fields,
+        "updated_by_label": by_label,
+        "missing_fact_count": len(missing_fact),
+        "missing_fact_sample": missing_fact[:20],
+    }
+    print("USER_CONFIRMED_SETTLEMENT_USABILITY_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    print(
+        "USER_CONFIRMED_SETTLEMENT_USABILITY_BACKFILL: %s"
+        % json.dumps(
+            {
+                "operation": "user_confirmed_settlement_usability_backfill",
+                "status": "FAIL",
+                "error": str(err),
+                "traceback": traceback.format_exc(),
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
+    )
+    sys.exit(1)

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -56,6 +56,7 @@ echo "FORMAL_BUSINESS_RELEASE_GATE_START: db=${DB_NAME} started_at=${started_at}
 run_odoo_shell_check "user_confirmed_menu_surface" "scripts/verify/user_confirmed_menu_surface_guard.py"
 run_odoo_shell_check "user_confirmed_form_capability" "scripts/verify/user_confirmed_form_capability_audit.py"
 run_odoo_shell_check "user_confirmed_form_data_alignment" "scripts/verify/user_confirmed_form_data_alignment_audit.py"
+run_odoo_shell_check "user_confirmed_settlement_usability" "scripts/verify/user_confirmed_settlement_usability_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_user_confirmed_settlement_usability.sh
+++ b/scripts/ops/validate_user_confirmed_settlement_usability.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/user_confirmed_settlement_usability_audit.py"

--- a/scripts/verify/user_confirmed_settlement_usability_audit.py
+++ b/scripts/verify/user_confirmed_settlement_usability_audit.py
@@ -1,0 +1,102 @@
+# -*- coding: utf-8 -*-
+"""Audit direct-acceptance settlement usability fields on formal settlements.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/user_confirmed_settlement_usability_audit.py
+"""
+
+import json
+import sys
+import traceback
+
+
+SOURCE_PREFIX = "sc.legacy.direct.acceptance.fact"
+REQUIRED_VISIBLE_FIELDS_BY_LABEL = {
+    "材料结算单": ("legacy_visible_01", "legacy_visible_02", "legacy_visible_03", "legacy_visible_04", "legacy_visible_07"),
+    "机械结算单": ("legacy_visible_01", "legacy_visible_02", "legacy_visible_03", "legacy_visible_04", "legacy_visible_07"),
+    "劳务结算": ("legacy_visible_01", "legacy_visible_02", "legacy_visible_03", "legacy_visible_04", "legacy_visible_07"),
+    "分包结算单": ("legacy_visible_01", "legacy_visible_02", "legacy_visible_03", "legacy_visible_04", "legacy_visible_06"),
+    "工程结算单": ("legacy_visible_01", "legacy_visible_02", "legacy_visible_03", "legacy_visible_04", "legacy_visible_07"),
+}
+AMOUNT_VISIBLE_FIELDS = {
+    "legacy_visible_06",
+    "legacy_visible_07",
+}
+
+
+def _text(value):
+    value = "" if value is None or value is False else str(value)
+    return value.strip()
+
+
+def _count_missing(records, field_name):
+    count = 0
+    for record in records:
+        if _text(getattr(record, field_name, False)):
+            continue
+        if field_name in AMOUNT_VISIBLE_FIELDS and not (record.settlement_amount or record.amount_total):
+            continue
+        count += 1
+    return count
+
+
+def main():
+    Settlement = env["sc.settlement.order"].sudo().with_context(active_test=False)  # noqa: F821
+    settlements = Settlement.search([("legacy_fact_model", "=ilike", SOURCE_PREFIX + "%")])
+    failures = []
+    by_label = {}
+    missing_label = settlements.filtered(lambda record: not _text(record.legacy_acceptance_label))
+    if missing_label:
+        failures.append(
+            {
+                "check": "legacy_acceptance_label",
+                "missing": len(missing_label),
+                "sample": missing_label.ids[:20],
+            }
+        )
+
+    for label, required_fields in REQUIRED_VISIBLE_FIELDS_BY_LABEL.items():
+        records = settlements.filtered(lambda record, label=label: record.legacy_acceptance_label == label)
+        by_label[label] = len(records)
+        if not records:
+            failures.append({"check": "label_present", "label": label, "missing": True})
+            continue
+        for field_name in required_fields:
+            missing_count = _count_missing(records, field_name)
+            if missing_count:
+                failures.append(
+                    {
+                        "check": "visible_field",
+                        "label": label,
+                        "field": field_name,
+                        "missing": missing_count,
+                    }
+                )
+
+    result = {
+        "audit": "user_confirmed_settlement_usability_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "settlement_count": len(settlements),
+        "by_label": by_label,
+        "failures": failures,
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("USER_CONFIRMED_SETTLEMENT_USABILITY_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "user_confirmed_settlement_usability_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print(
+        "USER_CONFIRMED_SETTLEMENT_USABILITY_AUDIT: %s"
+        % json.dumps(result, ensure_ascii=False, sort_keys=True)
+    )
+    sys.exit(1)


### PR DESCRIPTION
## Summary

- add a direct-acceptance settlement usability backfill for formal `sc.settlement.order` records
- add an audit and wrapper that verify 2593 settlement records are classified into the expected user-confirmed settlement categories
- wire the settlement usability audit into the formal business release gate
- update audit documentation with the 2026-06-10 release-gate evidence

## Validation

- `python3 -m py_compile scripts/ops/user_confirmed_settlement_usability_backfill.py scripts/verify/user_confirmed_settlement_usability_audit.py`
- `DB_NAME=sc_demo scripts/ops/validate_user_confirmed_settlement_usability.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`

Formal release gate result: PASS, 62 confirmed menus, 256844 checked records, 861 checked fields, 0 mismatches.