### PR TITLE
Add settlement contract surface coverage gate

### DIFF
--- a/docs/audit/settlement_contract_surface_2026-06-10.md
+++ b/docs/audit/settlement_contract_surface_2026-06-10.md
@@ -1,0 +1,86 @@
+# Settlement Contract Surface 2026-06-10
+
+## Scope
+
+专项补齐并固化 `sc.settlement.order` 的合同/结算字段承接规则。
+
+覆盖字段：
+
+- `contract_id`
+- `legacy_contract_no`
+- `contract_subject`
+- `engineering_address`
+- `settlement_period_start`
+- `settlement_period_end`
+- `planned_settlement_date`
+
+## Root Cause
+
+收入/支出合同结算投影已能进入正式 `sc.settlement.order`，但部分合同快照字段没有沉入结算单，导致通用结算列表矩阵仍把合同编号、合同名称、工程地址等字段判为业务值缺口。
+
+直营验收来源的结算单多数没有正式合同关系，不能为消除空值而伪造合同。该类数据已经由用户确认结算可见字段门禁单独覆盖。
+
+## Backfill
+
+```text
+SETTLEMENT_CONTRACT_SURFACE_BACKFILL: {"operation": "settlement_contract_surface_backfill", "settlement_count": 2747, "status": "PASS", "updated_by_source": {"construction.contract.expense:settlement_surface": 118, "construction.contract.income:settlement_surface": 36, "sc.legacy.direct.acceptance.fact": 110, "sc.legacy.direct.acceptance.fact:direct_engineering_settlement_order": 37}, "updated_fields": {"contract_subject": 37, "engineering_address": 16, "legacy_contract_no": 176, "settlement_period_end": 88, "settlement_period_start": 88}, "updated_rows": 301}
+```
+
+说明：
+
+- 合同来源结算：从关联 `construction.contract` 补齐合同编号、合同名称和有来源的工程地址。
+- 直营工程结算：从验收字段 `legacy_visible_13` 补合同名称，从 `legacy_visible_15` 补工程地址。
+- 结算起止日期：只解析明确日期区间文本。
+- `planned_settlement_date` 未回填；当前旧源没有独立计划结算日期，不能用单据日期替代。
+
+## Audit
+
+```text
+SETTLEMENT_CONTRACT_SURFACE_AUDIT: {"audit": "settlement_contract_surface_audit", "contract_backed_missing_count": 0, "direct_engineering_missing_count": 0, "status": "PASS", "total": 2747}
+```
+
+关键结论：
+
+- 合同来源结算：`154` 条合同快照缺口清零。
+- 直营工程结算：`37` 条合同名称/工程地址可承接缺口清零。
+- 直营验收来源无合同记录保留源范围说明，不伪造正式合同。
+
+## Release Gate
+
+```text
+FORMAL_BUSINESS_RELEASE_GATE_RESULT: PASS db=sc_demo started_at=2026-06-10T01:06:52+08:00 finished_at=2026-06-10T01:09:10+08:00
+```
+
+关键数据对齐结果：
+
+- 用户确认正式菜单：`62`
+- 检查记录：`256844`
+- 检查字段：`862`
+- 不一致字段：`0`
+- 只读来源字段未承接：`0`
+
+## Visible Matrix Classification
+
+修复前：
+
+- 需要模型专项业务值门：`4`
+- 涉及：`sc.settlement.order`
+
+修复后：
+
+- `sc.settlement.order` 进入 `covered_by_settlement_contract_surface_gate`
+- 需要模型专项业务值门：`3`
+
+剩余模型级业务字段缺口：
+
+- `project.material.plan`: `legacy_visible_10`
+- `sc.construction.diary`: `legacy_visible_07`, `legacy_visible_08`
+- `sc.material.rfq`: `due_date`, `purchase_request_id`, `source_material_plan_id`
+
+## Policy
+
+- 不改用户已确认菜单体系。
+- 不覆盖用户已验收列表值。
+- 不制造源数据不存在的合同或计划日期。
+- 对有正式合同来源的结算单强制承接合同快照。
+- 对直营验收来源的结算单保留用户确认可见字段门禁作为承接依据。

--- a/scripts/ops/settlement_contract_surface_backfill.py
+++ b/scripts/ops/settlement_contract_surface_backfill.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+"""Backfill settlement contract surface fields from auditable sources.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/ops/settlement_contract_surface_backfill.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+import traceback
+from datetime import date
+
+
+DIRECT_ENGINEERING_SOURCE = "sc.legacy.direct.acceptance.fact:direct_engineering_settlement_order"
+
+
+def _text(value) -> str:
+    value = "" if value in (None, False) else str(value)
+    value = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if value in {"False", "false", "None", "none"}:
+        return ""
+    return value
+
+
+def _contract_no(contract) -> str:
+    for field_name in (
+        "legacy_contract_no",
+        "legacy_visible_contract_no",
+        "legacy_document_no",
+        "name",
+    ):
+        value = _text(getattr(contract, field_name, False))
+        if value:
+            return value
+    return ""
+
+
+def _contract_address(contract) -> str:
+    for field_name in ("engineering_address", "legacy_visible_engineering_address"):
+        value = _text(getattr(contract, field_name, False))
+        if value:
+            return value
+    return ""
+
+
+def _date_from_parts(year: int, month: int, day: int):
+    try:
+        return date(year, month, day)
+    except ValueError:
+        return None
+
+
+def _parse_date_tokens(raw: str) -> list[date]:
+    text = _text(raw)
+    if not text:
+        return []
+
+    tokens: list[date] = []
+    for match in re.finditer(r"(20\d{2})\s*[年./-]\s*(\d{1,2})\s*[月./-]\s*(\d{1,2})\s*日?", text):
+        parsed = _date_from_parts(int(match.group(1)), int(match.group(2)), int(match.group(3)))
+        if parsed:
+            tokens.append(parsed)
+
+    if tokens:
+        return tokens
+
+    month_range = re.search(
+        r"(20\d{2})\s*年\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日?\s*[~至到\\-—]+\s*(\d{1,2})\s*月\s*(\d{1,2})\s*日?",
+        text,
+    )
+    if month_range:
+        year = int(month_range.group(1))
+        start = _date_from_parts(year, int(month_range.group(2)), int(month_range.group(3)))
+        end = _date_from_parts(year, int(month_range.group(4)), int(month_range.group(5)))
+        return [item for item in (start, end) if item]
+
+    return []
+
+
+def _parse_period(record):
+    candidates = [
+        record.settlement_description,
+        record.title,
+        record.legacy_visible_06,
+        record.legacy_visible_08,
+        record.legacy_visible_13,
+        record.note,
+    ]
+    for value in candidates:
+        parsed = _parse_date_tokens(value)
+        if len(parsed) >= 2:
+            return min(parsed), max(parsed)
+    return None, None
+
+
+def _settlement_values(record) -> dict:
+    vals = {}
+    if record.contract_id:
+        contract = record.contract_id
+        contract_no = _contract_no(contract)
+        if contract_no and _text(record.legacy_contract_no) != contract_no:
+            vals["legacy_contract_no"] = contract_no
+        subject = _text(contract.subject)
+        if subject and _text(record.contract_subject) != subject:
+            vals["contract_subject"] = subject
+        address = _contract_address(contract)
+        if address and _text(record.engineering_address) != address:
+            vals["engineering_address"] = address
+
+    if record.legacy_fact_model == DIRECT_ENGINEERING_SOURCE:
+        subject = _text(record.legacy_visible_13)
+        if subject and not _text(record.contract_subject):
+            vals["contract_subject"] = subject
+        address = _text(record.legacy_visible_15)
+        if address and not _text(record.engineering_address):
+            vals["engineering_address"] = address
+
+    start, end = _parse_period(record)
+    if start and not record.settlement_period_start:
+        vals["settlement_period_start"] = start.isoformat()
+    if end and not record.settlement_period_end:
+        vals["settlement_period_end"] = end.isoformat()
+
+    if vals:
+        vals["write_uid"] = 1
+    return vals
+
+
+def main():
+    Settlement = env["sc.settlement.order"].sudo().with_context(  # noqa: F821
+        active_test=False,
+        legacy_migration_allow_missing_contract=True,
+    )
+    records = Settlement.search([])
+    updated = 0
+    updated_fields = {}
+    by_source = {}
+
+    for record in records:
+        vals = _settlement_values(record)
+        if not vals:
+            continue
+        source = _text(record.legacy_fact_model) or "__manual__"
+        by_source[source] = by_source.get(source, 0) + 1
+        for field_name in vals:
+            if field_name == "write_uid":
+                continue
+            updated_fields[field_name] = updated_fields.get(field_name, 0) + 1
+        record.write(vals)
+        updated += 1
+
+    env.cr.commit()  # noqa: F821
+    result = {
+        "operation": "settlement_contract_surface_backfill",
+        "status": "PASS",
+        "settlement_count": len(records),
+        "updated_rows": updated,
+        "updated_fields": updated_fields,
+        "updated_by_source": by_source,
+    }
+    print("SETTLEMENT_CONTRACT_SURFACE_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "operation": "settlement_contract_surface_backfill",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print("SETTLEMENT_CONTRACT_SURFACE_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -60,6 +60,7 @@ run_odoo_shell_check "user_confirmed_settlement_usability" "scripts/verify/user_
 run_odoo_shell_check "project_budget_legacy_material" "scripts/verify/project_budget_legacy_material_audit.py"
 run_odoo_shell_check "operation_strategy_contract_surface" "scripts/verify/operation_strategy_contract_surface_audit.py"
 run_odoo_shell_check "receipt_invoice_source_document" "scripts/verify/receipt_invoice_source_document_audit.py"
+run_odoo_shell_check "settlement_contract_surface" "scripts/verify/settlement_contract_surface_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_settlement_contract_surface.sh
+++ b/scripts/ops/validate_settlement_contract_surface.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/settlement_contract_surface_audit.py"

--- a/scripts/verify/settlement_contract_surface_audit.py
+++ b/scripts/verify/settlement_contract_surface_audit.py
@@ -1,0 +1,239 @@
+# -*- coding: utf-8 -*-
+"""Audit settlement contract surface coverage rules.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/settlement_contract_surface_audit.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+from pathlib import Path
+
+
+DIRECT_ACCEPTANCE_PREFIX = "sc.legacy.direct.acceptance.fact"
+DIRECT_ENGINEERING_SOURCE = "sc.legacy.direct.acceptance.fact:direct_engineering_settlement_order"
+CONTRACT_BACKED_SOURCES = {
+    "construction.contract.income:settlement_surface",
+    "construction.contract.expense:settlement_surface",
+}
+BUSINESS_FIELDS = {
+    "contract_id",
+    "legacy_contract_no",
+    "contract_subject",
+    "engineering_address",
+    "settlement_period_start",
+    "settlement_period_end",
+    "planned_settlement_date",
+}
+
+
+def artifact_root() -> Path:
+    root = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", "artifacts/migration"))
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        root = Path("/tmp/sce-migration-artifacts")
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+OUTPUT_JSON = artifact_root() / "settlement_contract_surface_audit_result_v1.json"
+
+
+def _text(value) -> str:
+    value = "" if value in (None, False) else str(value)
+    value = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if value in {"False", "false", "None", "none"}:
+        return ""
+    return value
+
+
+def _scalar(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def _fetchall(sql, params=None):
+    env.cr.execute(sql, params or [])  # noqa: F821
+    names = [desc[0] for desc in env.cr.description]  # noqa: F821
+    return [dict(zip(names, row)) for row in env.cr.fetchall()]  # noqa: F821
+
+
+def main():
+    failures = []
+
+    total = int(_scalar("SELECT COUNT(*) FROM sc_settlement_order") or 0)
+    by_source = _fetchall(
+        """
+        SELECT COALESCE(legacy_fact_model, '') AS legacy_fact_model,
+               COALESCE(legacy_acceptance_label, '') AS legacy_acceptance_label,
+               COALESCE(settlement_type, '') AS settlement_type,
+               COUNT(*) AS total,
+               COUNT(*) FILTER (WHERE contract_id IS NOT NULL) AS with_contract,
+               COUNT(*) FILTER (WHERE COALESCE(legacy_contract_no, '') <> '') AS with_legacy_contract_no,
+               COUNT(*) FILTER (WHERE COALESCE(contract_subject, '') <> '') AS with_contract_subject,
+               COUNT(*) FILTER (WHERE COALESCE(engineering_address, '') <> '') AS with_engineering_address,
+               COUNT(*) FILTER (WHERE settlement_period_start IS NOT NULL) AS with_period_start,
+               COUNT(*) FILTER (WHERE settlement_period_end IS NOT NULL) AS with_period_end,
+               COUNT(*) FILTER (WHERE planned_settlement_date IS NOT NULL) AS with_planned_date
+          FROM sc_settlement_order
+         GROUP BY legacy_fact_model, legacy_acceptance_label, settlement_type
+         ORDER BY total DESC
+        """
+    )
+
+    contract_backed_missing = _fetchall(
+        """
+        SELECT s.id, s.name, s.legacy_fact_model, s.contract_id,
+               s.legacy_contract_no, c.legacy_contract_no AS contract_legacy_contract_no,
+               c.legacy_document_no AS contract_legacy_document_no, c.name AS contract_name,
+               s.contract_subject, c.subject AS contract_subject_source,
+               s.engineering_address, c.engineering_address AS contract_engineering_address
+          FROM sc_settlement_order AS s
+          JOIN construction_contract AS c ON c.id = s.contract_id
+         WHERE s.legacy_fact_model = ANY(%s)
+           AND (
+                COALESCE(s.legacy_contract_no, '') = ''
+                OR COALESCE(s.contract_subject, '') = ''
+                OR (
+                    COALESCE(c.engineering_address, '') <> ''
+                    AND COALESCE(s.engineering_address, '') <> COALESCE(c.engineering_address, '')
+                )
+           )
+         ORDER BY s.id
+         LIMIT 20
+        """,
+        [list(CONTRACT_BACKED_SOURCES)],
+    )
+    contract_backed_missing_count = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_settlement_order AS s
+              JOIN construction_contract AS c ON c.id = s.contract_id
+             WHERE s.legacy_fact_model = ANY(%s)
+               AND (
+                    COALESCE(s.legacy_contract_no, '') = ''
+                    OR COALESCE(s.contract_subject, '') = ''
+                    OR (
+                        COALESCE(c.engineering_address, '') <> ''
+                        AND COALESCE(s.engineering_address, '') <> COALESCE(c.engineering_address, '')
+                    )
+               )
+            """,
+            [list(CONTRACT_BACKED_SOURCES)],
+        )
+        or 0
+    )
+    if contract_backed_missing_count:
+        failures.append(
+            {
+                "check": "contract_backed_settlement_contract_snapshot",
+                "missing": contract_backed_missing_count,
+                "sample": contract_backed_missing,
+            }
+        )
+
+    direct_engineering_missing_count = int(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_settlement_order
+             WHERE legacy_fact_model = %s
+               AND (
+                    (COALESCE(legacy_visible_13, '') <> '' AND COALESCE(contract_subject, '') = '')
+                    OR (COALESCE(legacy_visible_15, '') <> '' AND COALESCE(engineering_address, '') = '')
+               )
+            """,
+            [DIRECT_ENGINEERING_SOURCE],
+        )
+        or 0
+    )
+    if direct_engineering_missing_count:
+        failures.append(
+            {
+                "check": "direct_engineering_visible_contract_fields",
+                "missing": direct_engineering_missing_count,
+                "sample": _fetchall(
+                    """
+                    SELECT id, name, contract_subject, legacy_visible_13,
+                           engineering_address, legacy_visible_15
+                      FROM sc_settlement_order
+                     WHERE legacy_fact_model = %s
+                       AND (
+                            (COALESCE(legacy_visible_13, '') <> '' AND COALESCE(contract_subject, '') = '')
+                            OR (COALESCE(legacy_visible_15, '') <> '' AND COALESCE(engineering_address, '') = '')
+                       )
+                     ORDER BY id
+                     LIMIT 20
+                    """,
+                    [DIRECT_ENGINEERING_SOURCE],
+                ),
+            }
+        )
+
+    no_contract_by_source = _fetchall(
+        """
+        SELECT COALESCE(legacy_fact_model, '') AS legacy_fact_model,
+               COALESCE(legacy_acceptance_label, '') AS legacy_acceptance_label,
+               COUNT(*) AS records_without_contract
+          FROM sc_settlement_order
+         WHERE contract_id IS NULL
+         GROUP BY legacy_fact_model, legacy_acceptance_label
+         ORDER BY records_without_contract DESC
+        """
+    )
+
+    source_scope_notes = [
+        {
+            "source_prefix": DIRECT_ACCEPTANCE_PREFIX,
+            "fields": sorted(BUSINESS_FIELDS),
+            "decision": "direct_acceptance_settlements_may_not_have_formal_contract; user-confirmed visible fields are guarded separately",
+        },
+        {
+            "source": DIRECT_ENGINEERING_SOURCE,
+            "fields": ["contract_subject", "engineering_address"],
+            "decision": "covered from legacy_visible_13 and legacy_visible_15 when present",
+        },
+        {
+            "field": "planned_settlement_date",
+            "decision": "not backfilled unless a distinct source value exists; current legacy projections do not carry a separate planned date",
+        },
+    ]
+
+    result = {
+        "audit": "settlement_contract_surface_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "total": total,
+        "by_source": by_source,
+        "contract_backed_sources": sorted(CONTRACT_BACKED_SOURCES),
+        "contract_backed_missing_count": contract_backed_missing_count,
+        "direct_engineering_missing_count": direct_engineering_missing_count,
+        "no_contract_by_source": no_contract_by_source,
+        "source_scope_notes": source_scope_notes,
+        "covered_business_fields": sorted(BUSINESS_FIELDS),
+        "failures": failures,
+    }
+    OUTPUT_JSON.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("SETTLEMENT_CONTRACT_SURFACE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "settlement_contract_surface_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("SETTLEMENT_CONTRACT_SURFACE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/verify/visible_data_usability_warning_classification.py
+++ b/scripts/verify/visible_data_usability_warning_classification.py
@@ -157,6 +157,7 @@ def _classify_issue(
     *,
     entry_metadata_pass: bool,
     contract_value_pass: bool,
+    settlement_contract_pass: bool,
 ) -> tuple[str, str, set[str]]:
     fields = _fields(issue)
     business_fields = fields - ENTRY_METADATA_FIELDS - DERIVED_OR_SYSTEM_FIELDS
@@ -190,6 +191,9 @@ def _classify_issue(
             return "contract_warning_partly_covered", "contract_gate_passed_but_some_fields_need_rule", uncovered
         return "contract_value_gate_required", "contract_targeted_gate_missing_or_failed", business_fields
 
+    if issue.get("model") == "sc.settlement.order" and settlement_contract_pass:
+        return "covered_by_settlement_contract_surface_gate", "targeted_settlement_contract_surface_gate_passed", set()
+
     if fields and business_fields:
         return "requires_model_specific_business_value_gate", "business_fields_need_source_value_rule_or_backfill", business_fields
 
@@ -203,11 +207,13 @@ def main() -> int:
 
     entry_path, entry = _latest_json("formal_entry_metadata_audit_result_v1.json")
     contract_path, contract = _latest_json("construction_contract_history_value_gap_probe_result_v1.json")
+    settlement_path, settlement = _latest_json("settlement_contract_surface_audit_result_v1.json")
     project_path, project = _latest_json("project_migration_field_continuity_gap_probe_result_v1.json")
     formal_path, formal = _latest_json("formal_business_backfill_audit_probe_result_v1.json")
 
     entry_metadata_pass = _status(entry) == "PASS"
     contract_value_pass = _status(contract) == "PASS"
+    settlement_contract_pass = _status(settlement) == "PASS"
 
     rows: list[dict[str, Any]] = []
     bucket_counts: Counter[str] = Counter()
@@ -219,6 +225,7 @@ def main() -> int:
             issue,
             entry_metadata_pass=entry_metadata_pass,
             contract_value_pass=contract_value_pass,
+            settlement_contract_pass=settlement_contract_pass,
         )
         bucket_counts[bucket] += 1
         if unresolved:
@@ -257,6 +264,7 @@ def main() -> int:
         "visible_matrix": str(visible_path),
         "entry_metadata_audit": str(entry_path) if entry_path else None,
         "contract_history_value_probe": str(contract_path) if contract_path else None,
+        "settlement_contract_surface_audit": str(settlement_path) if settlement_path else None,
         "project_migration_field_continuity_probe": str(project_path) if project_path else None,
         "formal_business_backfill_audit": str(formal_path) if formal_path else None,
         "visible_warning_count": int(visible.get("warning_count") or 0),


### PR DESCRIPTION
## Summary

- Backfill auditable settlement contract surface fields on `sc.settlement.order`.
- Add a dedicated settlement contract surface audit and validation entrypoint.
- Wire the audit into the formal business release gate and visible warning classification.

## Root Cause

Income/expense settlement projections moved records into the formal settlement model, but did not fully persist contract snapshot fields such as contract number. Direct-acceptance settlements often do not have a formal contract source, so those must be covered by a source-scope rule rather than fabricated contract links.

## Validation

- `python3 -m py_compile scripts/ops/settlement_contract_surface_backfill.py scripts/verify/settlement_contract_surface_audit.py scripts/verify/visible_data_usability_warning_classification.py`
- `DB_NAME=sc_demo scripts/ops/validate_settlement_contract_surface.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- `python3 scripts/verify/visible_data_usability_warning_classification.py`

Key local evidence:

- Backfilled 301 settlement rows.
- Updated fields: `legacy_contract_no` 176, `contract_subject` 37, `engineering_address` 16, `settlement_period_start/end` 88 each.
- Settlement contract surface audit: PASS, 2747 settlements, 0 contract-backed snapshot gaps, 0 direct engineering visible contract field gaps.
- Formal release gate: PASS, 62 user-confirmed menus, 256844 records, 862 fields, 0 mismatches.
- Model-specific business gaps reduced from 4 to 3; `sc.settlement.order` is covered by the new targeted gate.