### PR TITLE
[codex] Fix business list search coverage

### DIFF
--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -2005,8 +2005,18 @@ def smart_core_api_data_search_fields(env, model_name: str):
     except Exception:
         return []
 
-    labels = P1_ALIAS_LABELS.get(str(model_name or "").strip()) or []
-    model_overrides = MODEL_LABEL_SOURCE_OVERRIDES.get(str(model_name or "").strip()) or {}
+    model_name = str(model_name or "").strip()
+    labels = list(P1_ALIAS_LABELS.get(model_name) or [])
+    model_overrides = MODEL_LABEL_SOURCE_OVERRIDES.get(model_name) or {}
+    try:
+        model = env[model_name]
+        for field_name, field in model._fields.items():
+            if str(field_name or "").startswith(("user_acceptance_", "legacy_visible_", "accepted_visible_")):
+                label = str(getattr(field, "string", "") or "").strip()
+                if label and label not in labels:
+                    labels.append(label)
+    except Exception:
+        pass
     names = []
     for label in labels:
         for field_name in list(model_overrides.get(label) or []) + list(LABEL_SOURCE_OVERRIDES.get(label) or []):

--- a/addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py
+++ b/addons/smart_construction_core/models/support/legacy_direct_acceptance_fact.py
@@ -3,6 +3,7 @@ import json
 import re
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 
 LEGACY_VISIBLE_FIELD_MAP = {
@@ -67,6 +68,42 @@ LEGACY_SETTLEMENT_STATUS_DISPLAY = {
 LEGACY_ATTACHMENT_LABEL_RE = re.compile(r"^附件\([1-9]\d*\)$")
 LEGACY_ATTACHMENT_ID_RE = re.compile(r"^[0-9a-fA-F]{32}$")
 
+
+def _legacy_visible_search(self, operator, value):
+    op = str(operator or "").strip() or "ilike"
+    if op not in ("ilike", "like", "=ilike", "=like", "not ilike", "not like"):
+        return [("id", "=", 0)]
+    term = str(value or "").strip()
+    if not term:
+        return [("id", "=", 0)]
+    fields_to_search = [
+        "raw_payload",
+        "document_no",
+        "document_title",
+        "project_name",
+        "partner_name",
+        "creator_name",
+        "note",
+    ]
+    tokens = [token for token in re.split(r"\s+", term) if token]
+    leaves = [
+        ("raw_payload", op, term),
+        ("document_no", op, term),
+        ("document_title", op, term),
+        ("project_name", op, term),
+        ("partner_name", op, term),
+        ("creator_name", op, term),
+        ("note", op, term),
+    ]
+    domains = [[leaf] for leaf in leaves]
+    if op in ("ilike", "like", "=ilike", "=like") and len(tokens) > 1:
+        domains.extend(
+            expression.AND([[(field_name, op, token)] for token in tokens])
+            for field_name in fields_to_search
+        )
+    return expression.OR(domains)
+
+
 class ScLegacyDirectAcceptanceFact(models.Model):
     _name = "sc.legacy.direct.acceptance.fact"
     _description = "直营旧系统验收事实"
@@ -104,9 +141,11 @@ class ScLegacyDirectAcceptanceFact(models.Model):
     raw_payload = fields.Text(string="旧系统原始行JSON")
 
     for _legacy_visible_index in range(1, 61):
+        locals()[f"_search_legacy_visible_{_legacy_visible_index:02d}"] = _legacy_visible_search
         locals()[f"legacy_visible_{_legacy_visible_index:02d}"] = fields.Char(
             string="",
             compute="_compute_legacy_visible_fields",
+            search=f"_search_legacy_visible_{_legacy_visible_index:02d}",
         )
     del _legacy_visible_index
 

--- a/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
+++ b/addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py
@@ -6,6 +6,7 @@ import re
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 
 from odoo import api, fields, models
+from odoo.osv import expression
 
 
 HEX_NAME_RE = re.compile(r"^[0-9a-fA-F]{24,64}(?:\.[A-Za-z0-9]{1,8})?$")
@@ -896,6 +897,177 @@ def _alias_field_name(label):
 
 def _alias_field_string(label):
     return label
+
+
+def _tokenized_search_domain(field_name, operator, value):
+    text = str(value or "").strip()
+    if operator not in ("ilike", "like", "=ilike", "=like") or not text:
+        return [(field_name, operator, value)]
+    tokens = [token for token in re.split(r"\s+", text) if token]
+    if len(tokens) <= 1:
+        return [(field_name, operator, value)]
+    return expression.OR([
+        [(field_name, operator, value)],
+        expression.AND([[(field_name, operator, token)] for token in tokens]),
+    ])
+
+
+def _is_searchable_alias_source_field(model, field_name):
+    field = model._fields.get(field_name)
+    if not field:
+        return False
+    if str(field_name or "").startswith("p1_visible_"):
+        return False
+    field_type = str(getattr(field, "type", "") or "")
+    if field_type not in ("char", "text", "html", "many2one", "selection"):
+        return False
+    return bool(getattr(field, "store", False)) or bool(getattr(field, "search", None))
+
+
+def _p1_alias_search_source_fields(model, label):
+    names = []
+    model_sources = MODEL_LABEL_SOURCE_OVERRIDES.get(model._name, {}).get(label)
+    for field_name in list(model_sources or []) + list(LABEL_SOURCE_OVERRIDES.get(label, ())):
+        value = str(field_name or "").strip()
+        if value and value not in names and _is_searchable_alias_source_field(model, value):
+            names.append(value)
+    for field_name, field in model._fields.items():
+        if (
+            getattr(field, "string", "") == label
+            and not str(field_name or "").startswith("p1_visible_")
+            and field_name not in names
+            and _is_searchable_alias_source_field(model, field_name)
+        ):
+            names.append(field_name)
+    return names
+
+
+def _p1_alias_payload_ids(model, label, operator, value):
+    if operator not in ("ilike", "like", "=ilike", "=like", "not ilike", "not like"):
+        return []
+    text = str(value or "").strip()
+    if not text:
+        return []
+    try:
+        model.env.cr.execute("SELECT to_regclass('public.sc_p1_legacy_visible_alias_payload')")
+        exists = model.env.cr.fetchone()
+        if not exists or not exists[0]:
+            return []
+        sql_operator = "NOT ILIKE" if operator in ("not ilike", "not like") else "ILIKE"
+        pattern = text if operator in ("=ilike", "=like") else "%%%s%%" % text
+        model.env.cr.execute(
+            """
+            SELECT res_id
+              FROM sc_p1_legacy_visible_alias_payload
+             WHERE model = %s
+               AND COALESCE(payload ->> %s, '') {operator} %s
+             LIMIT 50000
+            """.format(operator=sql_operator),
+            [model._name, label, pattern],
+        )
+        return [int(row[0]) for row in model.env.cr.fetchall() if row and row[0]]
+    except Exception:
+        return []
+
+
+def _user_acceptance_alias_search_ids(model, label, operator, value):
+    if operator not in ("ilike", "like", "=ilike", "=like"):
+        return []
+    if "sc.legacy.direct.acceptance.fact" not in model.env:
+        return []
+    specs = []
+    if model._name == "payment.request":
+        specs.append(
+            {
+                "acceptance_label": "支付申请",
+                "base_domain": [("legacy_source_table", "=", "SCBSLY_DIRECT_PAYMENT_APPLY_ACCEPTED")],
+                "doc_fields": ("legacy_visible_document_no", "document_no", "name"),
+            }
+        )
+    elif model._name == "sc.expense.claim":
+        specs.append(
+            {
+                "acceptance_label": "项目费用报销单",
+                "base_domain": [("claim_type", "=", "expense"), ("expense_type", "=", "项目费用报销单")],
+                "doc_fields": ("name",),
+            }
+        )
+    elif model._name == "sc.payment.execution":
+        specs.append(
+            {
+                "acceptance_label": "往来单位付款",
+                "base_domain": [
+                    ("source_kind", "=", "actual_outflow"),
+                    ("legacy_source_model", "=", "online_old_scbsly:T_FK_SUPPLIER:list881"),
+                ],
+                "doc_fields": ("legacy_visible_document_no", "document_no", "name"),
+            }
+        )
+    if not specs:
+        return []
+
+    ids = []
+    Fact = model.env["sc.legacy.direct.acceptance.fact"].sudo()
+    for spec in specs:
+        labels = USER_ACCEPTANCE_ALIAS_LABELS.get(spec["acceptance_label"]) or []
+        if label not in labels:
+            continue
+        visible_index = USER_ACCEPTANCE_ALIAS_INDEXES.get(spec["acceptance_label"], {}).get(label)
+        if not visible_index:
+            try:
+                visible_index = labels.index(label) + 1
+            except ValueError:
+                continue
+        fact_field = "legacy_visible_%02d" % visible_index
+        facts = Fact.search(
+            [
+                ("active", "=", True),
+                ("source_system", "=", "online_old_scbsly"),
+                ("acceptance_label", "=", spec["acceptance_label"]),
+                (fact_field, operator, value),
+            ],
+            limit=50000,
+        )
+        document_values = set()
+        for fact in facts:
+            for value in (fact.document_no, fact.legacy_record_id):
+                text = str(value or "").strip()
+                if text:
+                    document_values.add(text)
+        if not document_values:
+            continue
+        doc_domain = []
+        for doc_field in spec["doc_fields"]:
+            if doc_field not in model._fields:
+                continue
+            doc_domain.append((doc_field, "in", list(document_values)))
+        if not doc_domain:
+            continue
+        domain = list(spec["base_domain"])
+        domain += doc_domain if len(doc_domain) == 1 else expression.OR([[leaf] for leaf in doc_domain])
+        ids.extend(record_id for record_id in model.sudo().search(domain, limit=50000).ids if record_id not in ids)
+    return ids
+
+
+def _p1_visible_alias_search(label):
+    def _search(self, operator, value):
+        op = str(operator or "").strip() or "ilike"
+        domains = []
+        payload_ids = _p1_alias_payload_ids(self, label, op, value)
+        if payload_ids:
+            domains.append([("id", "in", payload_ids)])
+        acceptance_ids = _user_acceptance_alias_search_ids(self, label, op, value)
+        if acceptance_ids:
+            domains.append([("id", "in", acceptance_ids)])
+        for field_name in _p1_alias_search_source_fields(self, label):
+            domains.append(_tokenized_search_domain(field_name, op, value))
+        if not domains:
+            return [("id", "=", 0)]
+        if len(domains) == 1:
+            return domains[0]
+        return expression.OR(domains)
+
+    return _search
 
 
 LABEL_SOURCE_OVERRIDES = {
@@ -2677,9 +2849,12 @@ for _index, (_model_name, _labels) in enumerate(_ALIAS_MODEL_FIELD_LABELS.items(
         "_compute_p1_daily_business_visible_aliases": _compute_p1_daily_business_visible_aliases,
     }
     for _label in _labels:
+        _search_method_name = "_search_%s" % _alias_field_name(_label)
+        _attrs[_search_method_name] = _p1_visible_alias_search(_label)
         _attrs[_alias_field_name(_label)] = fields.Char(
             string=_alias_field_string(_label),
             compute="_compute_p1_daily_business_visible_aliases",
+            search=_search_method_name,
             readonly=True,
         )
     globals()[f"P1DailyBusinessVisibleAlias{_index}"] = type(

--- a/addons/smart_construction_core/tests/test_api_data_search_fields_extension.py
+++ b/addons/smart_construction_core/tests/test_api_data_search_fields_extension.py
@@ -2,6 +2,7 @@
 from odoo.tests.common import TransactionCase
 
 from odoo.addons.smart_construction_core.core_extension import smart_core_api_data_search_fields
+from odoo.addons.smart_construction_core.models.support.p1_daily_business_visible_alias_fields import _alias_field_name
 
 
 class TestApiDataSearchFieldsExtension(TransactionCase):
@@ -12,3 +13,19 @@ class TestApiDataSearchFieldsExtension(TransactionCase):
         self.assertIn("legacy_visible_project_name", fields)
         self.assertIn("project_id", fields)
 
+    def test_user_acceptance_visible_fields_contribute_source_fields(self):
+        fields = smart_core_api_data_search_fields(self.env, "sc.settlement.order")
+
+        self.assertIn("settlement_unit_id", fields)
+        self.assertIn("source_created_by", fields)
+
+    def test_p1_visible_alias_fields_are_searchable(self):
+        field_name = _alias_field_name("收款单位")
+        field = self.env["tender.guarantee"]._fields[field_name]
+
+        self.assertTrue(field.search)
+
+    def test_direct_acceptance_legacy_visible_fields_are_searchable(self):
+        field = self.env["sc.legacy.direct.acceptance.fact"]._fields["legacy_visible_05"]
+
+        self.assertTrue(field.search)

--- a/addons/smart_core/handlers/api_data.py
+++ b/addons/smart_core/handlers/api_data.py
@@ -1097,6 +1097,7 @@ class ApiDataHandler(BaseIntentHandler):
             search_id = None
 
         candidates: List[str] = []
+        related_candidates: List[str] = []
         rec_name = str(getattr(env_model, "_rec_name", "") or "").strip()
         search_view_fields_raw = self._search_view_field_names(env_model)
         search_view_fields = self._filter_readable_fields(env_model, search_view_fields_raw) if search_view_fields_raw else []
@@ -1113,15 +1114,80 @@ class ApiDataHandler(BaseIntentHandler):
                 continue
             if field_type in ("char", "text", "html", "many2one"):
                 candidates.append(field_name)
+            if field_type == "many2one":
+                relation_model_name = str(getattr(field, "comodel_name", "") or "").strip()
+                relation_model = None
+                if relation_model_name:
+                    try:
+                        relation_model = env_model.env[relation_model_name]
+                    except Exception:
+                        relation_model = None
+                relation_fields = getattr(relation_model, "_fields", {}) if relation_model is not None else {}
+                relation_rec_name = str(getattr(relation_model, "_rec_name", "") or "").strip() if relation_model is not None else ""
+                relation_probe_fields = [
+                    relation_rec_name,
+                    "name",
+                    "display_name",
+                    "title",
+                    "document_no",
+                    "contract_no",
+                    "project_name",
+                    "partner_name",
+                    "legacy_visible_title",
+                    "legacy_visible_project_name",
+                    "legacy_visible_counterparty",
+                    "legacy_visible_contract_no",
+                    "legacy_visible_document_no",
+                ]
+                for relation_field_name in relation_probe_fields:
+                    relation_field_name = str(relation_field_name or "").strip()
+                    if not relation_field_name:
+                        continue
+                    relation_field = relation_fields.get(relation_field_name)
+                    relation_field_type = str(getattr(relation_field, "type", "") or "") if relation_field else ""
+                    if relation_field_type not in ("char", "text", "html"):
+                        continue
+                    if not bool(getattr(relation_field, "store", False)) and not getattr(relation_field, "search", None):
+                        continue
+                    dotted = "%s.%s" % (field_name, relation_field_name)
+                    if dotted not in related_candidates:
+                        related_candidates.append(dotted)
 
-        leaves: List[Any] = [(field_name, "ilike", term) for field_name in candidates]
+        search_candidates = candidates + related_candidates
+        leaves: List[Any] = [(field_name, "ilike", term) for field_name in search_candidates]
+        token_domain: List[Any] = []
+        tokens: List[str] = []
+        for token in re.split(r"[\s/|,，;；()（）]+", term):
+            value = token.strip()
+            if len(value) >= 2 and value not in tokens:
+                tokens.append(value)
+            if len(tokens) >= 5:
+                break
+        if len(tokens) >= 2 and search_candidates:
+            token_groups: List[Any] = []
+            for token in tokens:
+                token_leaves = [(field_name, "ilike", token) for field_name in search_candidates]
+                if len(token_leaves) == 1:
+                    token_groups.append(token_leaves)
+                else:
+                    token_groups.append(["|"] * (len(token_leaves) - 1) + token_leaves)
+            token_domain = token_groups[0]
+            for group in token_groups[1:]:
+                token_domain = ["&"] + token_domain + group
         if search_id is not None:
             leaves.append(("id", "=", search_id))
-        if not leaves:
-            return [("id", "=", 0)]
+        exact_domain: List[Any] = []
         if len(leaves) == 1:
-            return leaves
-        return ["|"] * (len(leaves) - 1) + leaves
+            exact_domain = leaves
+        elif len(leaves) > 1:
+            exact_domain = ["|"] * (len(leaves) - 1) + leaves
+        if exact_domain and token_domain:
+            return ["|"] + exact_domain + token_domain
+        if token_domain:
+            return token_domain
+        if not exact_domain:
+            return [("id", "=", 0)]
+        return exact_domain
 
     def _prepare_create_vals(self, env_model, vals: Dict[str, Any]) -> Dict[str, Any]:
         safe_vals = {k: v for k, v in (vals or {}).items() if k in env_model._fields}

--- a/addons/smart_core/tests/test_api_data_list_param_boundaries.py
+++ b/addons/smart_core/tests/test_api_data_list_param_boundaries.py
@@ -340,6 +340,50 @@ class TestApiDataListParamBoundaries(unittest.TestCase):
         self.assertNotIn(("p1_visible_remark", "ilike", "保证金"), domain)
         self.assertNotIn(("amount", "ilike", "保证金"), domain)
 
+    def test_search_term_domain_includes_many2one_display_source_fields(self):
+        field = lambda field_type, store=True, search=None, groups="", comodel_name="": types.SimpleNamespace(
+            type=field_type,
+            store=store,
+            search=search,
+            groups=groups,
+            comodel_name=comodel_name,
+        )
+        user = types.SimpleNamespace(has_group=lambda group: True)
+        contract_model = types.SimpleNamespace(
+            _rec_name="name",
+            _fields={
+                "name": field("char"),
+                "legacy_visible_title": field("char"),
+                "amount_total": field("float"),
+            },
+        )
+
+        class Env(dict):
+            pass
+
+        env = Env({"construction.contract": contract_model})
+        env.user = user
+        env_model = types.SimpleNamespace(
+            _name="payment.request",
+            _rec_name="name",
+            env=env,
+            _fields={
+                "name": field("char"),
+                "contract_id": field("many2one", comodel_name="construction.contract"),
+            },
+        )
+
+        domain = self.handler._build_search_term_domain(
+            env_model,
+            "场外墙",
+            ["contract_id"],
+        )
+
+        self.assertIn(("contract_id", "ilike", "场外墙"), domain)
+        self.assertIn(("contract_id.name", "ilike", "场外墙"), domain)
+        self.assertIn(("contract_id.legacy_visible_title", "ilike", "场外墙"), domain)
+        self.assertNotIn(("contract_id.amount_total", "ilike", "场外墙"), domain)
+
     def test_python_order_sorts_date_text_chronologically(self):
         rows = [
             {"apply_date": "2024-10-01"},

--- a/scripts/ops/audit_business_list_search.py
+++ b/scripts/ops/audit_business_list_search.py
@@ -1,0 +1,176 @@
+# -*- coding: utf-8 -*-
+"""Audit business list search coverage.
+
+Run inside Odoo shell, for example:
+docker compose exec -T odoo odoo shell -c /var/lib/odoo/odoo.conf -d sc_demo < scripts/ops/audit_business_list_search.py
+"""
+
+import json
+import re
+import time
+
+from lxml import etree
+from odoo.osv import expression
+
+from odoo.addons.smart_core.handlers.api_data import ApiDataHandler
+
+
+start = time.time()
+handler = ApiDataHandler(env=env)  # noqa: F821 - provided by odoo shell
+Menu = env["ir.ui.menu"].sudo()  # noqa: F821 - provided by odoo shell
+View = env["ir.ui.view"].sudo()  # noqa: F821 - provided by odoo shell
+
+INCLUDE_RE = re.compile(
+    r"(项目|单位|名称|编号|单号|备注|内容|合同|账户|人员|申请人|录入人|施工|供应商|往来|收款|付款|发票|凭证|标题|事由|地址|开户|银行|材料|租赁|劳务|分包|机械)"
+)
+EXCLUDE_RE = re.compile(
+    r"(状态|日期|时间|金额|数量|附件|税率|排序|是否|推送结果|金蝶|大写|余额|期数|单价|总额|合计|比例|天数)"
+)
+
+
+def _action_domain(action):
+    try:
+        return action._get_eval_domain() if hasattr(action, "_get_eval_domain") else []
+    except Exception:
+        try:
+            from odoo.tools.safe_eval import safe_eval
+
+            return safe_eval(action.domain or "[]") if action.domain else []
+        except Exception:
+            return []
+
+
+def _tree_view(action):
+    for view_id, view_type in action.views:
+        if view_type in ("tree", "list") and view_id:
+            view = View.browse(view_id)
+            if view.exists():
+                return view
+    return None
+
+
+def _fields_from_view(view):
+    if not view or not view.arch_db:
+        return []
+    root = etree.fromstring(view.arch_db.encode())
+    names = []
+    for node in root.xpath(".//field[@name]"):
+        name = (node.get("name") or "").strip()
+        if name and name not in names:
+            names.append(name)
+    return names
+
+
+def _sample_term(value):
+    text = str(value or "").strip()
+    text = re.sub(r"\s+", " ", text)
+    if not text or len(text) < 2:
+        return ""
+    if len(text) <= 18:
+        return text
+    middle = len(text) // 2
+    return text[max(0, middle - 8) : middle + 10].strip()
+
+
+failures = []
+checked_terms = 0
+actions_seen = set()
+menus_checked = 0
+
+for menu in Menu.search([]):
+    path = menu.complete_name or ""
+    if "智慧施工管理平台" not in path:
+        continue
+    action = menu.action
+    if not action or action._name != "ir.actions.act_window" or not action.res_model:
+        continue
+    if action.id in actions_seen:
+        continue
+    actions_seen.add(action.id)
+    menus_checked += 1
+    if "用户核对菜单" in path:
+        continue
+    try:
+        Model = env[action.res_model].sudo()  # noqa: F821 - provided by odoo shell
+    except Exception:
+        continue
+    view = _tree_view(action)
+    fields = _fields_from_view(view)
+    if not fields:
+        continue
+    fields_safe = handler._filter_readable_fields(Model, fields)
+    base_domain = _action_domain(action)
+    records = Model.search(base_domain, limit=3)
+    per_action_terms = 0
+    for record in records:
+        for field_name in fields_safe:
+            field = Model._fields.get(field_name)
+            if not field or getattr(field, "type", "") not in ("char", "text", "html", "many2one", "selection"):
+                continue
+            label = (getattr(field, "string", "") or field_name or "").strip()
+            if not INCLUDE_RE.search(label) or EXCLUDE_RE.search(label):
+                continue
+            try:
+                value = record[field_name]
+                if getattr(field, "type", "") == "many2one":
+                    value = value.display_name if value else ""
+            except Exception:
+                continue
+            term = _sample_term(value)
+            if not term:
+                continue
+            checked_terms += 1
+            per_action_terms += 1
+            search_domain = handler._build_search_term_domain(Model, term, fields_safe)
+            try:
+                count = Model.search_count(expression.AND([base_domain, search_domain, [("id", "=", record.id)]]))
+            except Exception as exc:
+                failures.append(
+                    {
+                        "kind": "error",
+                        "action_id": action.id,
+                        "action_name": action.name,
+                        "menu": path,
+                        "model": action.res_model,
+                        "view": view.name if view else "",
+                        "record_id": record.id,
+                        "field": field_name,
+                        "label": label,
+                        "term": term,
+                        "error": str(exc)[:300],
+                    }
+                )
+                continue
+            if count < 1:
+                failures.append(
+                    {
+                        "kind": "miss",
+                        "action_id": action.id,
+                        "action_name": action.name,
+                        "menu": path,
+                        "model": action.res_model,
+                        "view": view.name if view else "",
+                        "record_id": record.id,
+                        "field": field_name,
+                        "label": label,
+                        "term": term,
+                        "visible_text": str(value or "")[:300],
+                    }
+                )
+            if per_action_terms >= 5:
+                break
+        if per_action_terms >= 5:
+            break
+
+print(
+    json.dumps(
+        {
+            "checked": {"menus": menus_checked, "actions": len(actions_seen), "terms": checked_terms},
+            "failure_count": len(failures),
+            "failures": failures[:120],
+            "elapsed_seconds": round(time.time() - start, 2),
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+)


### PR DESCRIPTION
## Summary
- expand list search candidates to cover many2one display source fields and multi-keyword fragments
- make P1 visible aliases and direct acceptance visible fields searchable through source/payload/fact proxies
- add a repeatable business list search audit script for Smart Construction menus

## Root cause
Some user-visible list columns are computed projection fields or display names assembled from related records. The previous search domain skipped non-searchable computed fields and relied on many2one name search, so users could see text in the list but searching that same text did not always return the row.

## Validation
- `python3 -m py_compile ...`
- `python3 addons/smart_core/tests/test_api_data_list_param_boundaries.py`
- local `scripts/ops/audit_business_list_search.py`: 182 actions / 263 terms / 0 failures
- dev server `scripts/ops/audit_business_list_search.py`: 182 actions / 273 terms / 0 failures