### PR TITLE
Add material plan visible note coverage gate

### DIFF
--- a/docs/audit/material_plan_visible_note_2026-06-10.md
+++ b/docs/audit/material_plan_visible_note_2026-06-10.md
@@ -1,0 +1,54 @@
+# Material Plan Visible Note Coverage
+
+Date: 2026-06-10
+Database: `sc_demo`
+Scope: user-confirmed formal menu `材料计划`
+
+## Decision
+
+`project.material.plan.legacy_visible_10` is covered by a targeted source-value gate.
+
+The source field is the user-confirmed `备注` column from direct acceptance `材料计划`.
+Non-empty source notes must be projected into:
+
+- `project.material.plan.legacy_visible_10`
+- `project.material.plan.line.note`
+- `project.material.plan.line_note_summary`
+
+Empty source notes remain empty. No synthetic backfill is allowed.
+
+## Evidence
+
+`DB_NAME=sc_demo scripts/ops/validate_material_plan_visible_note.sh`
+
+- Source material-plan facts: 686
+- Formal material plans: 686
+- Source rows with non-empty notes: 133
+- Source rows with empty notes: 553
+- Projected source notes: 133
+- Missing formal visible notes: 0
+- Missing line notes: 0
+- Missing line-note summaries: 0
+- Status: PASS
+
+`DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
+
+- User-confirmed menus: 62
+- Checked records: 256844
+- Checked fields: 862
+- Mismatch fields: 0
+- Material plan visible note gate: PASS
+- Business capability gate: PASS
+- Status: PASS
+
+## Classification Impact
+
+`python3 scripts/verify/visible_data_usability_warning_classification.py`
+
+- `covered_by_material_plan_visible_note_gate`: 1
+- Remaining model-specific business value gates: 2
+  - `sc.construction.diary`: `legacy_visible_07`, `legacy_visible_08`
+  - `sc.material.rfq`: `due_date`, `purchase_request_id`, `source_material_plan_id`
+
+This removes `project.material.plan.legacy_visible_10` from the unresolved
+model-specific business gap list without changing accepted user-visible data.

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -61,6 +61,7 @@ run_odoo_shell_check "project_budget_legacy_material" "scripts/verify/project_bu
 run_odoo_shell_check "operation_strategy_contract_surface" "scripts/verify/operation_strategy_contract_surface_audit.py"
 run_odoo_shell_check "receipt_invoice_source_document" "scripts/verify/receipt_invoice_source_document_audit.py"
 run_odoo_shell_check "settlement_contract_surface" "scripts/verify/settlement_contract_surface_audit.py"
+run_odoo_shell_check "material_plan_visible_note" "scripts/verify/material_plan_visible_note_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_material_plan_visible_note.sh
+++ b/scripts/ops/validate_material_plan_visible_note.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/material_plan_visible_note_audit.py"

--- a/scripts/verify/material_plan_visible_note_audit.py
+++ b/scripts/verify/material_plan_visible_note_audit.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+"""Audit material plan visible note coverage from direct-acceptance source.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/material_plan_visible_note_audit.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+import zlib
+from pathlib import Path
+
+
+SOURCE_SYSTEM = "online_old_scbsly"
+SOURCE_FACT_MODEL = "online_old_scbsly:direct_acceptance_fact"
+ACCEPTANCE_LABEL = "材料计划"
+LEGACY_FACT_TYPE = "direct_acceptance:材料计划"
+
+
+def artifact_root() -> Path:
+    root = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", "artifacts/migration"))
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        root = Path("/tmp/sce-migration-artifacts")
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+OUTPUT_JSON = artifact_root() / "material_plan_visible_note_audit_result_v1.json"
+
+
+def _text(value) -> str:
+    value = "" if value in (None, False) else str(value)
+    value = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if value.lower() in {"false", "none", "null"}:
+        return ""
+    return value
+
+
+def _source_key(fact) -> int:
+    token = f"{SOURCE_SYSTEM}:{ACCEPTANCE_LABEL}:{fact.legacy_record_id or fact.id}".encode("utf-8")
+    return zlib.crc32(token) & 0x7FFFFFFF
+
+
+def _line_notes(plan) -> list[str]:
+    notes = []
+    for line in plan.line_ids:
+        note = _text(line.note)
+        if note and note not in notes:
+            notes.append(note)
+    return notes
+
+
+def main():
+    Fact = env["sc.legacy.direct.acceptance.fact"].sudo().with_context(active_test=False)  # noqa: F821
+    Plan = env["project.material.plan"].sudo().with_context(active_test=False)  # noqa: F821
+
+    facts = Fact.search(
+        [
+            ("source_system", "=", SOURCE_SYSTEM),
+            ("acceptance_label", "=", ACCEPTANCE_LABEL),
+            ("active", "=", True),
+        ],
+        order="document_no,legacy_record_id,id",
+    )
+    plans = Plan.search(
+        [
+            ("legacy_fact_model", "=", SOURCE_FACT_MODEL),
+            ("legacy_fact_type", "=", LEGACY_FACT_TYPE),
+        ],
+        order="id",
+    )
+    plans_by_key = {plan.legacy_fact_id: plan for plan in plans}
+
+    failures = []
+    missing_plan = []
+    duplicate_plan_keys = {}
+    source_note_count = 0
+    source_note_empty_count = 0
+    source_note_projected_count = 0
+    source_note_missing_count = 0
+    source_note_line_missing_count = 0
+    source_note_summary_missing_count = 0
+    source_note_missing_sample = []
+    source_note_line_missing_sample = []
+    source_note_summary_missing_sample = []
+
+    seen_keys = {}
+    for plan in plans:
+        seen_keys.setdefault(plan.legacy_fact_id, []).append(plan.id)
+    duplicate_plan_keys = {
+        str(key): ids
+        for key, ids in seen_keys.items()
+        if key and len(ids) > 1
+    }
+
+    for fact in facts:
+        key = _source_key(fact)
+        plan = plans_by_key.get(key)
+        if not plan:
+            missing_plan.append({"fact_id": fact.id, "legacy_record_id": _text(fact.legacy_record_id), "source_key": key})
+            continue
+        source_note = _text(fact.legacy_visible_10)
+        plan_note = _text(plan.legacy_visible_10)
+        line_notes = _line_notes(plan)
+        summary_note = _text(plan.line_note_summary)
+        if source_note:
+            source_note_count += 1
+            if plan_note == source_note:
+                source_note_projected_count += 1
+            else:
+                source_note_missing_count += 1
+                if len(source_note_missing_sample) < 20:
+                    source_note_missing_sample.append(
+                        {
+                            "plan_id": plan.id,
+                            "fact_id": fact.id,
+                            "source_note": source_note,
+                            "plan_legacy_visible_10": plan_note,
+                        }
+                    )
+            if source_note not in line_notes:
+                source_note_line_missing_count += 1
+                if len(source_note_line_missing_sample) < 20:
+                    source_note_line_missing_sample.append(
+                        {
+                            "plan_id": plan.id,
+                            "fact_id": fact.id,
+                            "source_note": source_note,
+                            "line_notes": line_notes,
+                        }
+                    )
+            if source_note not in summary_note:
+                source_note_summary_missing_count += 1
+                if len(source_note_summary_missing_sample) < 20:
+                    source_note_summary_missing_sample.append(
+                        {
+                            "plan_id": plan.id,
+                            "fact_id": fact.id,
+                            "source_note": source_note,
+                            "line_note_summary": summary_note,
+                        }
+                    )
+        else:
+            source_note_empty_count += 1
+
+    extra_plans = [
+        {"plan_id": plan.id, "legacy_fact_id": plan.legacy_fact_id}
+        for plan in plans
+        if plan.legacy_fact_id not in {_source_key(fact) for fact in facts}
+    ]
+
+    if len(facts) != len(plans):
+        failures.append({"check": "source_formal_count", "source_count": len(facts), "formal_count": len(plans)})
+    if missing_plan:
+        failures.append({"check": "missing_formal_plan", "missing": len(missing_plan), "sample": missing_plan[:20]})
+    if extra_plans:
+        failures.append({"check": "extra_formal_plan", "extra": len(extra_plans), "sample": extra_plans[:20]})
+    if duplicate_plan_keys:
+        failures.append({"check": "duplicate_formal_plan_key", "duplicates": duplicate_plan_keys})
+    if source_note_missing_count:
+        failures.append(
+            {
+                "check": "legacy_visible_10_matches_source_note",
+                "missing": source_note_missing_count,
+                "sample": source_note_missing_sample,
+            }
+        )
+    if source_note_line_missing_count:
+        failures.append(
+            {
+                "check": "line_note_matches_source_note",
+                "missing": source_note_line_missing_count,
+                "sample": source_note_line_missing_sample,
+            }
+        )
+    if source_note_summary_missing_count:
+        failures.append(
+            {
+                "check": "line_note_summary_matches_source_note",
+                "missing": source_note_summary_missing_count,
+                "sample": source_note_summary_missing_sample,
+            }
+        )
+
+    result = {
+        "audit": "material_plan_visible_note_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "source_count": len(facts),
+        "formal_count": len(plans),
+        "source_note_count": source_note_count,
+        "source_note_empty_count": source_note_empty_count,
+        "source_note_projected_count": source_note_projected_count,
+        "source_note_missing_count": source_note_missing_count,
+        "source_note_line_missing_count": source_note_line_missing_count,
+        "source_note_summary_missing_count": source_note_summary_missing_count,
+        "covered_business_fields": ["legacy_visible_10", "line_ids.note", "line_note_summary"],
+        "source_scope_notes": [
+            {
+                "field": "legacy_visible_10",
+                "label": "备注",
+                "decision": "source empty values remain empty; source non-empty notes must project to formal visible and line note fields",
+            }
+        ],
+        "failures": failures,
+    }
+    OUTPUT_JSON.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("MATERIAL_PLAN_VISIBLE_NOTE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "material_plan_visible_note_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("MATERIAL_PLAN_VISIBLE_NOTE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/verify/visible_data_usability_warning_classification.py
+++ b/scripts/verify/visible_data_usability_warning_classification.py
@@ -158,6 +158,7 @@ def _classify_issue(
     entry_metadata_pass: bool,
     contract_value_pass: bool,
     settlement_contract_pass: bool,
+    material_plan_note_pass: bool,
 ) -> tuple[str, str, set[str]]:
     fields = _fields(issue)
     business_fields = fields - ENTRY_METADATA_FIELDS - DERIVED_OR_SYSTEM_FIELDS
@@ -194,6 +195,9 @@ def _classify_issue(
     if issue.get("model") == "sc.settlement.order" and settlement_contract_pass:
         return "covered_by_settlement_contract_surface_gate", "targeted_settlement_contract_surface_gate_passed", set()
 
+    if issue.get("model") == "project.material.plan" and business_fields == {"legacy_visible_10"} and material_plan_note_pass:
+        return "covered_by_material_plan_visible_note_gate", "targeted_material_plan_visible_note_gate_passed", set()
+
     if fields and business_fields:
         return "requires_model_specific_business_value_gate", "business_fields_need_source_value_rule_or_backfill", business_fields
 
@@ -208,12 +212,14 @@ def main() -> int:
     entry_path, entry = _latest_json("formal_entry_metadata_audit_result_v1.json")
     contract_path, contract = _latest_json("construction_contract_history_value_gap_probe_result_v1.json")
     settlement_path, settlement = _latest_json("settlement_contract_surface_audit_result_v1.json")
+    material_plan_path, material_plan = _latest_json("material_plan_visible_note_audit_result_v1.json")
     project_path, project = _latest_json("project_migration_field_continuity_gap_probe_result_v1.json")
     formal_path, formal = _latest_json("formal_business_backfill_audit_probe_result_v1.json")
 
     entry_metadata_pass = _status(entry) == "PASS"
     contract_value_pass = _status(contract) == "PASS"
     settlement_contract_pass = _status(settlement) == "PASS"
+    material_plan_note_pass = _status(material_plan) == "PASS"
 
     rows: list[dict[str, Any]] = []
     bucket_counts: Counter[str] = Counter()
@@ -226,6 +232,7 @@ def main() -> int:
             entry_metadata_pass=entry_metadata_pass,
             contract_value_pass=contract_value_pass,
             settlement_contract_pass=settlement_contract_pass,
+            material_plan_note_pass=material_plan_note_pass,
         )
         bucket_counts[bucket] += 1
         if unresolved:
@@ -265,6 +272,7 @@ def main() -> int:
         "entry_metadata_audit": str(entry_path) if entry_path else None,
         "contract_history_value_probe": str(contract_path) if contract_path else None,
         "settlement_contract_surface_audit": str(settlement_path) if settlement_path else None,
+        "material_plan_visible_note_audit": str(material_plan_path) if material_plan_path else None,
         "project_migration_field_continuity_probe": str(project_path) if project_path else None,
         "formal_business_backfill_audit": str(formal_path) if formal_path else None,
         "visible_warning_count": int(visible.get("warning_count") or 0),


### PR DESCRIPTION
## Summary
- add a targeted audit for user-confirmed material plan `备注` coverage
- include the audit in the formal business release gate
- classify `project.material.plan.legacy_visible_10` as covered only when the targeted audit passes
- document the source-empty versus source-non-empty decision boundary

## Validation
- `python3 -m py_compile scripts/verify/material_plan_visible_note_audit.py scripts/verify/visible_data_usability_warning_classification.py`
- `DB_NAME=sc_demo scripts/ops/validate_material_plan_visible_note.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- `python3 scripts/verify/visible_data_usability_warning_classification.py`

## Notes
This does not change menu configuration or backfill accepted user-visible data. Source-empty material plan notes remain empty; source non-empty notes are guarded across the formal visible field and material plan line notes.