### PR TITLE
Add operation strategy surface coverage gate

### DIFF
--- a/docs/audit/operation_strategy_contract_surface_2026-06-10.md
+++ b/docs/audit/operation_strategy_contract_surface_2026-06-10.md
@@ -1,0 +1,69 @@
+# Operation Strategy And Contract Surface 2026-06-10
+
+## Scope
+
+专项补齐正式业务模型中的经营方式和合同编号可见承接字段。
+
+覆盖模型：
+
+- `sc.general.contract`
+- `sc.fund.account`
+- `sc.treasury.reconciliation`
+
+## Root Cause
+
+项目主数据 `project.project.operation_strategy` 已完整，但部分正式模型上的存储型 related 字段没有刷新，导致列表/矩阵看到经营方式为空。
+
+一般合同还存在 `contract_no` 为空但 `document_no` 有值的历史合同，影响合同编号检索。
+
+## Backfill
+
+```text
+OPERATION_STRATEGY_CONTRACT_SURFACE_BACKFILL: {"contract_no_updated": 38, "remaining": {"sc_fund_account_no_strategy": 1, "sc_general_contract_no_contract_no": 0, "sc_general_contract_no_strategy": 0, "sc_treasury_reconciliation_no_strategy": 0}, "status": "PASS", "strategy_updates": {"sc_fund_account": {"before_mismatch": 161, "updated": 161}, "sc_general_contract": {"before_mismatch": 335, "updated": 335}, "sc_treasury_reconciliation": {"before_mismatch": 19806, "updated": 19806}}}
+```
+
+说明：
+
+- `sc_fund_account_no_strategy = 1` 是无项目账户，不属于项目经营方式错配。
+- 一般合同空 `contract_no` 使用 `document_no` 兜底，未伪造不存在的合同编号。
+
+## Audit
+
+```text
+OPERATION_STRATEGY_CONTRACT_SURFACE_AUDIT: {"failures": [], "general_contract_no": {"missing_contract_no": 0, "missing_contract_no_with_document_no": 0, "total": 1065}, "status": "PASS", "strategy": {"sc.fund.account": {"missing_with_project": 0, "no_project": 1, "total": 165}, "sc.general.contract": {"missing_with_project": 0, "no_project": 0, "total": 1065}, "sc.treasury.reconciliation": {"missing_with_project": 0, "no_project": 0, "total": 20060}}}
+```
+
+## Release Gate
+
+```text
+FORMAL_BUSINESS_RELEASE_GATE_RESULT: PASS db=sc_demo started_at=2026-06-10T00:33:04+08:00 finished_at=2026-06-10T00:35:19+08:00
+```
+
+关键数据对齐结果：
+
+- 用户确认正式菜单：`62`
+- 检查记录：`256844`
+- 检查字段：`862`
+- 不一致字段：`0`
+- 只读来源字段未承接：`0`
+
+## Visible Matrix
+
+修复前：
+
+- `issue_count`: `22`
+- 需要模型专项业务值门：`8`
+- 涉及：`sc.general.contract`, `sc.fund.account`, `sc.treasury.reconciliation`
+
+修复后：
+
+- `issue_count`: `20`
+- 需要模型专项业务值门：`5`
+- `sc.general.contract`, `sc.fund.account`, `sc.treasury.reconciliation` 已退出业务字段缺口
+
+## Policy
+
+- 不改用户已确认菜单体系。
+- 不覆盖用户已验收列表值。
+- 不制造源数据不存在的业务事实。
+- 只刷新可由项目主数据稳定推导的经营方式，以及可由审批编号兜底的一般合同编号。

--- a/scripts/ops/operation_strategy_contract_surface_backfill.py
+++ b/scripts/ops/operation_strategy_contract_surface_backfill.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+"""Backfill stored operation strategy and contract number surfaces.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/ops/operation_strategy_contract_surface_backfill.py
+"""
+
+import json
+import sys
+import traceback
+
+
+STRATEGY_TARGETS = (
+    ("sc_general_contract", "project_id"),
+    ("sc_fund_account", "project_id"),
+    ("sc_treasury_reconciliation", "project_id"),
+)
+
+
+def _scalar(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def _refresh_operation_strategy(table, project_column):
+    before = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM %s AS target
+              JOIN project_project AS project ON project.id = target.%s
+             WHERE COALESCE(target.operation_strategy, '') IS DISTINCT FROM COALESCE(project.operation_strategy, '')
+            """
+            % (table, project_column)
+        )
+        or 0
+    )
+    env.cr.execute(  # noqa: F821
+        """
+        UPDATE %s AS target
+           SET operation_strategy = project.operation_strategy,
+               write_date = NOW()
+          FROM project_project AS project
+         WHERE project.id = target.%s
+           AND COALESCE(target.operation_strategy, '') IS DISTINCT FROM COALESCE(project.operation_strategy, '')
+        """
+        % (table, project_column)
+    )
+    updated = env.cr.rowcount  # noqa: F821
+    return {"before_mismatch": before, "updated": updated}
+
+
+def main():
+    strategy_updates = {
+        table: _refresh_operation_strategy(table, project_column)
+        for table, project_column in STRATEGY_TARGETS
+    }
+
+    env.cr.execute(  # noqa: F821
+        """
+        UPDATE sc_general_contract
+           SET contract_no = NULLIF(document_no, ''),
+               write_date = NOW()
+         WHERE COALESCE(contract_no, '') = ''
+           AND COALESCE(document_no, '') <> ''
+        """
+    )
+    contract_no_updated = env.cr.rowcount  # noqa: F821
+
+    env.cr.commit()  # noqa: F821
+
+    result = {
+        "operation": "operation_strategy_contract_surface_backfill",
+        "status": "PASS",
+        "strategy_updates": strategy_updates,
+        "contract_no_updated": contract_no_updated,
+        "remaining": {
+            "sc_general_contract_no_strategy": int(
+                _scalar("SELECT COUNT(*) FROM sc_general_contract WHERE COALESCE(operation_strategy, '') = ''") or 0
+            ),
+            "sc_general_contract_no_contract_no": int(
+                _scalar("SELECT COUNT(*) FROM sc_general_contract WHERE COALESCE(contract_no, '') = ''") or 0
+            ),
+            "sc_fund_account_no_strategy": int(
+                _scalar("SELECT COUNT(*) FROM sc_fund_account WHERE COALESCE(operation_strategy, '') = ''") or 0
+            ),
+            "sc_treasury_reconciliation_no_strategy": int(
+                _scalar("SELECT COUNT(*) FROM sc_treasury_reconciliation WHERE COALESCE(operation_strategy, '') = ''") or 0
+            ),
+        },
+    }
+    print("OPERATION_STRATEGY_CONTRACT_SURFACE_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "operation": "operation_strategy_contract_surface_backfill",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print("OPERATION_STRATEGY_CONTRACT_SURFACE_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -58,6 +58,7 @@ run_odoo_shell_check "user_confirmed_form_capability" "scripts/verify/user_confi
 run_odoo_shell_check "user_confirmed_form_data_alignment" "scripts/verify/user_confirmed_form_data_alignment_audit.py"
 run_odoo_shell_check "user_confirmed_settlement_usability" "scripts/verify/user_confirmed_settlement_usability_audit.py"
 run_odoo_shell_check "project_budget_legacy_material" "scripts/verify/project_budget_legacy_material_audit.py"
+run_odoo_shell_check "operation_strategy_contract_surface" "scripts/verify/operation_strategy_contract_surface_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_operation_strategy_contract_surface.sh
+++ b/scripts/ops/validate_operation_strategy_contract_surface.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/operation_strategy_contract_surface_audit.py"

--- a/scripts/verify/operation_strategy_contract_surface_audit.py
+++ b/scripts/verify/operation_strategy_contract_surface_audit.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+"""Audit stored operation strategy and contract number business surfaces.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/operation_strategy_contract_surface_audit.py
+"""
+
+import json
+import sys
+import traceback
+
+
+STRATEGY_TARGETS = (
+    ("sc_general_contract", "project_id", "sc.general.contract"),
+    ("sc_fund_account", "project_id", "sc.fund.account"),
+    ("sc_treasury_reconciliation", "project_id", "sc.treasury.reconciliation"),
+)
+
+
+def _fetchall(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    names = [desc[0] for desc in env.cr.description]  # noqa: F821
+    return [dict(zip(names, row)) for row in env.cr.fetchall()]  # noqa: F821
+
+
+def _scalar(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def main():
+    failures = []
+    strategy = {}
+    for table, project_column, model in STRATEGY_TARGETS:
+        mismatch_rows = _fetchall(
+            """
+            SELECT target.id, target.%s AS project_id, target.operation_strategy AS stored_strategy,
+                   project.operation_strategy AS project_strategy
+              FROM %s AS target
+              JOIN project_project AS project ON project.id = target.%s
+             WHERE COALESCE(target.operation_strategy, '') IS DISTINCT FROM COALESCE(project.operation_strategy, '')
+             ORDER BY target.id
+             LIMIT 20
+            """
+            % (project_column, table, project_column)
+        )
+        missing_with_project = int(
+            _scalar(
+                """
+                SELECT COUNT(*)
+                  FROM %s AS target
+                  JOIN project_project AS project ON project.id = target.%s
+                 WHERE COALESCE(target.operation_strategy, '') = ''
+                """
+                % (table, project_column)
+            )
+            or 0
+        )
+        total = int(_scalar("SELECT COUNT(*) FROM %s" % table) or 0)
+        no_project = int(_scalar("SELECT COUNT(*) FROM %s WHERE %s IS NULL" % (table, project_column)) or 0)
+        strategy[model] = {
+            "total": total,
+            "no_project": no_project,
+            "missing_with_project": missing_with_project,
+            "mismatch_sample": mismatch_rows,
+        }
+        if mismatch_rows or missing_with_project:
+            failures.append(
+                {
+                    "check": "operation_strategy_matches_project",
+                    "model": model,
+                    "missing_with_project": missing_with_project,
+                    "mismatch_sample": mismatch_rows,
+                }
+            )
+
+    general_contract_no = {
+        "total": int(_scalar("SELECT COUNT(*) FROM sc_general_contract") or 0),
+        "missing_contract_no": int(
+            _scalar("SELECT COUNT(*) FROM sc_general_contract WHERE COALESCE(contract_no, '') = ''") or 0
+        ),
+        "missing_contract_no_with_document_no": int(
+            _scalar(
+                """
+                SELECT COUNT(*)
+                  FROM sc_general_contract
+                 WHERE COALESCE(contract_no, '') = ''
+                   AND COALESCE(document_no, '') <> ''
+                """
+            )
+            or 0
+        ),
+    }
+    if general_contract_no["missing_contract_no_with_document_no"]:
+        failures.append(
+            {
+                "check": "general_contract_contract_no_document_no_fallback",
+                **general_contract_no,
+            }
+        )
+
+    result = {
+        "audit": "operation_strategy_contract_surface_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "strategy": strategy,
+        "general_contract_no": general_contract_no,
+        "failures": failures,
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("OPERATION_STRATEGY_CONTRACT_SURFACE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "operation_strategy_contract_surface_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("OPERATION_STRATEGY_CONTRACT_SURFACE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)


### PR DESCRIPTION
## Summary
- refresh stored operation strategy surfaces from project master data for general contracts, fund accounts, and treasury reconciliations
- backfill general contract numbers from document numbers when the source has no separate contract number
- add an audit and validation wrapper for these business-facing fields
- wire the audit into the formal business release gate

## Validation
- `DB_NAME=sc_demo scripts/ops/validate_operation_strategy_contract_surface.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- visible data usability matrix issue count reduced from 22 to 20; model-specific business value gaps reduced from 8 to 5