### PR TITLE
Add executive readonly delivery evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3982,6 +3982,11 @@ verify.delivery.material.action_replay: guard.prod.forbid check-compose-project 
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_MATERIAL_LOGIN=$(or $(ROLE_MATERIAL_LOGIN),demo_business_full) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/material_action_replay_seed.py
 	@ROLE_MATERIAL_LOGIN=$(or $(ROLE_MATERIAL_LOGIN),demo_business_full) python3 scripts/verify/material_action_replay_smoke.py
 
+.PHONY: verify.delivery.executive.readonly
+verify.delivery.executive.readonly: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_EXECUTIVE_READONLY_LOGIN=$(or $(ROLE_EXECUTIVE_READONLY_LOGIN),executive_readonly_smoke) ROLE_EXECUTIVE_READONLY_PASSWORD=$(or $(ROLE_EXECUTIVE_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/executive_readonly_seed.py
+	@ROLE_EXECUTIVE_READONLY_LOGIN=$(or $(ROLE_EXECUTIVE_READONLY_LOGIN),executive_readonly_smoke) ROLE_EXECUTIVE_READONLY_PASSWORD=$(or $(ROLE_EXECUTIVE_READONLY_PASSWORD),demo) python3 scripts/verify/executive_readonly_smoke.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -40,9 +40,10 @@ green. The next iteration should not reopen release blockers unless a live gate 
 ## P1: Read-Only and Ledger Evidence
 
 1. Executive read-only acceptance
-   - Scope: `portal.dashboard`, `finance.operating_metrics`
-   - Target: executive role can read KPI surfaces and cannot trigger write-oriented actions.
-   - Evidence target: read-only browser or API acceptance report.
+   - Status: done
+   - Scope: `portal.dashboard`, `finance.operating_metrics`, `portal.capability_matrix`; `projects.dashboard_showcase` is recorded when the demo action is installed.
+   - Target: executive role can see the read-only journey scenes, read operating metrics, and cannot create/write operating metric records.
+   - Evidence target: `make verify.delivery.executive.readonly`, `artifacts/backend/executive_readonly_smoke.json`, and the scoreboard row `Executive readonly smoke`.
 
 2. Treasury/settlement ledger snapshot
    - Scope: `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders`

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:18:07Z
-- branch: `topic/material-action-replay-evidence`
-- commit_ref: `16a8a5b37`
+- generated_at_utc: 2026-06-30T08:29:12Z
+- branch: `topic/executive-readonly-evidence`
+- commit_ref: `576e4d567`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -30,6 +30,7 @@
 | Payment approval chain smoke | PASS | `artifacts/backend/payment_request_approval_chain_summary.json` |
 | Project task action smoke | PASS | `artifacts/backend/project_task_action_smoke.json` |
 | Material action replay smoke | PASS | `artifacts/backend/material_action_replay_smoke.json` |
+| Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
@@ -41,7 +42,7 @@
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Covered by strict scene gate (`PASS`) | 需补台账对账快照证据 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Covered by strict scene gate (`PASS`) | 需补搜索/分页动作证据 |
-| 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Covered by strict scene gate (`PASS`) | 需补只读角色验收脚本 |
+| 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Strict scene gate (`PASS`), executive readonly smoke (`PASS`) | 只读验收已脚本化；后续补长周期趋势证据 |
 | 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Covered by strict scene gate (`PASS`) | 需补审计导出证据链 |
 | 主数据与工作台 | `data.dictionary`, `default` | 全角色 | 用户角色、字典主数据 | Covered by strict scene gate (`PASS`) | `default` 场景需持续监控占位语义 |
 

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -22,6 +22,7 @@ MODULE9_SMOKE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_m
 PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_request_approval_chain_summary.json"
 PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
 MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_action_replay_smoke.json"
+EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -428,6 +429,11 @@ def main() -> int:
     material_replay_ok = bool(material_replay_payload.get("ok")) if material_replay_present else False
     material_replay_label = _bool_status_label(material_replay_ok) if material_replay_present else "UNKNOWN"
 
+    executive_readonly_payload = _load_json(EXECUTIVE_READONLY_REPORT_PATH)
+    executive_readonly_present = bool(executive_readonly_payload)
+    executive_readonly_ok = bool(executive_readonly_payload.get("ok")) if executive_readonly_present else False
+    executive_readonly_label = _bool_status_label(executive_readonly_ok) if executive_readonly_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -475,6 +481,12 @@ def main() -> int:
         "Material action replay smoke",
         material_replay_label,
         str(MATERIAL_ACTION_REPLAY_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Executive readonly smoke",
+        executive_readonly_label,
+        str(EXECUTIVE_READONLY_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/executive_readonly_seed.py
+++ b/scripts/verify/executive_readonly_seed.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_seed.json"
+
+LOGIN = os.getenv("ROLE_EXECUTIVE_READONLY_LOGIN") or "executive_readonly_smoke"
+PASSWORD = os.getenv("ROLE_EXECUTIVE_READONLY_PASSWORD") or "demo"
+
+GROUP_XMLIDS = [
+    "base.group_user",
+    "smart_construction_core.group_sc_internal_user",
+    "smart_construction_core.group_sc_cap_project_read",
+    "smart_construction_core.group_sc_cap_finance_read",
+    "smart_construction_core.group_sc_cap_material_read",
+    "smart_construction_core.group_sc_cap_cost_read",
+    "smart_construction_core.group_sc_cap_data_read",
+    "smart_construction_core.group_sc_role_executive",
+    "smart_construction_custom.group_sc_role_executive",
+]
+
+ACTION_XMLIDS = {
+    "finance.operating_metrics": "smart_construction_core.action_sc_operating_metrics_project",
+    "projects.dashboard_showcase": "smart_construction_demo.action_project_dashboard_showcase",
+}
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _ref(xmlid: str):
+    return env.ref(xmlid, raise_if_not_found=False)  # noqa: F821
+
+
+def _group_ids() -> tuple[list[int], list[str]]:
+    ids: list[int] = []
+    missing: list[str] = []
+    for xmlid in GROUP_XMLIDS:
+        rec = _ref(xmlid)
+        if rec:
+            ids.append(int(rec.id))
+        else:
+            missing.append(xmlid)
+    return ids, missing
+
+
+def _action_row(scene_key: str, xmlid: str) -> dict:
+    rec = _ref(xmlid)
+    return {
+        "scene_key": scene_key,
+        "action_xmlid": xmlid,
+        "action_id": int(rec.id) if rec else 0,
+        "model": str(getattr(rec, "res_model", "") or "") if rec else "",
+        "available": bool(rec),
+    }
+
+
+def _operating_metrics_count() -> int:
+    try:
+        return int(env["sc.operating.metrics.project"].sudo().search_count([]))  # noqa: F821
+    except Exception:
+        return 0
+
+
+group_ids, missing_groups = _group_ids()
+if missing_groups:
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": False,
+        "login": LOGIN,
+        "missing_groups": missing_groups,
+    }
+    _write_report(payload)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)
+
+User = env["res.users"].sudo()  # noqa: F821
+Partner = env["res.partner"].sudo()  # noqa: F821
+user = User.search([("login", "=", LOGIN)], limit=1)
+partner = False
+if user:
+    partner = user.partner_id
+else:
+    partner = Partner.search([("name", "=", "Executive Readonly Smoke")], limit=1)
+    if not partner:
+        partner = Partner.create({"name": "Executive Readonly Smoke"})
+    user = User.create(
+        {
+            "name": "Executive Readonly Smoke",
+            "login": LOGIN,
+            "password": PASSWORD,
+            "partner_id": partner.id,
+            "company_id": env.company.id,  # noqa: F821
+            "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+            "groups_id": [(6, 0, group_ids)],
+        }
+    )
+
+user.write(
+    {
+        "name": "Executive Readonly Smoke",
+        "password": PASSWORD,
+        "active": True,
+        "company_id": env.company.id,  # noqa: F821
+        "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+        "groups_id": [(6, 0, group_ids)],
+    }
+)
+
+actions = [_action_row(scene_key, xmlid) for scene_key, xmlid in ACTION_XMLIDS.items()]
+finance_action = next((row for row in actions if row["scene_key"] == "finance.operating_metrics"), {})
+errors: list[str] = []
+if int(finance_action.get("action_id") or 0) <= 0:
+    errors.append("finance_operating_metrics_action_missing")
+if str(finance_action.get("model") or "") != "sc.operating.metrics.project":
+    errors.append(f"finance_operating_metrics_model_mismatch:{finance_action.get('model')}")
+if _operating_metrics_count() <= 0:
+    errors.append("operating_metrics_empty")
+
+env.cr.commit()  # noqa: F821
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": not errors,
+    "login": LOGIN,
+    "user_id": int(user.id),
+    "group_xmlids": GROUP_XMLIDS,
+    "group_ids": group_ids,
+    "actions": actions,
+    "operating_metrics_count": _operating_metrics_count(),
+    "errors": errors,
+}
+_write_report(payload)
+print(REPORT_PATH)
+print("[executive_readonly_seed] PASS" if payload["ok"] else "[executive_readonly_seed] FAIL")
+if errors:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)

--- a/scripts/verify/executive_readonly_smoke.py
+++ b/scripts/verify/executive_readonly_smoke.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from python_http_smoke_utils import get_base_url, http_post_json
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
+SEED_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_seed.json"
+
+DB_NAME = os.getenv("DB_NAME") or os.getenv("E2E_DB") or "sc_demo"
+LOGIN = os.getenv("ROLE_EXECUTIVE_READONLY_LOGIN") or "executive_readonly_smoke"
+PASSWORD = os.getenv("ROLE_EXECUTIVE_READONLY_PASSWORD") or os.getenv("E2E_PASSWORD") or "demo"
+
+EXECUTIVE_SCENES = [
+    "portal.dashboard",
+    "finance.operating_metrics",
+    "portal.capability_matrix",
+]
+OPTIONAL_EXECUTIVE_SCENES = [
+    "projects.dashboard_showcase",
+]
+FINANCE_MODEL = "sc.operating.metrics.project"
+READ_FIELDS = [
+    "id",
+    "display_name",
+    "project_id",
+    "receipt_amount",
+    "settlement_amount_total",
+    "net_cash_amount",
+]
+WRITE_DENIAL_MARKER = "executive-readonly-smoke-denied"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _intent_url() -> str:
+    return f"{get_base_url().rstrip('/')}/api/v1/intent?db={DB_NAME}"
+
+
+def _headers(token: str | None = None, *, anonymous: bool = False) -> dict[str, str]:
+    headers = {"X-Odoo-DB": DB_NAME}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if anonymous:
+        headers["X-Anonymous-Intent"] = "1"
+    return headers
+
+
+def _intent(intent: str, params: dict | None = None, token: str | None = None, *, anonymous: bool = False) -> tuple[int, dict]:
+    status, payload = http_post_json(
+        _intent_url(),
+        {"intent": intent, "params": params or {}},
+        headers=_headers(token, anonymous=anonymous),
+    )
+    return status, payload if isinstance(payload, dict) else {}
+
+
+def _login() -> str:
+    status, payload = _intent(
+        "login",
+        {"db": DB_NAME, "login": LOGIN, "password": PASSWORD},
+        anonymous=True,
+    )
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    token = str(data.get("token") or "").strip()
+    if status >= 400 or payload.get("ok") is not True or not token:
+        raise AssertionError(f"login failed status={status} error={payload.get('error')}")
+    return token
+
+
+def _load_seed() -> dict:
+    if not SEED_REPORT_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(SEED_REPORT_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _seed_action_id(seed: dict, scene_key: str) -> int:
+    rows = seed.get("actions") if isinstance(seed.get("actions"), list) else []
+    for row in rows:
+        if isinstance(row, dict) and row.get("scene_key") == scene_key:
+            try:
+                return int(row.get("action_id") or 0)
+            except Exception:
+                return 0
+    return 0
+
+
+def _records(payload: dict) -> list[dict]:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    rows = data.get("records") if isinstance(data.get("records"), list) else []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _contract_model(payload: dict) -> str:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    action = data.get("action") if isinstance(data.get("action"), dict) else {}
+    entry = data.get("entry") if isinstance(data.get("entry"), dict) else {}
+    return str(action.get("res_model") or entry.get("model") or data.get("model") or "").strip()
+
+
+def _walk(value: Any):
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _scene_values(payload: dict) -> set[str]:
+    values: set[str] = set()
+    scene_keys = {"scene_key", "sceneKey", "scene", "code", "key"}
+    for item in _walk(payload):
+        if isinstance(item, dict):
+            for key, value in item.items():
+                if key in scene_keys and isinstance(value, str) and "." in value:
+                    values.add(value.strip())
+    return values
+
+
+def _assert_denied(status: int, payload: dict) -> tuple[bool, str]:
+    if status >= 400:
+        return True, f"http_{status}"
+    if payload.get("ok") is not True:
+        error = payload.get("error")
+        if isinstance(error, dict):
+            return True, str(error.get("code") or error.get("message") or "intent_denied")
+        return True, str(error or "intent_denied")
+    return False, "unexpected_success"
+
+
+def _startup_scene_check(token: str, seed: dict) -> dict:
+    status, payload = _intent("system.init", {"scene_key": "portal.dashboard", "with_preload": False}, token)
+    scenes = _scene_values(payload)
+    missing = [scene for scene in EXECUTIVE_SCENES if scene not in scenes]
+    optional_available = [scene for scene in OPTIONAL_EXECUTIVE_SCENES if _seed_action_id(seed, scene) > 0]
+    optional_unavailable = [scene for scene in OPTIONAL_EXECUTIVE_SCENES if _seed_action_id(seed, scene) <= 0]
+    optional_missing = [scene for scene in optional_available if scene not in scenes]
+    ok = status < 400 and payload.get("ok") is True and not missing
+    return {
+        "step": "system.init.executive_scenes",
+        "ok": ok,
+        "status": status,
+        "required_scenes": EXECUTIVE_SCENES,
+        "optional_scenes": OPTIONAL_EXECUTIVE_SCENES,
+        "found_scenes": sorted(scene for scene in scenes if scene in set(EXECUTIVE_SCENES)),
+        "optional_found_scenes": sorted(scene for scene in scenes if scene in set(OPTIONAL_EXECUTIVE_SCENES)),
+        "missing_scenes": missing,
+        "optional_missing_scenes": optional_missing,
+        "optional_unavailable_scenes": optional_unavailable,
+    }
+
+
+def _finance_readonly_check(token: str, action_id: int) -> dict:
+    steps: list[dict] = []
+    errors: list[str] = []
+    if action_id <= 0:
+        return {"step": "finance.operating_metrics.readonly", "ok": False, "errors": ["action_id_missing"], "steps": steps}
+
+    status, contract_payload = _intent(
+        "ui.contract",
+        {
+            "op": "action_open",
+            "action_id": action_id,
+            "source_mode": "backend_internal",
+            "contract_surface": "native",
+            "scene_key": "finance.operating_metrics",
+        },
+        token,
+    )
+    contract_ok = status < 400 and contract_payload.get("ok") is True
+    model = _contract_model(contract_payload)
+    steps.append({"step": "ui.contract.action_open", "ok": contract_ok, "status": status, "model": model})
+    if not contract_ok:
+        errors.append("action_contract_failed")
+    if model and model != FINANCE_MODEL:
+        errors.append(f"action_model_mismatch:{model}")
+
+    status, list_payload = _intent(
+        "api.data",
+        {
+            "op": "list",
+            "model": FINANCE_MODEL,
+            "fields": READ_FIELDS,
+            "domain": [],
+            "limit": 5,
+            "order": "id desc",
+        },
+        token,
+    )
+    rows = _records(list_payload)
+    record_id = int(rows[0].get("id") or 0) if rows else 0
+    steps.append({"step": "api.data.list", "ok": status < 400 and list_payload.get("ok") is True and record_id > 0, "status": status, "record_id": record_id, "count": len(rows)})
+    if record_id <= 0:
+        errors.append("operating_metrics_list_empty")
+
+    if record_id > 0:
+        status, read_payload = _intent(
+            "api.data",
+            {"op": "read", "model": FINANCE_MODEL, "ids": [record_id], "fields": READ_FIELDS},
+            token,
+        )
+        read_rows = _records(read_payload)
+        steps.append({"step": "api.data.read", "ok": status < 400 and read_payload.get("ok") is True and bool(read_rows), "status": status, "record_id": record_id})
+        if not read_rows:
+            errors.append("operating_metrics_read_failed")
+
+        status, write_payload = _intent(
+            "api.data",
+            {"op": "write", "model": FINANCE_MODEL, "ids": [record_id], "vals": {"display_name": WRITE_DENIAL_MARKER}},
+            token,
+        )
+        denied, reason = _assert_denied(status, write_payload)
+        steps.append({"step": "api.data.write_denied", "ok": denied, "status": status, "reason": reason, "record_id": record_id})
+        if not denied:
+            errors.append("write_unexpectedly_allowed")
+
+    status, create_payload = _intent(
+        "api.data",
+        {"op": "create", "model": FINANCE_MODEL, "vals": {"display_name": WRITE_DENIAL_MARKER}},
+        token,
+    )
+    denied, reason = _assert_denied(status, create_payload)
+    steps.append({"step": "api.data.create_denied", "ok": denied, "status": status, "reason": reason})
+    if not denied:
+        errors.append("create_unexpectedly_allowed")
+
+    return {
+        "step": "finance.operating_metrics.readonly",
+        "ok": not errors,
+        "model": FINANCE_MODEL,
+        "record_id": record_id,
+        "steps": steps,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    token = _login()
+    seed = _load_seed()
+    checks = [
+        _startup_scene_check(token, seed),
+        _finance_readonly_check(token, _seed_action_id(seed, "finance.operating_metrics")),
+    ]
+    failures = [row for row in checks if not row.get("ok")]
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": not failures,
+        "db": DB_NAME,
+        "base_url": get_base_url().rstrip("/"),
+        "login": LOGIN,
+        "seed_present": bool(seed),
+        "seed_ok": bool(seed.get("ok")) if seed else False,
+        "summary": {
+            "check_count": len(checks),
+            "pass_count": len(checks) - len(failures),
+            "failed_count": len(failures),
+        },
+        "checks": checks,
+    }
+    REPORT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(REPORT_JSON)
+    if failures:
+        print("[executive_readonly_smoke] FAIL")
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 2
+    print("[executive_readonly_smoke] PASS")
+    print(json.dumps(payload["summary"], ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add a repeatable executive read-only seed and smoke for delivery readiness.
- Create/repair a dedicated `executive_readonly_smoke` user with read-only executive groups.
- Verify executive startup scene visibility, operating metrics `ui.contract`/`api.data` read access, and create/write denial.
- Wire the smoke into the Makefile and delivery readiness scoreboard refresh.
- Mark the P1 executive read-only acceptance item done and refresh the scoreboard evidence row.

## Validation

- `python3 -m py_compile scripts/verify/executive_readonly_seed.py scripts/verify/executive_readonly_smoke.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.executive.readonly DB_NAME=sc_demo`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`