### PR TITLE
[codex] fix action view payload read ACL

### DIFF
--- a/addons/smart_construction_core/security/ir.model.access.csv
+++ b/addons/smart_construction_core/security/ir.model.access.csv
@@ -65,6 +65,7 @@ access_project_stage_project_user,project.project.stage.project.user,model_proje
 access_project_stage_manager,project.project.stage.manager,model_project_project_stage,smart_construction_core.group_sc_cap_project_manager,1,1,1,1
 access_ir_actions_act_window_sc_internal_read,ir.actions.act.window.sc.internal.read,base.model_ir_actions_act_window,smart_construction_core.group_sc_internal_user,1,0,0,0
 access_ir_actions_act_window_base_user_read,ir.actions.act.window.base.user.read,base.model_ir_actions_act_window,base.group_user,1,0,0,0
+access_ir_actions_act_window_view_sc_internal_read,ir.actions.act.window.view.sc.internal.read,base.model_ir_actions_act_window_view,smart_construction_core.group_sc_internal_user,1,0,0,0
 access_sc_capability_read,sc.capability.read,model_sc_capability,smart_construction_core.group_sc_internal_user,1,0,0,0
 access_sc_capability_admin,sc.capability.admin,model_sc_capability,smart_core.group_smart_core_admin,1,1,1,1
 access_sc_capability_group_read,sc.capability.group.read,model_sc_capability_group,smart_construction_core.group_sc_internal_user,1,0,0,0

--- a/addons/smart_construction_core/tests/test_action_groups_gate.py
+++ b/addons/smart_construction_core/tests/test_action_groups_gate.py
@@ -55,3 +55,23 @@ class TestActionGroupsGate(TransactionCase):
         self.assertEqual(menu.groups_id, expected_group)
         self.assertNotIn(expected_group, legacy_action.groups_id)
         self.assertNotIn(expected_group, legacy_menu.groups_id)
+
+    def test_business_config_user_can_read_business_entity_action_payload(self):
+        group = self.env.ref("smart_construction_core.group_sc_cap_business_config_admin")
+        company = self.env.ref("base.main_company")
+        user = self.env["res.users"].with_context(no_reset_password=True).create(
+            {
+                "name": "action_payload_business_config",
+                "login": "action_payload_business_config",
+                "email": "action_payload_business_config@example.com",
+                "company_id": company.id,
+                "company_ids": [(6, 0, [company.id])],
+                "groups_id": [(6, 0, [group.id])],
+            }
+        )
+        action = self.env.ref("smart_construction_core.action_sc_business_entity").with_user(user)
+
+        payload = action.read()[0]
+
+        self.assertEqual(payload["res_model"], "sc.business.entity")
+        self.assertEqual(payload["id"], action.id)


### PR DESCRIPTION
## Summary
- Add read-only ACL for `ir.actions.act_window.view` to SC internal users.
- Add regression coverage that a business configuration user can read the `业务核算主体` action payload.

## Root Cause
After action 706 was moved to the business configuration group, reading the action payload still traversed `ir.actions.act_window.view`. SC users already had read ACL for `ir.actions.act_window`, but not its child view binding model, so `/a/706` could still fail with `PERMISSION_DENIED`.

## Validation
- `git diff --check`
- ACL CSV uniqueness and permission-bit smoke script
- `python3 -m py_compile addons/smart_construction_core/tests/test_action_groups_gate.py`