### PR TITLE
Add material RFQ source coverage gate

### DIFF
--- a/docs/audit/material_rfq_source_coverage_2026-06-10.md
+++ b/docs/audit/material_rfq_source_coverage_2026-06-10.md
@@ -1,0 +1,60 @@
+# Material RFQ Source Coverage
+
+Date: 2026-06-10
+Database: `sc_demo`
+Scope: user-confirmed formal menu `报价单` / formal business menu `询比价`
+
+## Decision
+
+Historical `报价单` rows are projected to formal `sc.material.rfq`.
+
+For formal source fields:
+
+- `source_material_plan_id`: backfill only when the legacy `GLYWID` plus material name plus spec matches exactly one formal material plan.
+- `purchase_request_id`: keep empty for accepted legacy rows because the accepted source does not carry a stable purchase-request reference.
+- `due_date`: keep empty for accepted legacy rows because the accepted source does not carry a distinct quote deadline. Do not copy `rfq_date` into `due_date`.
+
+This preserves accepted user-visible quote data and avoids inventing upstream process data.
+
+## Evidence
+
+`DB_NAME=sc_demo scripts/ops/backfill_material_rfq_source_plan.sh`
+
+- Linked unique source-plan matches: 24
+- Rows without plan source: 95
+- Rows with plan source but no unique material/spec match: 7
+- Status: PASS
+
+`DB_NAME=sc_demo scripts/ops/validate_material_rfq_source_coverage.sh`
+
+- Source quote facts: 126
+- Formal RFQs: 126
+- Source deadline count: 0
+- Source purchase-request reference count: 0
+- Unique material-plan matches: 24
+- Linked material-plan matches: 24
+- Linked material-plan line matches: 24
+- Failures: 0
+- Status: PASS
+
+`DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
+
+- User-confirmed menus: 62
+- Checked records: 256844
+- Checked fields: 862
+- Mismatch fields: 0
+- Material RFQ source coverage gate: PASS
+- Business capability gate: PASS
+- Status: PASS
+
+## Classification Impact
+
+`python3 scripts/verify/visible_data_usability_warning_classification.py`
+
+- `covered_by_material_rfq_source_coverage_gate`: 1
+- Remaining model-specific business value gates: 1
+  - `sc.construction.diary`: `legacy_visible_07`, `legacy_visible_08`
+
+This removes `sc.material.rfq.due_date`, `sc.material.rfq.purchase_request_id`,
+and `sc.material.rfq.source_material_plan_id` from the unresolved
+model-specific business gap list. Only source-proven relationships are written.

--- a/scripts/migration/material_rfq_source_plan_backfill_write.py
+++ b/scripts/migration/material_rfq_source_plan_backfill_write.py
@@ -1,0 +1,171 @@
+# -*- coding: utf-8 -*-
+"""Backfill verifiable material-plan links for legacy material RFQ rows.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/migration/material_rfq_source_plan_backfill_write.py
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import traceback
+import zlib
+from collections import Counter, defaultdict
+
+
+SOURCE_SYSTEM = "online_old_scbsly"
+SOURCE_FACT_MODEL = "online_old_scbsly:direct_acceptance_fact"
+RFQ_LABEL = "报价单"
+PLAN_LABEL = "材料计划"
+RFQ_FACT_TYPE = "direct_acceptance:报价单"
+PLAN_FACT_TYPE = "direct_acceptance:材料计划"
+PLAN_LINK_SOURCE_KEY = "GLYWID$CGXBJ_CGXJD_CB"
+
+
+def _text(value) -> str:
+    value = "" if value in (None, False) else str(value)
+    value = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if value.lower() in {"false", "none", "null"}:
+        return ""
+    return value
+
+
+def _norm(value) -> str:
+    return _text(value).replace(" ", "").lower()
+
+
+def _payload(record) -> dict:
+    raw = _text(record.raw_payload)
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+
+def _payload_text(payload: dict, key: str) -> str:
+    return _text(payload.get(key))
+
+
+def _source_key(label: str, fact) -> int:
+    token = f"{SOURCE_SYSTEM}:{label}:{fact.legacy_record_id or fact.id}".encode("utf-8")
+    return zlib.crc32(token) & 0x7FFFFFFF
+
+
+def _visible(record, index: int) -> str:
+    return _text(getattr(record, "legacy_visible_%02d" % index, ""))
+
+
+def _build_plan_index(plan_facts, plans_by_key):
+    index = defaultdict(dict)
+    for fact in plan_facts:
+        payload = _payload(fact)
+        plan = plans_by_key.get(_source_key(PLAN_LABEL, fact))
+        if not plan:
+            continue
+        material = _norm(_visible(fact, 5) or payload.get("f_CLMC$T_JH_XMZJH"))
+        spec = _norm(_visible(fact, 6) or payload.get("f_GGXH$T_JH_XMZJH"))
+        for source_id in (_payload_text(payload, "Id"), _payload_text(payload, "ZBID$T_JH_XMZJH")):
+            if source_id:
+                index[(source_id, material, spec)][plan.id] = plan
+    return index
+
+
+def main():
+    Fact = env["sc.legacy.direct.acceptance.fact"].sudo().with_context(active_test=False)  # noqa: F821
+    Rfq = env["sc.material.rfq"].sudo().with_context(active_test=False)  # noqa: F821
+    Plan = env["project.material.plan"].sudo().with_context(active_test=False)  # noqa: F821
+
+    rfq_facts = Fact.search(
+        [("source_system", "=", SOURCE_SYSTEM), ("acceptance_label", "=", RFQ_LABEL), ("active", "=", True)],
+        order="document_no,legacy_record_id,id",
+    )
+    plan_facts = Fact.search(
+        [("source_system", "=", SOURCE_SYSTEM), ("acceptance_label", "=", PLAN_LABEL), ("active", "=", True)]
+    )
+    rfqs_by_key = {
+        rfq.legacy_fact_id: rfq
+        for rfq in Rfq.search([("legacy_fact_model", "=", SOURCE_FACT_MODEL), ("legacy_fact_type", "=", RFQ_FACT_TYPE)])
+    }
+    plans_by_key = {
+        plan.legacy_fact_id: plan
+        for plan in Plan.search([("legacy_fact_model", "=", SOURCE_FACT_MODEL), ("legacy_fact_type", "=", PLAN_FACT_TYPE)])
+    }
+    plan_index = _build_plan_index(plan_facts, plans_by_key)
+
+    status = Counter()
+    updated = []
+    skipped_samples = []
+    for fact in rfq_facts:
+        payload = _payload(fact)
+        rfq = rfqs_by_key.get(_source_key(RFQ_LABEL, fact))
+        if not rfq:
+            status["missing_formal_rfq"] += 1
+            continue
+
+        plan_source_id = _payload_text(payload, PLAN_LINK_SOURCE_KEY)
+        if not plan_source_id:
+            status["no_plan_source"] += 1
+            continue
+
+        match_key = (
+            plan_source_id,
+            _norm(_visible(fact, 5) or payload.get("HWMC$CGXBJ_CGXJD_CB")),
+            _norm(_visible(fact, 6) or payload.get("PPXH$CGXBJ_CGXJD_CB")),
+        )
+        plans = list(plan_index.get(match_key, {}).values())
+        if len(plans) != 1:
+            status["no_unique_plan_match"] += 1
+            if len(skipped_samples) < 20:
+                skipped_samples.append(
+                    {
+                        "fact_id": fact.id,
+                        "document_no": _text(fact.document_no),
+                        "plan_source_id": plan_source_id,
+                        "material": match_key[1],
+                        "spec": match_key[2],
+                        "matched_plan_count": len(plans),
+                    }
+                )
+            continue
+
+        plan = plans[0]
+        vals = {}
+        if rfq.source_material_plan_id != plan:
+            vals["source_material_plan_id"] = plan.id
+        if vals:
+            rfq.write(vals)
+        plan_line = plan.line_ids[:1]
+        if plan_line:
+            for line in rfq.line_ids:
+                if line.source_material_plan_line_id != plan_line:
+                    line.write({"source_material_plan_line_id": plan_line.id})
+        status["linked_unique_plan"] += 1
+        updated.append({"rfq_id": rfq.id, "rfq_name": _text(rfq.name), "plan_id": plan.id})
+
+    result = {
+        "script": "material_rfq_source_plan_backfill_write",
+        "status": "PASS",
+        "counts": dict(sorted(status.items())),
+        "updated_count": len(updated),
+        "updated_sample": updated[:20],
+        "skipped_sample": skipped_samples,
+    }
+    env.cr.commit()  # noqa: F821
+    print("MATERIAL_RFQ_SOURCE_PLAN_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "script": "material_rfq_source_plan_backfill_write",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print("MATERIAL_RFQ_SOURCE_PLAN_BACKFILL: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/ops/backfill_material_rfq_source_plan.sh
+++ b/scripts/ops/backfill_material_rfq_source_plan.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/migration/material_rfq_source_plan_backfill_write.py"

--- a/scripts/ops/validate_formal_business_release_gate.sh
+++ b/scripts/ops/validate_formal_business_release_gate.sh
@@ -62,6 +62,7 @@ run_odoo_shell_check "operation_strategy_contract_surface" "scripts/verify/opera
 run_odoo_shell_check "receipt_invoice_source_document" "scripts/verify/receipt_invoice_source_document_audit.py"
 run_odoo_shell_check "settlement_contract_surface" "scripts/verify/settlement_contract_surface_audit.py"
 run_odoo_shell_check "material_plan_visible_note" "scripts/verify/material_plan_visible_note_audit.py"
+run_odoo_shell_check "material_rfq_source_coverage" "scripts/verify/material_rfq_source_coverage_audit.py"
 
 echo "FORMAL_BUSINESS_RELEASE_GATE_CHECK_START: business_capability"
 DB_NAME="$DB_NAME" "$ROOT_DIR/scripts/ops/validate_business_capability_gate.sh"

--- a/scripts/ops/validate_material_rfq_source_coverage.sh
+++ b/scripts/ops/validate_material_rfq_source_coverage.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
+
+# shellcheck source=../common/env.sh
+source "$ROOT_DIR/scripts/common/env.sh"
+# shellcheck source=../common/guard_prod.sh
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+# shellcheck source=../common/compose.sh
+source "$ROOT_DIR/scripts/common/compose.sh"
+
+guard_prod_forbid
+
+: "${DB_NAME:?DB_NAME is required}"
+
+ODOO_ADDONS_PATH="${ODOO_ADDONS_PATH:-/usr/lib/python3/dist-packages/odoo/addons,/mnt/extra-addons,/mnt/addons_external/oca_server_ux}"
+DB_PASSWORD="${DB_PASSWORD:-${DB_USER}}"
+
+compose_dev exec -T \
+  -e PYTHONWARNINGS=ignore \
+  odoo odoo shell -d "$DB_NAME" \
+  --db_host=db --db_port=5432 --db_user="$DB_USER" --db_password="$DB_PASSWORD" \
+  --addons-path="$ODOO_ADDONS_PATH" \
+  --logfile=/dev/null --log-level=warn \
+  < "$ROOT_DIR/scripts/verify/material_rfq_source_coverage_audit.py"

--- a/scripts/verify/material_rfq_source_coverage_audit.py
+++ b/scripts/verify/material_rfq_source_coverage_audit.py
@@ -1,0 +1,304 @@
+# -*- coding: utf-8 -*-
+"""Audit material RFQ source-field coverage from accepted legacy quote data.
+
+Run inside Odoo shell:
+    odoo shell -d sc_demo < scripts/verify/material_rfq_source_coverage_audit.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import traceback
+import zlib
+from collections import Counter, defaultdict
+from pathlib import Path
+
+
+SOURCE_SYSTEM = "online_old_scbsly"
+SOURCE_FACT_MODEL = "online_old_scbsly:direct_acceptance_fact"
+RFQ_LABEL = "报价单"
+PLAN_LABEL = "材料计划"
+RFQ_FACT_TYPE = "direct_acceptance:报价单"
+PLAN_FACT_TYPE = "direct_acceptance:材料计划"
+
+DEADLINE_SOURCE_KEYS = ("JHQ", "BJJZRQ", "YQBJSJ", "YQBJQX", "date_deadline")
+PURCHASE_REQUEST_SOURCE_KEYS = ("CGDID", "CGDID$CGXBJ_CGXJD_CB", "CGDH$CGXBJ_CGXJD_CB")
+PLAN_LINK_SOURCE_KEY = "GLYWID$CGXBJ_CGXJD_CB"
+
+
+def artifact_root() -> Path:
+    root = Path(os.getenv("MIGRATION_ARTIFACT_ROOT", "artifacts/migration"))
+    try:
+        root.mkdir(parents=True, exist_ok=True)
+    except PermissionError:
+        root = Path("/tmp/sce-migration-artifacts")
+        root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+OUTPUT_JSON = artifact_root() / "material_rfq_source_coverage_audit_result_v1.json"
+
+
+def _text(value) -> str:
+    value = "" if value in (None, False) else str(value)
+    value = value.replace("\r\n", "\n").replace("\r", "\n").strip()
+    if value.lower() in {"false", "none", "null"}:
+        return ""
+    return value
+
+
+def _norm(value) -> str:
+    return _text(value).replace(" ", "").lower()
+
+
+def _payload(record) -> dict:
+    raw = _text(record.raw_payload)
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except Exception:
+        return {}
+
+
+def _payload_text(payload: dict, key: str) -> str:
+    return _text(payload.get(key))
+
+
+def _source_key(label: str, fact) -> int:
+    token = f"{SOURCE_SYSTEM}:{label}:{fact.legacy_record_id or fact.id}".encode("utf-8")
+    return zlib.crc32(token) & 0x7FFFFFFF
+
+
+def _visible(record, index: int) -> str:
+    return _text(getattr(record, "legacy_visible_%02d" % index, ""))
+
+
+def _build_plan_index(facts, plans_by_key):
+    index = defaultdict(dict)
+    for fact in facts:
+        payload = _payload(fact)
+        plan = plans_by_key.get(_source_key(PLAN_LABEL, fact))
+        if not plan:
+            continue
+        material = _norm(_visible(fact, 5) or payload.get("f_CLMC$T_JH_XMZJH"))
+        spec = _norm(_visible(fact, 6) or payload.get("f_GGXH$T_JH_XMZJH"))
+        for source_id in (_payload_text(payload, "Id"), _payload_text(payload, "ZBID$T_JH_XMZJH")):
+            if source_id:
+                index[(source_id, material, spec)][plan.id] = plan
+    return index
+
+
+def _expected_matches(rfq_facts, rfqs_by_key, plan_index):
+    expected = {}
+    status = Counter()
+    samples = defaultdict(list)
+    source_deadline_count = 0
+    source_purchase_request_count = 0
+
+    for fact in rfq_facts:
+        payload = _payload(fact)
+        rfq = rfqs_by_key.get(_source_key(RFQ_LABEL, fact))
+        if not rfq:
+            status["missing_formal_rfq"] += 1
+            if len(samples["missing_formal_rfq"]) < 20:
+                samples["missing_formal_rfq"].append({"fact_id": fact.id, "document_no": _text(fact.document_no)})
+            continue
+
+        if any(_payload_text(payload, key) for key in DEADLINE_SOURCE_KEYS):
+            source_deadline_count += 1
+        if any(_payload_text(payload, key) for key in PURCHASE_REQUEST_SOURCE_KEYS):
+            source_purchase_request_count += 1
+
+        plan_source_id = _payload_text(payload, PLAN_LINK_SOURCE_KEY)
+        if not plan_source_id:
+            status["no_plan_source"] += 1
+            continue
+
+        match_key = (
+            plan_source_id,
+            _norm(_visible(fact, 5) or payload.get("HWMC$CGXBJ_CGXJD_CB")),
+            _norm(_visible(fact, 6) or payload.get("PPXH$CGXBJ_CGXJD_CB")),
+        )
+        plans = list(plan_index.get(match_key, {}).values())
+        if len(plans) == 1:
+            expected[rfq.id] = plans[0]
+            status["unique_plan_match"] += 1
+        elif not plans:
+            status["plan_source_without_material_spec_match"] += 1
+            if len(samples["plan_source_without_material_spec_match"]) < 20:
+                samples["plan_source_without_material_spec_match"].append(
+                    {
+                        "fact_id": fact.id,
+                        "document_no": _text(fact.document_no),
+                        "plan_source_id": plan_source_id,
+                        "material": match_key[1],
+                        "spec": match_key[2],
+                    }
+                )
+        else:
+            status["ambiguous_plan_match"] += 1
+            if len(samples["ambiguous_plan_match"]) < 20:
+                samples["ambiguous_plan_match"].append(
+                    {
+                        "fact_id": fact.id,
+                        "document_no": _text(fact.document_no),
+                        "plan_source_id": plan_source_id,
+                        "plan_ids": [plan.id for plan in plans],
+                    }
+                )
+
+    return expected, status, samples, source_deadline_count, source_purchase_request_count
+
+
+def main():
+    Fact = env["sc.legacy.direct.acceptance.fact"].sudo().with_context(active_test=False)  # noqa: F821
+    Rfq = env["sc.material.rfq"].sudo().with_context(active_test=False)  # noqa: F821
+    Plan = env["project.material.plan"].sudo().with_context(active_test=False)  # noqa: F821
+
+    rfq_facts = Fact.search(
+        [("source_system", "=", SOURCE_SYSTEM), ("acceptance_label", "=", RFQ_LABEL), ("active", "=", True)],
+        order="document_no,legacy_record_id,id",
+    )
+    plan_facts = Fact.search(
+        [("source_system", "=", SOURCE_SYSTEM), ("acceptance_label", "=", PLAN_LABEL), ("active", "=", True)]
+    )
+    rfqs = Rfq.search([("legacy_fact_model", "=", SOURCE_FACT_MODEL), ("legacy_fact_type", "=", RFQ_FACT_TYPE)])
+    plans = Plan.search([("legacy_fact_model", "=", SOURCE_FACT_MODEL), ("legacy_fact_type", "=", PLAN_FACT_TYPE)])
+
+    rfqs_by_key = {rfq.legacy_fact_id: rfq for rfq in rfqs}
+    plans_by_key = {plan.legacy_fact_id: plan for plan in plans}
+    plan_index = _build_plan_index(plan_facts, plans_by_key)
+    expected, status, samples, source_deadline_count, source_purchase_request_count = _expected_matches(
+        rfq_facts,
+        rfqs_by_key,
+        plan_index,
+    )
+
+    failures = []
+    linked_match_count = 0
+    line_linked_match_count = 0
+    wrong_plan_links = []
+    missing_plan_links = []
+    missing_plan_line_links = []
+    unexpected_plan_links = []
+
+    for rfq in rfqs:
+        expected_plan = expected.get(rfq.id)
+        if expected_plan:
+            if rfq.source_material_plan_id == expected_plan:
+                linked_match_count += 1
+            else:
+                missing_plan_links.append(
+                    {
+                        "rfq_id": rfq.id,
+                        "rfq_name": _text(rfq.name),
+                        "expected_plan_id": expected_plan.id,
+                        "actual_plan_id": rfq.source_material_plan_id.id or False,
+                    }
+                )
+            plan_line = expected_plan.line_ids[:1]
+            rfq_lines = rfq.line_ids
+            if plan_line and rfq_lines and all(line.source_material_plan_line_id == plan_line for line in rfq_lines):
+                line_linked_match_count += 1
+            else:
+                missing_plan_line_links.append(
+                    {
+                        "rfq_id": rfq.id,
+                        "rfq_name": _text(rfq.name),
+                        "expected_plan_line_id": plan_line.id if plan_line else False,
+                        "actual_plan_line_ids": [line.source_material_plan_line_id.id or False for line in rfq_lines],
+                    }
+                )
+        elif rfq.source_material_plan_id:
+            unexpected_plan_links.append(
+                {"rfq_id": rfq.id, "rfq_name": _text(rfq.name), "actual_plan_id": rfq.source_material_plan_id.id}
+            )
+
+    if len(rfq_facts) != len(rfqs):
+        failures.append({"check": "source_formal_count", "source_count": len(rfq_facts), "formal_count": len(rfqs)})
+    if source_deadline_count:
+        failures.append({"check": "unexpected_source_deadline", "source_deadline_count": source_deadline_count})
+    if source_purchase_request_count:
+        failures.append(
+            {"check": "unexpected_source_purchase_request", "source_purchase_request_count": source_purchase_request_count}
+        )
+    if missing_plan_links:
+        failures.append(
+            {
+                "check": "unique_source_plan_link_projected",
+                "missing": len(missing_plan_links),
+                "sample": missing_plan_links[:20],
+            }
+        )
+    if wrong_plan_links:
+        failures.append({"check": "wrong_source_plan_link", "wrong": len(wrong_plan_links), "sample": wrong_plan_links[:20]})
+    if missing_plan_line_links:
+        failures.append(
+            {
+                "check": "unique_source_plan_line_link_projected",
+                "missing": len(missing_plan_line_links),
+                "sample": missing_plan_line_links[:20],
+            }
+        )
+    if unexpected_plan_links:
+        failures.append(
+            {
+                "check": "unexpected_unverifiable_source_plan_link",
+                "unexpected": len(unexpected_plan_links),
+                "sample": unexpected_plan_links[:20],
+            }
+        )
+
+    result = {
+        "audit": "material_rfq_source_coverage_audit",
+        "status": "PASS" if not failures else "FAIL",
+        "source_count": len(rfq_facts),
+        "formal_count": len(rfqs),
+        "source_deadline_count": source_deadline_count,
+        "source_purchase_request_count": source_purchase_request_count,
+        "match_status_counts": dict(sorted(status.items())),
+        "unique_plan_match_count": len(expected),
+        "linked_plan_match_count": linked_match_count,
+        "linked_plan_line_match_count": line_linked_match_count,
+        "covered_business_fields": ["due_date", "purchase_request_id", "source_material_plan_id"],
+        "source_scope_notes": [
+            {
+                "fields": ["due_date"],
+                "decision": "legacy quote source does not carry a distinct quote deadline; do not backfill from rfq_date",
+                "source_keys_checked": list(DEADLINE_SOURCE_KEYS),
+            },
+            {
+                "fields": ["purchase_request_id"],
+                "decision": "legacy quote source does not carry a stable purchase request reference in accepted data",
+                "source_keys_checked": list(PURCHASE_REQUEST_SOURCE_KEYS),
+            },
+            {
+                "fields": ["source_material_plan_id"],
+                "decision": "only rows with a unique GLYWID + material + spec match are linked to a formal material plan",
+                "source_key": PLAN_LINK_SOURCE_KEY,
+            },
+        ],
+        "samples": {key: value for key, value in sorted(samples.items())},
+        "failures": failures,
+    }
+    OUTPUT_JSON.write_text(json.dumps(result, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("MATERIAL_RFQ_SOURCE_COVERAGE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    return 0 if not failures else 1
+
+
+try:
+    sys.exit(main())
+except Exception as err:
+    result = {
+        "audit": "material_rfq_source_coverage_audit",
+        "status": "FAIL",
+        "error": str(err),
+        "traceback": traceback.format_exc(),
+    }
+    print(json.dumps(result, ensure_ascii=False, sort_keys=True))
+    print("MATERIAL_RFQ_SOURCE_COVERAGE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
+    sys.exit(1)

--- a/scripts/verify/visible_data_usability_warning_classification.py
+++ b/scripts/verify/visible_data_usability_warning_classification.py
@@ -159,6 +159,7 @@ def _classify_issue(
     contract_value_pass: bool,
     settlement_contract_pass: bool,
     material_plan_note_pass: bool,
+    material_rfq_source_pass: bool,
 ) -> tuple[str, str, set[str]]:
     fields = _fields(issue)
     business_fields = fields - ENTRY_METADATA_FIELDS - DERIVED_OR_SYSTEM_FIELDS
@@ -198,6 +199,13 @@ def _classify_issue(
     if issue.get("model") == "project.material.plan" and business_fields == {"legacy_visible_10"} and material_plan_note_pass:
         return "covered_by_material_plan_visible_note_gate", "targeted_material_plan_visible_note_gate_passed", set()
 
+    if (
+        issue.get("model") == "sc.material.rfq"
+        and business_fields <= {"due_date", "purchase_request_id", "source_material_plan_id"}
+        and material_rfq_source_pass
+    ):
+        return "covered_by_material_rfq_source_coverage_gate", "targeted_material_rfq_source_coverage_gate_passed", set()
+
     if fields and business_fields:
         return "requires_model_specific_business_value_gate", "business_fields_need_source_value_rule_or_backfill", business_fields
 
@@ -213,6 +221,7 @@ def main() -> int:
     contract_path, contract = _latest_json("construction_contract_history_value_gap_probe_result_v1.json")
     settlement_path, settlement = _latest_json("settlement_contract_surface_audit_result_v1.json")
     material_plan_path, material_plan = _latest_json("material_plan_visible_note_audit_result_v1.json")
+    material_rfq_path, material_rfq = _latest_json("material_rfq_source_coverage_audit_result_v1.json")
     project_path, project = _latest_json("project_migration_field_continuity_gap_probe_result_v1.json")
     formal_path, formal = _latest_json("formal_business_backfill_audit_probe_result_v1.json")
 
@@ -220,6 +229,7 @@ def main() -> int:
     contract_value_pass = _status(contract) == "PASS"
     settlement_contract_pass = _status(settlement) == "PASS"
     material_plan_note_pass = _status(material_plan) == "PASS"
+    material_rfq_source_pass = _status(material_rfq) == "PASS"
 
     rows: list[dict[str, Any]] = []
     bucket_counts: Counter[str] = Counter()
@@ -233,6 +243,7 @@ def main() -> int:
             contract_value_pass=contract_value_pass,
             settlement_contract_pass=settlement_contract_pass,
             material_plan_note_pass=material_plan_note_pass,
+            material_rfq_source_pass=material_rfq_source_pass,
         )
         bucket_counts[bucket] += 1
         if unresolved:
@@ -273,6 +284,7 @@ def main() -> int:
         "contract_history_value_probe": str(contract_path) if contract_path else None,
         "settlement_contract_surface_audit": str(settlement_path) if settlement_path else None,
         "material_plan_visible_note_audit": str(material_plan_path) if material_plan_path else None,
+        "material_rfq_source_coverage_audit": str(material_rfq_path) if material_rfq_path else None,
         "project_migration_field_continuity_probe": str(project_path) if project_path else None,
         "formal_business_backfill_audit": str(formal_path) if formal_path else None,
         "visible_warning_count": int(visible.get("warning_count") or 0),


### PR DESCRIPTION
## Summary
- add a repeatable backfill for source-proven material RFQ to material plan links
- add a material RFQ source coverage audit and include it in the formal release gate
- classify material RFQ source-field warnings as covered only when the targeted audit passes
- document the historical source boundary for `due_date`, `purchase_request_id`, and `source_material_plan_id`

## Data boundary
- links 24 RFQs to formal material plans and plan lines when `GLYWID + material + spec` has exactly one match
- keeps 95 rows empty because the accepted source has no plan reference
- keeps 7 rows empty because the source reference cannot be matched by material/spec
- does not synthesize quote deadline or purchase request values

## Validation
- `python3 -m py_compile scripts/migration/material_rfq_source_plan_backfill_write.py scripts/verify/material_rfq_source_coverage_audit.py scripts/verify/visible_data_usability_warning_classification.py`
- `DB_NAME=sc_demo scripts/ops/backfill_material_rfq_source_plan.sh`
- `DB_NAME=sc_demo scripts/ops/validate_material_rfq_source_coverage.sh`
- `DB_NAME=sc_demo scripts/ops/validate_formal_business_release_gate.sh`
- reran visible data usability matrix and classification

## Notes
This does not change the user-confirmed menu system or accepted visible list fields.