### PR TITLE
Add receipt invoice source document coverage gate

### DIFF
--- a/docs/audit/receipt_invoice_source_document_2026-06-10.md
+++ b/docs/audit/receipt_invoice_source_document_2026-06-10.md
@@ -1,0 +1,77 @@
+# Receipt Invoice Source Document 2026-06-10
+
+## Scope
+
+专项补齐正式业务模型 `sc.receipt.invoice.line.source_document_no`。
+
+覆盖菜单：
+
+- 智慧施工管理平台 / 财务中心 / 发票台账 / 收款发票
+
+## Root Cause
+
+历史收款发票明细迁移时保留了发票登记编号 `invoice_document_no`，但没有把父级收入申请中的来源业务单号写入 `source_document_no`。
+
+父级 `payment_request.note` 已稳定携带 `document_no=...`，且本批 4454 条收款发票明细均可由父级收入申请取到来源业务单号。
+
+## Backfill
+
+```text
+RECEIPT_INVOICE_SOURCE_DOCUMENT_BACKFILL: {"after_missing_source_document_no": 0, "before_missing_source_document_no": 4454, "candidate_rows": 4454, "operation": "receipt_invoice_source_document_backfill", "status": "PASS", "updated_rows": 4454}
+```
+
+说明：
+
+- 只补空的 `source_document_no`。
+- 来源限定为父级 `payment_request.note` 中的 `document_no=...`。
+- 不使用发票登记编号替代来源业务单号，避免混淆正式业务语义。
+- 不改用户已确认菜单体系。
+
+## Audit
+
+```text
+RECEIPT_INVOICE_SOURCE_DOCUMENT_AUDIT: {"audit": "receipt_invoice_source_document_audit", "failures": [], "mismatched_parent_document": 0, "missing_source_document_no": 0, "missing_with_parent_document": 0, "parent_document_available": 4454, "status": "PASS", "total": 4454}
+```
+
+## Release Gate
+
+```text
+FORMAL_BUSINESS_RELEASE_GATE_RESULT: PASS db=sc_demo started_at=2026-06-10T00:49:20+08:00 finished_at=2026-06-10T00:51:36+08:00
+```
+
+关键数据对齐结果：
+
+- 用户确认正式菜单：`62`
+- 检查记录：`256844`
+- 检查字段：`862`
+- 不一致字段：`0`
+- 只读来源字段未承接：`0`
+
+## Visible Matrix
+
+修复前：
+
+- `issue_count`: `20`
+- 需要模型专项业务值门：`5`
+- 涉及：`sc.receipt.invoice.line.source_document_no`
+
+修复后：
+
+- `issue_count`: `20`
+- 需要模型专项业务值门：`4`
+- `sc.receipt.invoice.line.source_document_no` 已退出模型专项业务字段缺口
+- `收款发票台账` 剩余 warning 仅为 `source_created_by/source_created_at` 来源元数据
+
+## Remaining Model-Specific Business Gaps
+
+- `sc.settlement.order`: `contract_id`, `legacy_contract_no`, `contract_subject`, `settlement_period_start`, `settlement_period_end`, `engineering_address`, `planned_settlement_date`
+- `project.material.plan`: `legacy_visible_10`
+- `sc.construction.diary`: `legacy_visible_07`, `legacy_visible_08`
+- `sc.material.rfq`: `due_date`, `purchase_request_id`, `source_material_plan_id`
+
+## Policy
+
+- 不改用户已确认菜单体系。
+- 不覆盖用户已验收列表值。
+- 不制造源数据不存在的业务事实。
+- 只承接父级收入申请中已经存在且可审计的来源业务单号。

--- a/scripts/ops/receipt_invoice_source_document_backfill.py
+++ b/scripts/ops/receipt_invoice_source_document_backfill.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""Backfill receipt invoice line source document numbers from parent requests.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/ops/receipt_invoice_source_document_backfill.py
+"""
+
+import json
+import sys
+import traceback
+
+
+SOURCE_DOCUMENT_EXPR = "NULLIF(substring(request.note FROM 'document_no=([^\\n;]+)'), '')"
+
+
+def _scalar(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def main():
+    before_missing = int(
+        _scalar("SELECT COUNT(*) FROM sc_receipt_invoice_line WHERE COALESCE(source_document_no, '') = ''") or 0
+    )
+    candidates = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_receipt_invoice_line AS line
+              JOIN payment_request AS request ON request.id = line.request_id
+             WHERE COALESCE(line.source_document_no, '') = ''
+               AND %s IS NOT NULL
+            """
+            % SOURCE_DOCUMENT_EXPR
+        )
+        or 0
+    )
+    env.cr.execute(  # noqa: F821
+        """
+        UPDATE sc_receipt_invoice_line AS line
+           SET source_document_no = %s,
+               write_uid = 1,
+               write_date = NOW()
+          FROM payment_request AS request
+         WHERE request.id = line.request_id
+           AND COALESCE(line.source_document_no, '') = ''
+           AND %s IS NOT NULL
+        """
+        % (SOURCE_DOCUMENT_EXPR, SOURCE_DOCUMENT_EXPR)
+    )
+    updated = env.cr.rowcount  # noqa: F821
+    env.cr.commit()  # noqa: F821
+
+    after_missing = int(
+        _scalar("SELECT COUNT(*) FROM sc_receipt_invoice_line WHERE COALESCE(source_document_no, '') = ''") or 0
+    )
+    result = {
+        "operation": "receipt_invoice_source_document_backfill",
+        "status": "PASS",
+        "before_missing_source_document_no": before_missing,
+        "candidate_rows": candidates,
+        "updated_rows": updated,
+        "after_missing_source_document_no": after_missing,
+    }
+    print("RECEIPT_INVOICE_SOURCE_DOCUMENT_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "operation": "receipt_invoice_source_document_backfill",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print("RECEIPT_INVOICE_SOURCE_DOCUMENT_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -59,6 +59,7 @@ run_odoo_shell_check "user_confirmed_form_data_alignment" "scripts/verify/user_c
 run_odoo_shell_check "user_confirmed_settlement_usability" "scripts/verify/user_confirmed_settlement_usability_audit.py"
 run_odoo_shell_check "project_budget_legacy_material" "scripts/verify/project_budget_legacy_material_audit.py"
 run_odoo_shell_check "operation_strategy_contract_surface" "scripts/verify/operation_strategy_contract_surface_audit.py"
+run_odoo_shell_check "receipt_invoice_source_document" "scripts/verify/receipt_invoice_source_document_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_receipt_invoice_source_document.sh
+++ b/scripts/ops/validate_receipt_invoice_source_document.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/receipt_invoice_source_document_audit.py"

--- a/scripts/verify/receipt_invoice_source_document_audit.py
+++ b/scripts/verify/receipt_invoice_source_document_audit.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+"""Audit receipt invoice line source document number coverage.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/receipt_invoice_source_document_audit.py
+"""
+
+import json
+import sys
+import traceback
+
+
+SOURCE_DOCUMENT_EXPR = "NULLIF(substring(request.note FROM 'document_no=([^\\n;]+)'), '')"
+
+
+def _scalar(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def _fetchall(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    names = [desc[0] for desc in env.cr.description]  # noqa: F821
+    return [dict(zip(names, row)) for row in env.cr.fetchall()]  # noqa: F821
+
+
+def main():
+    failures = []
+    total = int(_scalar("SELECT COUNT(*) FROM sc_receipt_invoice_line") or 0)
+    missing = int(_scalar("SELECT COUNT(*) FROM sc_receipt_invoice_line WHERE COALESCE(source_document_no, '') = ''") or 0)
+    parent_document_available = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_receipt_invoice_line AS line
+              JOIN payment_request AS request ON request.id = line.request_id
+             WHERE %s IS NOT NULL
+            """
+            % SOURCE_DOCUMENT_EXPR
+        )
+        or 0
+    )
+    missing_with_parent_document = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_receipt_invoice_line AS line
+              JOIN payment_request AS request ON request.id = line.request_id
+             WHERE COALESCE(line.source_document_no, '') = ''
+               AND %s IS NOT NULL
+            """
+            % SOURCE_DOCUMENT_EXPR
+        )
+        or 0
+    )
+    mismatched_parent_document = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_receipt_invoice_line AS line
+              JOIN payment_request AS request ON request.id = line.request_id
+             WHERE %s IS NOT NULL
+               AND COALESCE(line.source_document_no, '') <> %s
+            """
+            % (SOURCE_DOCUMENT_EXPR, SOURCE_DOCUMENT_EXPR)
+        )
+        or 0
+    )
+    if missing_with_parent_document or mismatched_parent_document:
+        failures.append(
+            {
+                "check": "source_document_no_matches_parent_request_document_no",
+                "missing_with_parent_document": missing_with_parent_document,
+                "mismatched_parent_document": mismatched_parent_document,
+                "sample": _fetchall(
+                    """
+                    SELECT line.id, line.request_id, line.source_document_no,
+                           %s AS parent_source_document_no,
+                           line.invoice_document_no, line.legacy_invoice_line_id
+                      FROM sc_receipt_invoice_line AS line
+                      JOIN payment_request AS request ON request.id = line.request_id
+                     WHERE %s IS NOT NULL
+                       AND COALESCE(line.source_document_no, '') <> %s
+                     ORDER BY line.id
+                     LIMIT 20
+                    """
+                    % (SOURCE_DOCUMENT_EXPR, SOURCE_DOCUMENT_EXPR, SOURCE_DOCUMENT_EXPR)
+                ),
+            }
+        )
+
+    result = {
+        "audit": "receipt_invoice_source_document_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "total": total,
+        "missing_source_document_no": missing,
+        "parent_document_available": parent_document_available,
+        "missing_with_parent_document": missing_with_parent_document,
+        "mismatched_parent_document": mismatched_parent_document,
+        "failures": failures,
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("RECEIPT_INVOICE_SOURCE_DOCUMENT_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "receipt_invoice_source_document_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("RECEIPT_INVOICE_SOURCE_DOCUMENT_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)


### PR DESCRIPTION
## Summary

- Backfill `sc.receipt.invoice.line.source_document_no` from parent `payment_request.note` `document_no=...` when the field is empty.
- Add a dedicated receipt invoice source document audit and validation entrypoint.
- Wire the audit into the formal business release gate and document the evidence.

## Root Cause

Receipt invoice line migration preserved invoice registration numbers, but left the formal source document number empty even though each parent receipt request already carried an auditable `document_no=...` value.

## Validation

- `python3 -m py_compile scripts/ops/receipt_invoice_source_document_backfill.py scripts/verify/receipt_invoice_source_document_audit.py`
- `DB_NAME=sc_demo scripts/ops/validate_receipt_invoice_source_document.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- `python3 scripts/verify/visible_data_usability_warning_classification.py`

Key local evidence:

- Backfilled 4454/4454 rows; remaining missing source document numbers: 0.
- Receipt invoice source document audit: PASS, 4454 rows, 0 missing, 0 mismatched.
- Formal release gate: PASS, 62 user-confirmed menus, 256844 records, 862 fields, 0 mismatches.
- Model-specific business gaps reduced from 5 to 4; `sc.receipt.invoice.line.source_document_no` is cleared.