### PR TITLE
[codex] Add output invoice adjustment entry metadata

### DIFF
--- a/addons/smart_construction_core/models/support/formal_entry_metadata_extensions.py
+++ b/addons/smart_construction_core/models/support/formal_entry_metadata_extensions.py
@@ -60,6 +60,7 @@ FORMAL_ENTRY_METADATA_MODELS = (
     "sc.material.settlement",
     "sc.material.settlement.line",
     "sc.office.admin.document",
+    "sc.output.invoice.adjustment",
     "sc.plan",
     "sc.plan.report",
     "sc.project.document",


### PR DESCRIPTION
## Summary

Adds `sc.output.invoice.adjustment` to the formal entry metadata extension model list so it consistently owns `source_created_by` and `source_created_at`.

## Why

After upgrading `smart_construction_core`, Odoo deleted the stale entry metadata fields for `sc.output.invoice.adjustment`, while inherited/formal views still expected them. This produced an invalid custom view warning for the output invoice adjustment list/form surface.

## Validation

- `python3 -m py_compile addons/smart_construction_core/models/support/formal_entry_metadata_extensions.py`
- `CODEX_MODE=gate CODEX_NEED_UPGRADE=1 MODULE=smart_construction_core DB_NAME=sc_demo make mod.upgrade`
- `DB_NAME=sc_demo MIGRATION_ARTIFACT_ROOT=artifacts/migration make formal_entry_metadata.surface.write`
- `DB_NAME=sc_demo MIGRATION_ARTIFACT_ROOT=artifacts/migration make verify.formal_entry_metadata.audit`
- `DB_NAME=sc_demo MIGRATION_ARTIFACT_ROOT=artifacts/migration make verify.finance_interfund.position.all`

The second module upgrade completed without the previous invalid `sc.output.invoice.adjustment` missing-field view warning.