### PR TITLE
Add project task action evidence smoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3972,6 +3972,11 @@ verify.product.delivery.action_closure.smoke: guard.prod.forbid
 verify.delivery.payment_approval.chain_summary: guard.prod.forbid
 	@python3 scripts/verify/payment_request_approval_chain_summary.py
 
+.PHONY: verify.delivery.project_task.action_smoke
+verify.delivery.project_task.action_smoke: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_PM_LOGIN=$(or $(ROLE_PM_LOGIN),demo_role_pm) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/project_task_action_seed.py
+	@python3 scripts/verify/project_task_action_smoke.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/addons/smart_construction_core/models/core/project_core.py
+++ b/addons/smart_construction_core/models/core/project_core.py
@@ -653,6 +653,19 @@ class ProjectProject(models.Model):
         tracking=True,
         help='驱动项目级联动控制：暂停/关闭禁止新增进度、成本等业务数据；结算中限制部分操作。'
     )
+    sc_execution_state = fields.Selection(
+        [
+            ("ready", "执行就绪"),
+            ("in_progress", "执行中"),
+            ("blocked", "执行阻塞"),
+            ("done", "执行完成"),
+        ],
+        string="执行推进状态",
+        default="ready",
+        tracking=True,
+        index=True,
+        help="项目执行场景的轻量状态机字段，由 project.execution.advance 统一推进。",
+    )
     sc_draft_autosaved_at = fields.Datetime(
         '草稿自动保存时间',
         readonly=True,

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -19,9 +19,10 @@ green. The next iteration should not reopen release blockers unless a live gate 
 ## P0: Script-Bound Action Evidence
 
 1. Project execution task action smoke
+   - Status: done
    - Scope: `projects.dashboard`, `projects.execution`
    - Target: PM role can open task list/board, advance one safe task action, and refresh the scene without losing contract shape.
-   - Evidence target: new or extended make target under `verify.delivery.journey.*`
+   - Evidence target: `make verify.delivery.project_task.action_smoke`, `artifacts/backend/project_task_action_smoke.json`, and the scoreboard row `Project task action smoke`.
 
 2. Payment approval chain scoreboard integration
    - Status: done

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T07:51:52Z
-- branch: `topic/delivery-action-evidence`
-- commit_ref: `f1eb896b4`
+- generated_at_utc: 2026-06-30T08:09:20Z
+- branch: `topic/project-task-action-evidence`
+- commit_ref: `07eb6f3ed`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -28,12 +28,13 @@
 | Product delivery action closure smoke | PASS | `artifacts/backend/product_delivery_action_closure_report.json` |
 | Product delivery module capability smoke | PASS | `artifacts/backend/product_delivery_module9_smoke_report.json` |
 | Payment approval chain smoke | PASS | `artifacts/backend/payment_request_approval_chain_summary.json` |
+| Project task action smoke | PASS | `artifacts/backend/project_task_action_smoke.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
 |---|---|---|---|---|---|
 | 项目立项与台账 | `projects.intake`, `projects.list`, `projects.ledger` | PM, 采购经理 | 项目类型、组织字典、用户 | Covered by strict scene gate (`PASS`) | 需补旅程级 trace 固化 |
-| 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Covered by strict scene gate (`PASS`) | 需补任务动作 system-bound 脚本 |
+| 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Strict scene gate (`PASS`), project task action smoke (`PASS`) | 任务动作推进已脚本化；后续补旅程级 trace 趋势 |
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Covered by strict scene gate (`PASS`) | 需补采购/材料/租赁动作回放证据 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Covered by strict scene gate (`PASS`) | 需补质量安全闭环动作证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -20,6 +20,7 @@ CONTRACT_CLOSURE_MAINLINE_SUMMARY_PATH = ROOT / "artifacts" / "backend" / "backe
 ACTION_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_action_closure_report.json"
 MODULE9_SMOKE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_module9_smoke_report.json"
 PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_request_approval_chain_summary.json"
+PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -416,6 +417,11 @@ def main() -> int:
     payment_approval_ok = bool(payment_approval_payload.get("ok")) if payment_approval_present else False
     payment_approval_label = _bool_status_label(payment_approval_ok) if payment_approval_present else "UNKNOWN"
 
+    project_task_payload = _load_json(PROJECT_TASK_ACTION_REPORT_PATH)
+    project_task_present = bool(project_task_payload)
+    project_task_ok = bool(project_task_payload.get("ok")) if project_task_present else False
+    project_task_label = _bool_status_label(project_task_ok) if project_task_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -451,6 +457,12 @@ def main() -> int:
         "Payment approval chain smoke",
         payment_approval_label,
         str(PAYMENT_APPROVAL_CHAIN_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Project task action smoke",
+        project_task_label,
+        str(PROJECT_TASK_ACTION_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/project_task_action_seed.py
+++ b/scripts/verify/project_task_action_seed.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from odoo import fields
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_seed.json"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _set_if_field(model, vals: dict, field_name: str, value) -> None:
+    if field_name in getattr(model, "_fields", {}):
+        vals[field_name] = value
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+login = os.getenv("ROLE_PM_LOGIN", "demo_role_pm")
+User = env["res.users"].sudo()  # noqa: F821
+pm_user = User.search([("login", "=", login)], limit=1)
+if not pm_user:
+    payload = {"generated_at_utc": _utc_now(), "ok": False, "error": f"missing PM user login={login}"}
+    _write_report(payload)
+    raise SystemExit(1)
+
+Project = env["project.project"].sudo()  # noqa: F821
+Task = env["project.task"].sudo()  # noqa: F821
+stamp = fields.Datetime.now().strftime("%Y%m%d%H%M%S")
+
+project_vals = {
+    "name": f"Delivery Action Smoke {stamp}",
+    "manager_id": pm_user.id,
+    "user_id": pm_user.id,
+    "company_id": env.company.id,  # noqa: F821
+    "operation_strategy": "direct",
+    "funding_enabled": True,
+}
+_set_if_field(Project, project_vals, "date_start", fields.Date.today())
+_set_if_field(Project, project_vals, "start_date", fields.Date.today())
+_set_if_field(Project, project_vals, "sc_demo_showcase", True)
+_set_if_field(Project, project_vals, "sc_demo_showcase_ready", True)
+_set_if_field(Project, project_vals, "sc_execution_state", "ready")
+if "user_ids" in getattr(Project, "_fields", {}):
+    project_vals["user_ids"] = [(4, pm_user.id)]
+
+project = Project.with_user(pm_user).create(project_vals)
+
+task_vals = {
+    "name": f"Delivery Action Smoke Task {stamp}",
+    "project_id": project.id,
+}
+if "user_ids" in getattr(Task, "_fields", {}):
+    task_vals["user_ids"] = [(4, pm_user.id)]
+if "user_id" in getattr(Task, "_fields", {}):
+    task_vals["user_id"] = pm_user.id
+if "sc_state" in getattr(Task, "_fields", {}):
+    task_vals["sc_state"] = "draft"
+
+task = Task.with_context(allow_transition=True).with_user(pm_user).create(task_vals)
+env.cr.commit()  # noqa: F821
+
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": True,
+    "login": login,
+    "project_id": int(project.id),
+    "task_id": int(task.id),
+    "project_name": project.display_name,
+    "task_name": task.display_name,
+}
+_write_report(payload)
+print(REPORT_PATH)
+print("[project_task_action_seed] PASS")

--- a/scripts/verify/project_task_action_smoke.py
+++ b/scripts/verify/project_task_action_smoke.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
+SEED_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_seed.json"
+
+BASE_URL = os.getenv("BASE_URL", "http://localhost:8070").rstrip("/")
+DB_NAME = os.getenv("DB_NAME") or os.getenv("DB") or "sc_demo"
+LOGIN = os.getenv("ROLE_PM_LOGIN", "demo_role_pm")
+PASSWORD = os.getenv("ROLE_PM_PASSWORD", "demo")
+REQUEST_RETRY_MAX = max(5, int(os.getenv("PROJECT_TASK_ACTION_SMOKE_REQUEST_RETRY_MAX", "30")))
+REQUEST_RETRY_SLEEP_SEC = max(1, int(os.getenv("PROJECT_TASK_ACTION_SMOKE_REQUEST_RETRY_SLEEP_SEC", "2")))
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _request_intent(intent: str, params: dict, *, token: str | None = None, anonymous: bool = False) -> dict:
+    payload = json.dumps({"intent": intent, "params": params}).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+        headers["X-Odoo-DB"] = DB_NAME
+    if anonymous:
+        headers["X-Anonymous-Intent"] = "1"
+    req = urllib.request.Request(f"{BASE_URL}/api/v1/intent", data=payload, headers=headers, method="POST")
+    body = None
+    last_err = None
+    for _ in range(REQUEST_RETRY_MAX):
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                body = resp.read().decode("utf-8")
+            last_err = None
+            break
+        except urllib.error.HTTPError as exc:
+            raw = exc.read().decode("utf-8", errors="replace")
+            if exc.code in (502, 503, 504):
+                last_err = exc
+                time.sleep(REQUEST_RETRY_SLEEP_SEC)
+                continue
+            try:
+                parsed = json.loads(raw or "{}")
+                if isinstance(parsed, dict):
+                    return parsed
+            except Exception:
+                pass
+            return {"ok": False, "error": {"code": f"HTTP_{exc.code}", "message": raw[:300]}}
+        except urllib.error.URLError as exc:
+            last_err = exc
+            time.sleep(REQUEST_RETRY_SLEEP_SEC)
+    if body is None:
+        return {"ok": False, "error": {"code": "REQUEST_FAILED", "message": str(last_err or "")}}
+    try:
+        parsed = json.loads(body or "{}")
+    except Exception as exc:
+        return {"ok": False, "error": {"code": "INVALID_JSON", "message": str(exc)}}
+    return parsed if isinstance(parsed, dict) else {"ok": False, "error": {"code": "INVALID_RESPONSE"}}
+
+
+def _reason(resp: dict) -> str:
+    if bool(resp.get("ok")):
+        data = resp.get("data") if isinstance(resp.get("data"), dict) else {}
+        return str(data.get("reason_code") or "OK")
+    error = resp.get("error") if isinstance(resp.get("error"), dict) else {}
+    return str(error.get("reason_code") or error.get("code") or "")
+
+
+def _records(resp: dict) -> list[dict]:
+    data = resp.get("data") if isinstance(resp.get("data"), dict) else {}
+    rows = data.get("records") if isinstance(data.get("records"), list) else []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _as_id(value) -> int:
+    if isinstance(value, (list, tuple)) and value:
+        value = value[0]
+    if isinstance(value, dict):
+        value = value.get("id")
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _login() -> str:
+    resp = _request_intent("login", {"db": DB_NAME, "login": LOGIN, "password": PASSWORD}, anonymous=True)
+    if not resp.get("ok"):
+        raise AssertionError(f"login failed: {resp.get('error')}")
+    token = str(((resp.get("data") or {}).get("token") or "")).strip()
+    if not token:
+        raise AssertionError("login token missing")
+    return token
+
+
+def _list_projects(token: str) -> list[dict]:
+    resp = _request_intent(
+        "api.data",
+        {
+            "op": "list",
+            "model": "project.project",
+            "fields": ["id", "name", "write_date"],
+            "limit": 20,
+            "order": "write_date desc,id desc",
+        },
+        token=token,
+    )
+    if not resp.get("ok"):
+        raise AssertionError(f"project list failed: {resp.get('error')}")
+    return _records(resp)
+
+
+def _create_task(token: str, project_id: int) -> tuple[int, dict]:
+    resp = _request_intent(
+        "api.data",
+        {
+            "op": "create",
+            "model": "project.task",
+            "vals": {
+                "name": f"Delivery action smoke {_utc_now()}",
+                "project_id": int(project_id),
+            },
+            "current_project_id": int(project_id),
+            "context": {"current_project_id": int(project_id), "default_project_id": int(project_id)},
+        },
+        token=token,
+    )
+    data = resp.get("data") if isinstance(resp.get("data"), dict) else {}
+    return _as_id(data.get("id") or data.get("record_id") or data.get("res_id")), resp
+
+
+def _pick_existing_task(token: str, project_id: int) -> tuple[int, dict]:
+    resp = _request_intent(
+        "api.data",
+        {
+            "op": "list",
+            "model": "project.task",
+            "fields": ["id", "name", "project_id", "sc_state"],
+            "domain": [["project_id", "=", int(project_id)]],
+            "limit": 10,
+            "order": "write_date desc,id desc",
+            "current_project_id": int(project_id),
+        },
+        token=token,
+    )
+    rows = _records(resp) if resp.get("ok") else []
+    return (_as_id(rows[0].get("id")) if rows else 0), resp
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _load_seed() -> dict:
+    if not SEED_REPORT_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(SEED_REPORT_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main() -> int:
+    steps: list[dict] = []
+    token = _login()
+    steps.append({"step": "login.pm", "ok": True})
+
+    seed = _load_seed()
+    seed_ok = bool(seed.get("ok")) and _as_id(seed.get("project_id")) > 0 and _as_id(seed.get("task_id")) > 0
+    task_auto_created = False
+    if seed_ok:
+        project_id = _as_id(seed.get("project_id"))
+        task_id = _as_id(seed.get("task_id"))
+        steps.append({"step": "load_seed", "ok": True, "project_id": project_id, "task_id": task_id})
+    else:
+        projects = _list_projects(token)
+        if not projects:
+            raise AssertionError("no project.project rows visible to PM role")
+        project_id = _as_id(projects[0].get("id"))
+        steps.append({"step": "select_project", "ok": project_id > 0, "project_id": project_id})
+
+        task_id, create_resp = _create_task(token, project_id)
+        task_auto_created = task_id > 0 and bool(create_resp.get("ok"))
+        steps.append(
+            {
+                "step": "api.data.create.project.task",
+                "ok": task_auto_created,
+                "reason_code": _reason(create_resp),
+                "task_id": task_id,
+            }
+        )
+    if task_id <= 0:
+        task_id, task_list_resp = _pick_existing_task(token, project_id)
+        steps.append(
+            {
+                "step": "api.data.list.project.task",
+                "ok": task_id > 0,
+                "reason_code": _reason(task_list_resp),
+                "task_id": task_id,
+            }
+        )
+    if task_id <= 0:
+        raise AssertionError("no project.task available for project execution smoke")
+
+    enter_resp = _request_intent(
+        "project.execution.enter",
+        {"project_id": project_id, "current_project_id": project_id},
+        token=token,
+    )
+    steps.append({"step": "project.execution.enter", "ok": bool(enter_resp.get("ok")), "reason_code": _reason(enter_resp)})
+    if not enter_resp.get("ok"):
+        raise AssertionError(f"project.execution.enter failed: {enter_resp.get('error')}")
+
+    block_results = {}
+    for block_key in ("execution_tasks", "next_actions"):
+        block_resp = _request_intent(
+            "project.execution.block.fetch",
+            {"project_id": project_id, "current_project_id": project_id, "block_key": block_key},
+            token=token,
+        )
+        data = block_resp.get("data") if isinstance(block_resp.get("data"), dict) else {}
+        block_results[block_key] = {
+            "ok": bool(block_resp.get("ok")),
+            "reason_code": _reason(block_resp),
+            "state": str(data.get("state") or ""),
+            "block_type": str(data.get("block_type") or ""),
+            "summary": data.get("data", {}).get("summary") if isinstance(data.get("data"), dict) else {},
+        }
+        steps.append({"step": f"project.execution.block.fetch.{block_key}", **block_results[block_key]})
+        if not block_resp.get("ok"):
+            raise AssertionError(f"project.execution.block.fetch[{block_key}] failed: {block_resp.get('error')}")
+
+    advance_resp = _request_intent(
+        "project.execution.advance",
+        {
+            "project_id": project_id,
+            "current_project_id": project_id,
+            "task_id": task_id,
+            "request_id": f"project_task_action_smoke_{project_id}_{task_id}_{int(time.time())}",
+        },
+        token=token,
+    )
+    advance_data = advance_resp.get("data") if isinstance(advance_resp.get("data"), dict) else {}
+    advance_ok = bool(advance_resp.get("ok")) and str(advance_data.get("result") or "") == "success"
+    steps.append(
+        {
+            "step": "project.execution.advance",
+            "ok": advance_ok,
+            "reason_code": _reason(advance_resp),
+            "result": str(advance_data.get("result") or ""),
+            "from_state": str(advance_data.get("from_state") or ""),
+            "to_state": str(advance_data.get("to_state") or ""),
+        }
+    )
+
+    refresh_resp = _request_intent(
+        "project.execution.block.fetch",
+        {"project_id": project_id, "current_project_id": project_id, "block_key": "execution_tasks"},
+        token=token,
+    )
+    steps.append(
+        {
+            "step": "project.execution.block.fetch.execution_tasks.after_advance",
+            "ok": bool(refresh_resp.get("ok")),
+            "reason_code": _reason(refresh_resp),
+        }
+    )
+
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": advance_ok and bool(refresh_resp.get("ok")),
+        "db": DB_NAME,
+        "base_url": BASE_URL,
+        "login": LOGIN,
+        "project_id": project_id,
+        "task_id": task_id,
+        "task_auto_created": task_auto_created,
+        "blocks": block_results,
+        "steps": steps,
+    }
+    _write_report(payload)
+    print(REPORT_PATH)
+    if not payload["ok"]:
+        print("[project_task_action_smoke] FAIL")
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 2
+    print("[project_task_action_smoke] PASS")
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except Exception as exc:
+        payload = {"generated_at_utc": _utc_now(), "ok": False, "error": str(exc)}
+        _write_report(payload)
+        print(REPORT_PATH)
+        print(f"[project_task_action_smoke] FAIL: {exc}")
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add `project.project.sc_execution_state` so `project.execution.advance` can persist the project execution state
- add a seeded PM-role project task action smoke and Make target `verify.delivery.project_task.action_smoke`
- publish `Project task action smoke` into the delivery readiness scoreboard and close the P0 iteration item

## Validation
- `python3 -m py_compile scripts/verify/project_task_action_smoke.py scripts/verify/project_task_action_seed.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make mod.upgrade CODEX_NEED_UPGRADE=1 MODULE=smart_construction_core DB_NAME=sc_demo`
- `make verify.delivery.project_task.action_smoke DB_NAME=sc_demo`
- `python3 scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`