### PR TITLE
Add legacy material budget projection gate

### DIFF
--- a/docs/audit/project_budget_legacy_material_2026-06-10.md
+++ b/docs/audit/project_budget_legacy_material_2026-06-10.md
@@ -1,0 +1,74 @@
+# Project Budget Legacy Material Projection 2026-06-10
+
+## Scope
+
+专项补齐历史材料预算/清单事实进入正式 `project.budget` 和 `project.budget.boq.line`。
+
+来源：
+
+- 表：`sc_legacy_material_stock_fact`
+- 条件：`active AND fact_type = 'material_budget_item' AND project_id IS NOT NULL`
+- 源行：`8747`
+- 源项目：`4`
+
+## Backfill
+
+```text
+PROJECT_BUDGET_LEGACY_MATERIAL_BACKFILL: {"created_budgets": 4, "created_lines": 8747, "operation": "project_budget_legacy_material_backfill", "skipped_lines": 0, "source_projects": 4, "source_rows": 8747, "status": "PASS"}
+```
+
+处理策略：
+
+- 每个项目生成一个历史预算版本：`LEGACY-MATERIAL-BUDGET`
+- 每条历史材料预算事实生成一条正式预算清单
+- 历史数量、单价、金额按源值保留；当前源数据金额/数量均为 `0`，不伪造目标成本
+- 历史来源 ID、源表、历史单位等写入清单备注，用于审计追踪和幂等回填
+
+## Audit
+
+```text
+PROJECT_BUDGET_LEGACY_MATERIAL_AUDIT: {"failures": [], "projected_budgets": 4, "projected_lines": 8747, "source_ids_projected": 8747, "source_projects": 4, "source_rows": 8747, "status": "PASS"}
+```
+
+项目分布：
+
+- 项目 `499`：`34/34`
+- 项目 `715`：`2/2`
+- 项目 `753`：`8402/8402`
+- 项目 `820`：`309/309`
+
+## Release Gate
+
+```text
+FORMAL_BUSINESS_RELEASE_GATE_RESULT: PASS db=sc_demo started_at=2026-06-10T00:18:18+08:00 finished_at=2026-06-10T00:20:32+08:00
+```
+
+关键数据对齐结果：
+
+- 用户确认正式菜单：`62`
+- 检查记录：`256844`
+- 检查字段：`861`
+- 不一致字段：`0`
+- 只读来源字段未承接：`0`
+
+## Visible Matrix
+
+预算投影前：
+
+- `issue_count`: `25`
+- `legacy_facts_not_projected_to_business_surface`: `3`
+- `project.budget`: `3`
+
+预算投影后：
+
+- `issue_count`: `22`
+- `legacy_facts_not_projected_to_business_surface`: `0`
+- 剩余业务字段专项模型：`8`
+- 剩余纯元数据门：`14`
+
+## Policy
+
+- 不改用户已确认菜单体系。
+- 不覆盖用户已验收列表值。
+- 不制造源数据不存在的预算金额。
+- 回填只在非生产门控脚本下执行，审计纳入正式发布门。

--- a/scripts/ops/project_budget_legacy_material_backfill.py
+++ b/scripts/ops/project_budget_legacy_material_backfill.py
@@ -1,0 +1,234 @@
+# -*- coding: utf-8 -*-
+"""Backfill legacy material budget facts into formal project budgets.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/ops/project_budget_legacy_material_backfill.py
+"""
+
+import json
+import re
+import sys
+import traceback
+from collections import defaultdict
+
+
+SOURCE_MODEL = "sc.legacy.material_stock_fact"
+SOURCE_FACT_TYPE = "material_budget_item"
+VERSION = "LEGACY-MATERIAL-BUDGET"
+NOTE_ID_RE = re.compile(r"legacy_material_stock_fact_id=(\d+)")
+
+
+def _text(value):
+    value = "" if value is None or value is False else str(value)
+    return value.strip()
+
+
+def _project_name(project):
+    return _text(project.display_name) or ("项目%s" % project.id)
+
+
+def _legacy_line_note(row):
+    parts = [
+        "legacy_material_stock_fact_id=%s" % row["id"],
+        "legacy_record_id=%s" % _text(row["legacy_record_id"]),
+        "source_table=%s" % _text(row["source_table"]),
+    ]
+    material_uom = _text(row.get("material_uom"))
+    if material_uom:
+        parts.append("legacy_uom=%s" % material_uom)
+    material_spec = _text(row.get("material_spec"))
+    if material_spec:
+        parts.append("legacy_spec=%s" % material_spec)
+    document_no = _text(row.get("document_no"))
+    if document_no:
+        parts.append("legacy_document_no=%s" % document_no)
+    return "; ".join(parts)
+
+
+def _uom_lookup():
+    Uom = env["uom.uom"].sudo().with_context(active_test=False)  # noqa: F821
+    lookup = {}
+    for uom in Uom.search([]):
+        candidates = {uom.display_name}
+        name = uom.name
+        if isinstance(name, dict):
+            candidates.update(name.values())
+        else:
+            candidates.add(name)
+        for candidate in candidates:
+            key = _text(candidate)
+            if key:
+                lookup.setdefault(key, uom.id)
+    aliases = {
+        "个": "件",
+        "支": "件",
+        "根": "件",
+        "套": "件",
+        "项": "件",
+        "时": "小时",
+        "日": "天",
+        "吨": "t",
+        "立方": "m³",
+        "方": "m³",
+        "平方": "m²",
+        "米": "m",
+    }
+    for source, target in aliases.items():
+        if target in lookup and source not in lookup:
+            lookup[source] = lookup[target]
+    return lookup
+
+
+def _fetch_source_rows():
+    env.cr.execute(  # noqa: F821
+        """
+        SELECT
+            id, project_id, source_table, legacy_record_id, document_no,
+            material_code, material_name, material_spec, material_uom,
+            qty, unit_price, amount_total, document_date, document_state
+        FROM sc_legacy_material_stock_fact
+        WHERE active
+          AND fact_type = %s
+          AND project_id IS NOT NULL
+        ORDER BY project_id, source_table, document_no, id
+        """,
+        [SOURCE_FACT_TYPE],
+    )
+    return env.cr.dictfetchall()  # noqa: F821
+
+
+def _existing_source_ids(budget):
+    source_ids = set()
+    for line in budget.line_ids:
+        match = NOTE_ID_RE.search(_text(line.note))
+        if match:
+            source_ids.add(int(match.group(1)))
+    return source_ids
+
+
+def main():
+    Budget = env["project.budget"].sudo().with_context(active_test=False)  # noqa: F821
+    Line = env["project.budget.boq.line"].sudo().with_context(active_test=False)  # noqa: F821
+    Project = env["project.project"].sudo().with_context(active_test=False)  # noqa: F821
+
+    rows = _fetch_source_rows()
+    rows_by_project = defaultdict(list)
+    for row in rows:
+        rows_by_project[row["project_id"]].append(row)
+
+    uom_by_name = _uom_lookup()
+    created_budgets = 0
+    created_lines = 0
+    skipped_lines = 0
+    unmapped_uoms = defaultdict(int)
+    by_project = {}
+
+    for project_id, project_rows in rows_by_project.items():
+        project = Project.browse(project_id)
+        if not project.exists():
+            continue
+
+        budget = Budget.search([("project_id", "=", project.id), ("version", "=", VERSION)], limit=1)
+        if not budget:
+            budget = Budget.create(
+                {
+                    "name": "历史材料预算基线 - %s" % _project_name(project),
+                    "project_id": project.id,
+                    "budget_kind": "material",
+                    "version": VERSION,
+                    "version_no": VERSION,
+                    "target_type": "drawing_budget",
+                    "source_channel": "system",
+                    "is_active": True,
+                    "is_baseline": True,
+                    "amount_revenue_target": 0.0,
+                    "amount_cost_target": sum(float(row.get("amount_total") or 0.0) for row in project_rows),
+                    "legacy_source_model": SOURCE_MODEL,
+                    "legacy_record_id": "%s:%s:project:%s" % (SOURCE_MODEL, SOURCE_FACT_TYPE, project.id),
+                    "note": "由历史材料预算/清单事实投影；源表 sc_legacy_material_stock_fact，事实类型 %s；源金额/数量按历史值保留。"
+                    % SOURCE_FACT_TYPE,
+                }
+            )
+            created_budgets += 1
+        else:
+            updates = {}
+            if budget.legacy_source_model != SOURCE_MODEL:
+                updates["legacy_source_model"] = SOURCE_MODEL
+            if budget.legacy_record_id != "%s:%s:project:%s" % (SOURCE_MODEL, SOURCE_FACT_TYPE, project.id):
+                updates["legacy_record_id"] = "%s:%s:project:%s" % (SOURCE_MODEL, SOURCE_FACT_TYPE, project.id)
+            if budget.budget_kind != "material":
+                updates["budget_kind"] = "material"
+            if budget.source_channel != "system":
+                updates["source_channel"] = "system"
+            if updates:
+                budget.write(updates)
+
+        existing_ids = _existing_source_ids(budget)
+        vals_list = []
+        for sequence, row in enumerate(project_rows, start=10):
+            if row["id"] in existing_ids:
+                skipped_lines += 1
+                continue
+            uom_name = _text(row.get("material_uom"))
+            uom_id = uom_by_name.get(uom_name)
+            if uom_name and not uom_id:
+                unmapped_uoms[uom_name] += 1
+            qty = float(row.get("qty") or 0.0)
+            price = float(row.get("unit_price") or 0.0)
+            name = _text(row.get("material_name")) or _text(row.get("material_code")) or "历史预算清单%s" % row["id"]
+            vals = {
+                "budget_id": budget.id,
+                "sequence": sequence,
+                "boq_code": _text(row.get("document_no")) or _text(row.get("material_code")) or str(row["id"]),
+                "name": name,
+                "qty_bidded": qty,
+                "price_bidded": price,
+                "measure_rule": "qty",
+                "cost_collection_method": "non_contract",
+                "cost_allocation_method": "manual",
+                "revenue_recognition": "progress",
+                "note": _legacy_line_note(row),
+            }
+            if uom_id:
+                vals["uom_id"] = uom_id
+            vals_list.append(vals)
+
+        if vals_list:
+            Line.create(vals_list)
+            created_lines += len(vals_list)
+
+        by_project[str(project.id)] = {
+            "project_name": _project_name(project),
+            "source_rows": len(project_rows),
+            "created_lines": len(vals_list),
+            "existing_lines": len(existing_ids),
+            "budget_id": budget.id,
+        }
+
+    env.cr.commit()  # noqa: F821
+    result = {
+        "operation": "project_budget_legacy_material_backfill",
+        "status": "PASS",
+        "source_rows": len(rows),
+        "source_projects": len(rows_by_project),
+        "created_budgets": created_budgets,
+        "created_lines": created_lines,
+        "skipped_lines": skipped_lines,
+        "unmapped_uoms": dict(sorted(unmapped_uoms.items())),
+        "by_project": by_project,
+    }
+    print("PROJECT_BUDGET_LEGACY_MATERIAL_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "operation": "project_budget_legacy_material_backfill",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print("PROJECT_BUDGET_LEGACY_MATERIAL_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -57,6 +57,7 @@ run_odoo_shell_check "user_confirmed_menu_surface" "scripts/verify/user_confirme
 run_odoo_shell_check "user_confirmed_form_capability" "scripts/verify/user_confirmed_form_capability_audit.py"
 run_odoo_shell_check "user_confirmed_form_data_alignment" "scripts/verify/user_confirmed_form_data_alignment_audit.py"
 run_odoo_shell_check "user_confirmed_settlement_usability" "scripts/verify/user_confirmed_settlement_usability_audit.py"
+run_odoo_shell_check "project_budget_legacy_material" "scripts/verify/project_budget_legacy_material_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_project_budget_legacy_material.sh
+++ b/scripts/ops/validate_project_budget_legacy_material.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/project_budget_legacy_material_audit.py"

--- a/scripts/verify/project_budget_legacy_material_audit.py
+++ b/scripts/verify/project_budget_legacy_material_audit.py
@@ -1,0 +1,148 @@
+# -*- coding: utf-8 -*-
+"""Audit legacy material budget projection into formal project budgets.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/project_budget_legacy_material_audit.py
+"""
+
+import json
+import re
+import sys
+import traceback
+from collections import Counter, defaultdict
+
+
+SOURCE_MODEL = "sc.legacy.material_stock_fact"
+SOURCE_FACT_TYPE = "material_budget_item"
+VERSION = "LEGACY-MATERIAL-BUDGET"
+NOTE_ID_RE = re.compile(r"legacy_material_stock_fact_id=(\d+)")
+
+
+def _text(value):
+    value = "" if value is None or value is False else str(value)
+    return value.strip()
+
+
+def _fetch_source_rows():
+    env.cr.execute(  # noqa: F821
+        """
+        SELECT id, project_id
+        FROM sc_legacy_material_stock_fact
+        WHERE active
+          AND fact_type = %s
+          AND project_id IS NOT NULL
+        ORDER BY project_id, id
+        """,
+        [SOURCE_FACT_TYPE],
+    )
+    return env.cr.dictfetchall()  # noqa: F821
+
+
+def _line_source_id(line):
+    match = NOTE_ID_RE.search(_text(line.note))
+    return int(match.group(1)) if match else None
+
+
+def main():
+    Budget = env["project.budget"].sudo().with_context(active_test=False)  # noqa: F821
+    source_rows = _fetch_source_rows()
+    source_ids_by_project = defaultdict(set)
+    for row in source_rows:
+        source_ids_by_project[row["project_id"]].add(row["id"])
+
+    budgets = Budget.search([("version", "=", VERSION)])
+    budget_by_project = {budget.project_id.id: budget for budget in budgets}
+    projected_ids_by_project = defaultdict(set)
+    duplicate_source_ids = Counter()
+    lines_without_source_id = []
+
+    for budget in budgets:
+        for line in budget.line_ids:
+            source_id = _line_source_id(line)
+            if not source_id:
+                lines_without_source_id.append(line.id)
+                continue
+            if source_id in projected_ids_by_project[budget.project_id.id]:
+                duplicate_source_ids[source_id] += 1
+            projected_ids_by_project[budget.project_id.id].add(source_id)
+
+    failures = []
+    if len(budgets) != len(source_ids_by_project):
+        failures.append(
+            {
+                "check": "budget_project_count",
+                "source_projects": len(source_ids_by_project),
+                "projected_budgets": len(budgets),
+            }
+        )
+
+    missing_budget_projects = sorted(set(source_ids_by_project) - set(budget_by_project))
+    if missing_budget_projects:
+        failures.append({"check": "missing_budget_projects", "project_ids": missing_budget_projects[:50]})
+
+    total_source_ids = set()
+    total_projected_ids = set()
+    project_breakdown = {}
+    for project_id, source_ids in source_ids_by_project.items():
+        projected_ids = projected_ids_by_project.get(project_id, set())
+        total_source_ids.update(source_ids)
+        total_projected_ids.update(projected_ids)
+        missing_ids = sorted(source_ids - projected_ids)
+        extra_ids = sorted(projected_ids - source_ids)
+        project_breakdown[str(project_id)] = {
+            "source_rows": len(source_ids),
+            "projected_lines": len(projected_ids),
+            "missing": len(missing_ids),
+            "extra": len(extra_ids),
+            "budget_id": budget_by_project.get(project_id).id if budget_by_project.get(project_id) else False,
+        }
+        if missing_ids or extra_ids:
+            failures.append(
+                {
+                    "check": "project_line_source_alignment",
+                    "project_id": project_id,
+                    "source_rows": len(source_ids),
+                    "projected_lines": len(projected_ids),
+                    "missing_sample": missing_ids[:20],
+                    "extra_sample": extra_ids[:20],
+                }
+            )
+
+    if lines_without_source_id:
+        failures.append({"check": "lines_without_source_id", "line_ids": lines_without_source_id[:50]})
+    if duplicate_source_ids:
+        failures.append(
+            {
+                "check": "duplicate_source_ids",
+                "duplicates": dict(sorted(duplicate_source_ids.items())[:50]),
+            }
+        )
+
+    result = {
+        "audit": "project_budget_legacy_material_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "source_rows": len(source_rows),
+        "source_projects": len(source_ids_by_project),
+        "projected_budgets": len(budgets),
+        "projected_lines": sum(len(ids) for ids in projected_ids_by_project.values()),
+        "source_ids_projected": len(total_source_ids & total_projected_ids),
+        "failures": failures,
+        "project_breakdown": project_breakdown,
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("PROJECT_BUDGET_LEGACY_MATERIAL_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "project_budget_legacy_material_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("PROJECT_BUDGET_LEGACY_MATERIAL_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- backfill legacy material budget facts into formal project budget versions and budget lines
- add a project budget legacy material audit and validation wrapper
- wire the audit into the formal business release gate
- document the local backfill and gate evidence

## Validation
- `DB_NAME=sc_demo scripts/ops/validate_project_budget_legacy_material.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- `scripts/verify/visible_data_usability_matrix_probe.py` via Odoo shell: issue count reduced from 25 to 22; `legacy_facts_not_projected_to_business_surface` reduced to 0