### PR TITLE
Integrate payment approval chain evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3968,6 +3968,10 @@ verify.product.delivery.governance_truth: guard.prod.forbid
 verify.product.delivery.action_closure.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_action_closure_smoke.py
 
+.PHONY: verify.delivery.payment_approval.chain_summary
+verify.delivery.payment_approval.chain_summary: guard.prod.forbid
+	@python3 scripts/verify/payment_request_approval_chain_summary.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -24,9 +24,11 @@ green. The next iteration should not reopen release blockers unless a live gate 
    - Evidence target: new or extended make target under `verify.delivery.journey.*`
 
 2. Payment approval chain scoreboard integration
+   - Status: done
    - Scope: `finance.payment_requests`, `finance.center`
    - Target: existing payment approval smoke result is written into the delivery readiness scoreboard evidence summary.
-   - Evidence target: scoreboard row references the smoke artifact and latest status.
+   - Evidence target: `artifacts/backend/payment_request_approval_chain_summary.json` and the scoreboard row `Payment approval chain smoke`.
+   - Note: `payment_request_approval_field_consumer_audit` still reports deprecated field references in non-strict mode; this is not part of the action handoff smoke closure.
 
 3. Purchase/material action replay
    - Scope: `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request`

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -35,7 +35,7 @@
 | 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Covered by strict scene gate (`PASS`) | 需补任务动作 system-bound 脚本 |
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Covered by strict scene gate (`PASS`) | 需补采购/材料/租赁动作回放证据 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Covered by strict scene gate (`PASS`) | 需补质量安全闭环动作证据 |
-| 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval smoke chain available | 需把审批 smoke 结果纳入统一看板 |
+| 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Covered by strict scene gate (`PASS`) | 需补台账对账快照证据 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Covered by strict scene gate (`PASS`) | 需补搜索/分页动作证据 |
 | 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Covered by strict scene gate (`PASS`) | 需补只读角色验收脚本 |

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T07:45:29Z
-- branch: `topic/lowcode-release-closure`
-- commit_ref: `de1308b8f`
+- generated_at_utc: 2026-06-30T07:51:52Z
+- branch: `topic/delivery-action-evidence`
+- commit_ref: `f1eb896b4`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -27,6 +27,7 @@
 | Mainline one-command summary | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
 | Product delivery action closure smoke | PASS | `artifacts/backend/product_delivery_action_closure_report.json` |
 | Product delivery module capability smoke | PASS | `artifacts/backend/product_delivery_module9_smoke_report.json` |
+| Payment approval chain smoke | PASS | `artifacts/backend/payment_request_approval_chain_summary.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -19,6 +19,7 @@ MAINLINE_SUMMARY_PATH = ROOT / "artifacts" / "backend" / "delivery_mainline_run_
 CONTRACT_CLOSURE_MAINLINE_SUMMARY_PATH = ROOT / "artifacts" / "backend" / "backend_contract_closure_mainline_summary.json"
 ACTION_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_action_closure_report.json"
 MODULE9_SMOKE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_module9_smoke_report.json"
+PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_request_approval_chain_summary.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -410,6 +411,11 @@ def main() -> int:
     module9_smoke_ok = bool(module9_smoke_payload.get("ok")) if module9_smoke_present else False
     module9_smoke_label = _bool_status_label(module9_smoke_ok) if module9_smoke_present else "UNKNOWN"
 
+    payment_approval_payload = _load_json(PAYMENT_APPROVAL_CHAIN_REPORT_PATH)
+    payment_approval_present = bool(payment_approval_payload)
+    payment_approval_ok = bool(payment_approval_payload.get("ok")) if payment_approval_present else False
+    payment_approval_label = _bool_status_label(payment_approval_ok) if payment_approval_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -439,6 +445,12 @@ def main() -> int:
         "Product delivery module capability smoke",
         module9_smoke_label,
         str(MODULE9_SMOKE_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Payment approval chain smoke",
+        payment_approval_label,
+        str(PAYMENT_APPROVAL_CHAIN_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/payment_request_approval_chain_summary.py
+++ b/scripts/verify/payment_request_approval_chain_summary.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT_ROOT = ROOT / "artifacts" / "codex"
+REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_request_approval_chain_summary.json"
+
+SMOKE_SOURCES = {
+    "finance_action_smoke": ARTIFACT_ROOT / "payment-request-approval-smoke",
+    "finance_executive_handoff_smoke": ARTIFACT_ROOT / "payment-request-approval-handoff-smoke",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _latest_summary(root: Path) -> Path | None:
+    if not root.is_dir():
+        return None
+    candidates = sorted(path for path in root.glob("*/summary.json") if path.is_file())
+    return candidates[-1] if candidates else None
+
+
+def _step_ok(step: object) -> bool:
+    if not isinstance(step, dict):
+        return False
+    return bool(step.get("ok"))
+
+
+def _summarize_component(name: str, root: Path) -> dict:
+    summary_path = _latest_summary(root)
+    if summary_path is None:
+        return {
+            "present": False,
+            "ok": False,
+            "path": "",
+            "step_count": 0,
+            "failed_steps": [],
+        }
+
+    payload = _load_json(summary_path)
+    steps = payload.get("steps") if isinstance(payload.get("steps"), list) else []
+    failed_steps = [
+        str((step or {}).get("step") or "<unknown>")
+        for step in steps
+        if not _step_ok(step)
+    ]
+    return {
+        "present": True,
+        "ok": bool(steps) and not failed_steps,
+        "path": str(summary_path.relative_to(ROOT)),
+        "payment_request_id": payload.get("payment_request_id"),
+        "auto_created": bool(payload.get("auto_created")),
+        "step_count": len(steps),
+        "failed_steps": failed_steps,
+        "selected_action": payload.get("selected_action") or payload.get("executive_selected_action") or "",
+        "followup_selected_action": payload.get("followup_selected_action") or "",
+        "followup_skip_reason": payload.get("followup_skip_reason") or "",
+    }
+
+
+def main() -> int:
+    components = {
+        name: _summarize_component(name, root)
+        for name, root in SMOKE_SOURCES.items()
+    }
+    present_count = sum(1 for item in components.values() if item.get("present"))
+    ok = bool(components) and all(bool(item.get("ok")) for item in components.values())
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": ok,
+        "summary": {
+            "component_count": len(components),
+            "present_count": present_count,
+            "missing_count": len(components) - present_count,
+            "failed_count": sum(1 for item in components.values() if item.get("present") and not item.get("ok")),
+        },
+        "components": components,
+    }
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(REPORT_PATH)
+    print("[payment_request_approval_chain_summary] PASS" if ok else "[payment_request_approval_chain_summary] INCOMPLETE")
+    return 0 if ok else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add `payment_request_approval_chain_summary.py` to normalize latest payment approval and finance/executive handoff smoke summaries into a stable backend artifact.
- Add `verify.delivery.payment_approval.chain_summary` Make target.
- Teach delivery readiness scoreboard refresh to surface `Payment approval chain smoke` from `artifacts/backend/payment_request_approval_chain_summary.json`.
- Mark the payment approval chain scoreboard integration item done in the action evidence iteration plan and update the payment module known limit.

## Validation
- `make verify.portal.payment_request_approval_all_smoke.container DB_NAME=sc_demo`
- `make verify.delivery.payment_approval.chain_summary`
- `python3 -m py_compile scripts/verify/payment_request_approval_chain_summary.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `python3 scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`

## Notes
- Initial payment smoke attempt hit local container artifact write permissions on `artifacts/codex`; after making that directory container-writable, both payment smoke scripts passed.
- `payment_request_approval_field_consumer_audit` still reports deprecated refs in non-strict mode; the existing Make target treats this as a warning unless `PAYMENT_APPROVAL_FIELD_AUDIT_STRICT=1` is set.
- Latest PR head is `cc2a4d400`; scoreboard points to evidence commit `f1eb896b4`, and the final delta after that evidence point is limited to the scoreboard refresh.