### PR TITLE
[codex] Fix list search for projection views

### DIFF
--- a/addons/smart_core/handlers/api_data.py
+++ b/addons/smart_core/handlers/api_data.py
@@ -14,6 +14,7 @@ import csv
 import io
 import hashlib
 import json
+import xml.etree.ElementTree as ET
 from datetime import datetime
 from urllib.parse import unquote
 
@@ -1013,6 +1014,43 @@ class ApiDataHandler(BaseIntentHandler):
             return None
         return self._project_scope_denied("当前项目上下文不允许访问或修改其他项目的数据", scope_meta)
 
+    def _search_view_field_names(self, env_model) -> List[str]:
+        model_name = str(getattr(env_model, "_name", "") or "").strip()
+        if not model_name:
+            return []
+        cache = getattr(self, "_search_view_field_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_search_view_field_cache", cache)
+        if model_name in cache:
+            return list(cache.get(model_name) or [])
+
+        names: List[str] = []
+        try:
+            views = env_model.env["ir.ui.view"].sudo().search([
+                ("model", "=", model_name),
+                ("type", "=", "search"),
+            ])
+        except Exception:
+            cache[model_name] = []
+            return []
+
+        for view in views:
+            arch = str(getattr(view, "arch_db", "") or "").strip()
+            if not arch:
+                continue
+            try:
+                root = ET.fromstring(arch.encode("utf-8"))
+            except Exception:
+                continue
+            for node in root.iter("field"):
+                field_name = str(node.attrib.get("name") or "").strip()
+                if field_name and field_name not in names:
+                    names.append(field_name)
+
+        cache[model_name] = names
+        return list(names)
+
     def _build_search_term_domain(self, env_model, search_term: str, fields_safe: List[str]) -> List[Any]:
         term = str(search_term or "").strip()
         if not term:
@@ -1024,7 +1062,9 @@ class ApiDataHandler(BaseIntentHandler):
 
         candidates: List[str] = []
         rec_name = str(getattr(env_model, "_rec_name", "") or "").strip()
-        for field_name in [rec_name, "name"] + list(fields_safe or []):
+        search_view_fields_raw = self._search_view_field_names(env_model)
+        search_view_fields = self._filter_readable_fields(env_model, search_view_fields_raw) if search_view_fields_raw else []
+        for field_name in [rec_name, "name"] + list(fields_safe or []) + list(search_view_fields or []):
             if not field_name or field_name == "id" or field_name in candidates:
                 continue
             field = env_model._fields.get(field_name)

--- a/addons/smart_core/tests/test_api_data_list_param_boundaries.py
+++ b/addons/smart_core/tests/test_api_data_list_param_boundaries.py
@@ -273,6 +273,43 @@ class TestApiDataListParamBoundaries(unittest.TestCase):
         self.assertNotIn(("computed_label", "ilike", "ABC"), domain)
         self.assertNotIn(("amount", "ilike", "ABC"), domain)
 
+    def test_search_term_domain_includes_search_view_fields_for_projection_lists(self):
+        field = lambda field_type, store=True, search=None, groups="": types.SimpleNamespace(
+            type=field_type,
+            store=store,
+            search=search,
+            groups=groups,
+        )
+        user = types.SimpleNamespace(has_group=lambda group: group == "allowed.group")
+        env_model = types.SimpleNamespace(
+            _name="x.receipt",
+            _rec_name="name",
+            env=types.SimpleNamespace(user=user),
+            _fields={
+                "name": field("char"),
+                "p1_visible_project": field("char", store=False),
+                "legacy_project_name": field("char"),
+                "project_id": field("many2one"),
+                "restricted_note": field("char", groups="blocked.group"),
+            },
+        )
+        self.handler._search_view_field_names = lambda model: [
+            "legacy_project_name",
+            "project_id",
+            "restricted_note",
+        ]
+
+        domain = self.handler._build_search_term_domain(
+            env_model,
+            "绵阳",
+            ["p1_visible_project"],
+        )
+
+        self.assertIn(("legacy_project_name", "ilike", "绵阳"), domain)
+        self.assertIn(("project_id", "ilike", "绵阳"), domain)
+        self.assertNotIn(("p1_visible_project", "ilike", "绵阳"), domain)
+        self.assertNotIn(("restricted_note", "ilike", "绵阳"), domain)
+
     def test_python_order_sorts_date_text_chronologically(self):
         rows = [
             {"apply_date": "2024-10-01"},


### PR DESCRIPTION
## Summary

Fixes free-text list search for low-code/formal projection views whose visible columns are non-stored display fields such as `p1_visible_*`.

## Root Cause

`api.data` built free-text search domains from the requested list fields only. Formal projection lists often request display-only projection fields, while the real searchable business fields are declared in the model search view. This caused pages such as engineering progress receipt income to show rows containing `绵阳`, but return zero results after searching `绵阳`.

## Changes

- Adds model search-view field extraction to `api.data` search candidates.
- Keeps existing safeguards: readable-field filtering, field existence checks, and only searchable/stored or explicit-search fields are used.
- Adds a regression test covering projection-list search behavior and permission filtering.

## Validation

- Local: `python3 addons/smart_core/tests/test_api_data_list_param_boundaries.py` passes, 20 tests.
- Local: `python3 -m py_compile addons/smart_core/handlers/api_data.py addons/smart_core/tests/test_api_data_list_param_boundaries.py` passes.
- Dev server: backend restarted and healthy.
- Dev server: action `949` engineering progress receipt income search `绵阳` returns 73 rows instead of 0.
- Dev server: action `778` income search `绵阳` returns 69 rows.
- Dev server: action `669` general contract search `合同` still returns 43 rows.