### PR TITLE
[codex] Include projection source fields in list search

### DIFF
--- a/addons/smart_construction_core/__init__.py
+++ b/addons/smart_construction_core/__init__.py
@@ -40,6 +40,7 @@ from .core_extension import (  # noqa: F401
     smart_core_intent_permission_model_acl_policy,
     smart_core_api_data_create_execution_policy,
     smart_core_api_data_unlink_allowed_models,
+    smart_core_api_data_search_fields,
     smart_core_model_code_mapping,
     smart_core_finalize_projected_contract_data,
     smart_core_finalize_unified_page_contract_v2,

--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -1995,6 +1995,27 @@ def smart_core_api_data_unlink_allowed_models(env):
     return get_api_data_unlink_allowed_model_contributions(env)
 
 
+def smart_core_api_data_search_fields(env, model_name: str):
+    try:
+        from .models.support.p1_daily_business_visible_alias_fields import (
+            LABEL_SOURCE_OVERRIDES,
+            MODEL_LABEL_SOURCE_OVERRIDES,
+            P1_ALIAS_LABELS,
+        )
+    except Exception:
+        return []
+
+    labels = P1_ALIAS_LABELS.get(str(model_name or "").strip()) or []
+    model_overrides = MODEL_LABEL_SOURCE_OVERRIDES.get(str(model_name or "").strip()) or {}
+    names = []
+    for label in labels:
+        for field_name in list(model_overrides.get(label) or []) + list(LABEL_SOURCE_OVERRIDES.get(label) or []):
+            value = str(field_name or "").strip()
+            if value and value not in names:
+                names.append(value)
+    return names
+
+
 def smart_core_model_code_mapping(env):
     return get_model_code_mapping_contributions(env)
 

--- a/addons/smart_construction_core/tests/__init__.py
+++ b/addons/smart_construction_core/tests/__init__.py
@@ -28,6 +28,7 @@ from . import test_capability_lint_gate
 from . import test_capability_registry_service
 from . import test_capability_contract_backend
 from . import test_api_data_batch_contract_backend
+from . import test_api_data_search_fields_extension
 from . import test_api_data_write_unlink_idempotency_backend
 from . import test_my_work_backend
 from . import test_reason_codes_backend

--- a/addons/smart_construction_core/tests/test_api_data_search_fields_extension.py
+++ b/addons/smart_construction_core/tests/test_api_data_search_fields_extension.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+from odoo.tests.common import TransactionCase
+
+from odoo.addons.smart_construction_core.core_extension import smart_core_api_data_search_fields
+
+
+class TestApiDataSearchFieldsExtension(TransactionCase):
+    def test_tender_guarantee_projection_search_fields_include_remark(self):
+        fields = smart_core_api_data_search_fields(self.env, "tender.guarantee")
+
+        self.assertIn("remark", fields)
+        self.assertIn("legacy_visible_project_name", fields)
+        self.assertIn("project_id", fields)
+

--- a/addons/smart_core/handlers/api_data.py
+++ b/addons/smart_core/handlers/api_data.py
@@ -1051,6 +1051,42 @@ class ApiDataHandler(BaseIntentHandler):
         cache[model_name] = names
         return list(names)
 
+    def _extension_search_field_names(self, env_model) -> List[str]:
+        model_name = str(getattr(env_model, "_name", "") or "").strip()
+        if not model_name:
+            return []
+        cache = getattr(self, "_extension_search_field_cache", None)
+        if cache is None:
+            cache = {}
+            setattr(self, "_extension_search_field_cache", cache)
+        if model_name in cache:
+            return list(cache.get(model_name) or [])
+
+        names: List[str] = []
+        try:
+            payload = call_extension_hook_first(
+                env_model.env,
+                "smart_core_api_data_search_fields",
+                env_model.env,
+                model_name,
+            )
+        except Exception:
+            payload = None
+        if isinstance(payload, dict):
+            raw_fields = payload.get(model_name) or payload.get("fields") or []
+        else:
+            raw_fields = payload or []
+        if isinstance(raw_fields, str):
+            raw_fields = [raw_fields]
+        if isinstance(raw_fields, (list, tuple, set)):
+            for field_name in raw_fields:
+                value = str(field_name or "").strip()
+                if value and value not in names:
+                    names.append(value)
+
+        cache[model_name] = names
+        return list(names)
+
     def _build_search_term_domain(self, env_model, search_term: str, fields_safe: List[str]) -> List[Any]:
         term = str(search_term or "").strip()
         if not term:
@@ -1064,7 +1100,9 @@ class ApiDataHandler(BaseIntentHandler):
         rec_name = str(getattr(env_model, "_rec_name", "") or "").strip()
         search_view_fields_raw = self._search_view_field_names(env_model)
         search_view_fields = self._filter_readable_fields(env_model, search_view_fields_raw) if search_view_fields_raw else []
-        for field_name in [rec_name, "name"] + list(fields_safe or []) + list(search_view_fields or []):
+        extension_fields_raw = self._extension_search_field_names(env_model)
+        extension_fields = self._filter_readable_fields(env_model, extension_fields_raw) if extension_fields_raw else []
+        for field_name in [rec_name, "name"] + list(fields_safe or []) + list(search_view_fields or []) + list(extension_fields or []):
             if not field_name or field_name == "id" or field_name in candidates:
                 continue
             field = env_model._fields.get(field_name)

--- a/addons/smart_core/tests/test_api_data_list_param_boundaries.py
+++ b/addons/smart_core/tests/test_api_data_list_param_boundaries.py
@@ -310,6 +310,36 @@ class TestApiDataListParamBoundaries(unittest.TestCase):
         self.assertNotIn(("p1_visible_project", "ilike", "绵阳"), domain)
         self.assertNotIn(("restricted_note", "ilike", "绵阳"), domain)
 
+    def test_search_term_domain_includes_extension_projection_source_fields(self):
+        field = lambda field_type, store=True, search=None, groups="": types.SimpleNamespace(
+            type=field_type,
+            store=store,
+            search=search,
+            groups=groups,
+        )
+        user = types.SimpleNamespace(has_group=lambda group: True)
+        env_model = types.SimpleNamespace(
+            _name="x.guarantee",
+            _rec_name="",
+            env=types.SimpleNamespace(user=user),
+            _fields={
+                "p1_visible_remark": field("char", store=False),
+                "remark": field("char"),
+                "amount": field("monetary"),
+            },
+        )
+        self.handler._extension_search_field_names = lambda model: ["remark", "amount"]
+
+        domain = self.handler._build_search_term_domain(
+            env_model,
+            "保证金",
+            ["p1_visible_remark"],
+        )
+
+        self.assertIn(("remark", "ilike", "保证金"), domain)
+        self.assertNotIn(("p1_visible_remark", "ilike", "保证金"), domain)
+        self.assertNotIn(("amount", "ilike", "保证金"), domain)
+
     def test_python_order_sorts_date_text_chronologically(self):
         rows = [
             {"apply_date": "2024-10-01"},


### PR DESCRIPTION
## Summary

Extends `api.data` free-text list search so formal/low-code projection lists can search the underlying source fields used to render visible projection columns.

## Root Cause

PR #849 fixed lists whose searchable business fields were declared in the model search view. `付款还保证金退回` uses `tender.guarantee` formal projection columns where visible text such as `退...投标保证金` comes from the stored `remark` field, but `remark` is not declared in `tender.guarantee.search`. As a result, users could see `保证金` in the list, while searching `保证金` returned zero rows.

## Changes

- Adds an `api.data` extension hook for additional model search fields.
- Keeps core generic: `smart_core` only consumes field names from extensions and still filters by field access, existence, type, and searchability.
- Implements the construction extension using existing P1 visible alias source mappings.
- Adds regression coverage for extension-provided projection source fields and `tender.guarantee` search field contributions.

## Validation

- Local: `python3 addons/smart_core/tests/test_api_data_list_param_boundaries.py` passes, 21 tests.
- Local: `python3 -m py_compile addons/smart_core/handlers/api_data.py addons/smart_construction_core/core_extension.py addons/smart_construction_core/__init__.py addons/smart_construction_core/tests/test_api_data_search_fields_extension.py addons/smart_construction_core/tests/__init__.py` passes.
- Dev server: backend restarted and healthy.
- Dev server: action `871` 付款还保证金退回 search `保证金` returns 1102 rows instead of 0.
- Dev server: action `871` search `绵阳` returns 55 rows.
- Dev server regression: action `949` 收款登记 search `绵阳` still returns 73 rows.