### PR TITLE
[codex] fix business entity action group boundary

### DIFF
--- a/addons/smart_construction_core/tests/test_action_groups_gate.py
+++ b/addons/smart_construction_core/tests/test_action_groups_gate.py
@@ -43,3 +43,15 @@ class TestActionGroupsGate(TransactionCase):
             risky,
             "存在菜单有限流但 Action 无 groups 的绕过风险：%s" % ", ".join(risky),
         )
+
+    def test_business_entity_entry_uses_business_config_group(self):
+        expected_group = self.env.ref("smart_construction_core.group_sc_cap_business_config_admin")
+        action = self.env.ref("smart_construction_core.action_sc_business_entity")
+        menu = self.env.ref("smart_construction_core.menu_sc_business_entity")
+        legacy_action = self.env.ref("smart_construction_core.action_sc_legacy_business_entity_map")
+        legacy_menu = self.env.ref("smart_construction_core.menu_sc_legacy_business_entity_map")
+
+        self.assertEqual(action.groups_id, expected_group)
+        self.assertEqual(menu.groups_id, expected_group)
+        self.assertNotIn(expected_group, legacy_action.groups_id)
+        self.assertNotIn(expected_group, legacy_menu.groups_id)

--- a/addons/smart_construction_core/views/support/business_entity_views.xml
+++ b/addons/smart_construction_core/views/support/business_entity_views.xml
@@ -102,7 +102,7 @@
             <field name="view_mode">tree,form</field>
             <field name="search_view_id" ref="view_sc_business_entity_search"/>
             <field name="context">{'search_default_state_candidate': 1, 'search_default_group_state': 1}</field>
-            <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_config_admin')])]"/>
+            <field name="groups_id" eval="[(6, 0, [ref('smart_construction_core.group_sc_cap_business_config_admin')])]"/>
         </record>
 
         <record id="view_sc_legacy_business_entity_map_search" model="ir.ui.view">
@@ -428,7 +428,7 @@
                   parent="smart_construction_core.menu_sc_data_center"
                   action="action_sc_business_entity"
                   sequence="11"
-                  groups="smart_construction_core.group_sc_cap_config_admin"/>
+                  groups="smart_construction_core.group_sc_cap_business_config_admin"/>
         <menuitem id="menu_sc_legacy_business_entity_map"
                   name="旧库业务主体映射"
                   parent="smart_construction_core.menu_sc_data_center"


### PR DESCRIPTION
## Summary
- Move the `业务核算主体` action/menu group from industry config admin to business config admin.
- Add an action-group regression test for the business entity entry.
- Keep legacy mapping governance actions limited to industry config admin.

## Root Cause
The previous fix added the missing read ACL for `sc.legacy.business.entity.map`, but action 706 and menu 417 were still bound only to `group_sc_cap_config_admin`. Business configuration users could see the entry through configured navigation, then the backend rejected the action group check.

## Validation
- `git diff --check`
- `python3 -m py_compile addons/smart_construction_core/tests/test_action_groups_gate.py`