### PR TITLE
[codex] align menu acceptance with hidden parent fallback

### DIFF
--- a/frontend/apps/web/scripts/low_code_menu_navigation_alignment_acceptance.mjs
+++ b/frontend/apps/web/scripts/low_code_menu_navigation_alignment_acceptance.mjs
@@ -100,17 +100,35 @@ async function navigationRequest(page) {
 
 function expectedVisiblePolicies(audit, panel) {
   const menuById = new Map((panel.menus || []).map((menu) => [Number(menu.id || menu.menu_id || 0), menu]));
+  const policyByMenuId = new Map((audit.applicable_policies || [])
+    .map((policy) => [Number(policy.menu_id || 0), policy])
+    .filter(([menuId]) => menuId > 0));
+  const isPolicyVisible = (menuId) => policyByMenuId.get(menuId)?.visible === true;
+  const effectiveVisibleParentId = (parentId) => {
+    let currentId = Number(parentId || 0);
+    const seen = new Set();
+    while (currentId && !seen.has(currentId)) {
+      seen.add(currentId);
+      if (isPolicyVisible(currentId)) return currentId;
+      const parentPolicy = policyByMenuId.get(currentId) || {};
+      const parentMenu = menuById.get(currentId) || {};
+      currentId = Number(parentPolicy.target_parent_menu_id || parentMenu.parent_id || 0);
+    }
+    return 0;
+  };
   const rows = [];
   for (const policy of audit.applicable_policies || []) {
     const menuId = Number(policy.menu_id || 0);
     if (!menuId || policy.visible !== true) continue;
     const menu = menuById.get(menuId) || {};
-    const expectedParentId = Number(policy.target_parent_menu_id || menu.parent_id || 0);
+    const configuredParentId = Number(policy.target_parent_menu_id || menu.parent_id || 0);
+    const expectedParentId = effectiveVisibleParentId(configuredParentId);
     rows.push({
       menuId,
       expectedLabel: normalize(policy.custom_label || policy.menu_label || menu.name),
       expectedParentId,
       targetParentId: Number(policy.target_parent_menu_id || 0),
+      configuredParentId,
       policyId: Number(policy.id || 0),
       menuCompleteName: normalize(policy.menu_complete_name || menu.complete_name),
     });

--- a/scripts/verify/business_config_guard_inventory.py
+++ b/scripts/verify/business_config_guard_inventory.py
@@ -185,6 +185,14 @@ TARGET_SOURCE_MARKER_REQUIREMENTS = {
             "sampleCount",
         ),
     },
+    "verify.business_config.low_code_menu_navigation_alignment": {
+        "frontend/apps/web/scripts/low_code_menu_navigation_alignment_acceptance.mjs": (
+            "effectiveVisibleParentId",
+            "configuredParentId",
+            "policy.visible !== true",
+            "navigation_config_only",
+        ),
+    },
     "verify.business_config.low_code_global_stability": {
         "frontend/apps/web/scripts/low_code_global_stability_acceptance.mjs": (
             "sanitizedContractJson",


### PR DESCRIPTION
## Summary

- Update low-code menu navigation alignment acceptance to match runtime behavior when a configured parent menu is hidden.
- Expected parent resolution now climbs to the nearest visible configured parent instead of comparing against a hidden parent that is intentionally absent from the navigation tree.
- Add guard markers so this acceptance rule does not regress.

## Root Cause

Development-server data had visible child menu policies pointing at `收付款办理(524)`, while that parent policy was hidden. Runtime navigation correctly promoted those visible children to the nearest visible parent `财务中心(306)`, but the acceptance script still expected the hidden parent id and reported two false parent mismatches.

## Validation

- `python3 scripts/verify/business_config_guard_inventory.py`
- `git diff --check`
- Local menu alignment: `BASE_URL=http://127.0.0.1:18081 ... node scripts/low_code_menu_navigation_alignment_acceptance.mjs`
- Development-server menu alignment: `BASE_URL=http://1.95.85.92:18081 ... node scripts/low_code_menu_navigation_alignment_acceptance.mjs`

Development server result after the fix: configured 481, applicable 481, final navigation 133, and zero missing/unexpected/duplicate/label/parent mismatches.