### PR TITLE
Add ledger snapshot delivery evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3987,6 +3987,11 @@ verify.delivery.executive.readonly: guard.prod.forbid check-compose-project chec
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_EXECUTIVE_READONLY_LOGIN=$(or $(ROLE_EXECUTIVE_READONLY_LOGIN),executive_readonly_smoke) ROLE_EXECUTIVE_READONLY_PASSWORD=$(or $(ROLE_EXECUTIVE_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/executive_readonly_seed.py
 	@ROLE_EXECUTIVE_READONLY_LOGIN=$(or $(ROLE_EXECUTIVE_READONLY_LOGIN),executive_readonly_smoke) ROLE_EXECUTIVE_READONLY_PASSWORD=$(or $(ROLE_EXECUTIVE_READONLY_PASSWORD),demo) python3 scripts/verify/executive_readonly_smoke.py
 
+.PHONY: verify.delivery.ledger.snapshot
+verify.delivery.ledger.snapshot: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/ledger_snapshot_seed.py
+	@ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) python3 scripts/verify/ledger_snapshot_smoke.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -46,9 +46,10 @@ green. The next iteration should not reopen release blockers unless a live gate 
    - Evidence target: `make verify.delivery.executive.readonly`, `artifacts/backend/executive_readonly_smoke.json`, and the scoreboard row `Executive readonly smoke`.
 
 2. Treasury/settlement ledger snapshot
+   - Status: done
    - Scope: `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders`
    - Target: ledger list/search/count snapshots are stable across refresh and company scope.
-   - Evidence target: ledger snapshot JSON with row counts and domain trace.
+   - Evidence target: `make verify.delivery.ledger.snapshot`, `artifacts/backend/ledger_snapshot_smoke.json`, and the scoreboard row `Ledger snapshot smoke`.
 
 3. Cost search and pagination smoke
    - Scope: `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare`

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:29:12Z
-- branch: `topic/executive-readonly-evidence`
-- commit_ref: `576e4d567`
+- generated_at_utc: 2026-06-30T08:37:03Z
+- branch: `topic/ledger-snapshot-evidence`
+- commit_ref: `55b4e4792`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -31,6 +31,7 @@
 | Project task action smoke | PASS | `artifacts/backend/project_task_action_smoke.json` |
 | Material action replay smoke | PASS | `artifacts/backend/material_action_replay_smoke.json` |
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
+| Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
@@ -40,7 +41,7 @@
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`) | 动作回放已脚本化；后续补跨单据状态推进证据 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Covered by strict scene gate (`PASS`) | 需补质量安全闭环动作证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
-| 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Covered by strict scene gate (`PASS`) | 需补台账对账快照证据 |
+| 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Covered by strict scene gate (`PASS`) | 需补搜索/分页动作证据 |
 | 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Strict scene gate (`PASS`), executive readonly smoke (`PASS`) | 只读验收已脚本化；后续补长周期趋势证据 |
 | 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Covered by strict scene gate (`PASS`) | 需补审计导出证据链 |

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -23,6 +23,7 @@ PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_r
 PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
 MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_action_replay_smoke.json"
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
+LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -434,6 +435,11 @@ def main() -> int:
     executive_readonly_ok = bool(executive_readonly_payload.get("ok")) if executive_readonly_present else False
     executive_readonly_label = _bool_status_label(executive_readonly_ok) if executive_readonly_present else "UNKNOWN"
 
+    ledger_snapshot_payload = _load_json(LEDGER_SNAPSHOT_REPORT_PATH)
+    ledger_snapshot_present = bool(ledger_snapshot_payload)
+    ledger_snapshot_ok = bool(ledger_snapshot_payload.get("ok")) if ledger_snapshot_present else False
+    ledger_snapshot_label = _bool_status_label(ledger_snapshot_ok) if ledger_snapshot_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -487,6 +493,12 @@ def main() -> int:
         "Executive readonly smoke",
         executive_readonly_label,
         str(EXECUTIVE_READONLY_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Ledger snapshot smoke",
+        ledger_snapshot_label,
+        str(LEDGER_SNAPSHOT_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/ledger_snapshot_seed.py
+++ b/scripts/verify/ledger_snapshot_seed.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_seed.json"
+
+LOGIN = os.getenv("ROLE_LEDGER_READONLY_LOGIN") or "ledger_readonly_smoke"
+PASSWORD = os.getenv("ROLE_LEDGER_READONLY_PASSWORD") or "demo"
+
+GROUP_XMLIDS = [
+    "base.group_user",
+    "smart_construction_core.group_sc_internal_user",
+    "smart_construction_core.group_sc_cap_finance_read",
+    "smart_construction_core.group_sc_cap_settlement_read",
+    "smart_construction_core.group_sc_cap_project_read",
+    "smart_construction_custom.group_sc_role_finance",
+]
+
+SCENES = [
+    (
+        "finance.payment_ledger",
+        "smart_construction_core.menu_payment_ledger",
+        "smart_construction_core.action_payment_ledger",
+        "payment.ledger",
+    ),
+    (
+        "finance.treasury_ledger",
+        "smart_construction_core.menu_sc_treasury_ledger",
+        "smart_construction_core.action_sc_treasury_ledger",
+        "sc.treasury.ledger",
+    ),
+    (
+        "finance.settlement_orders",
+        "smart_construction_core.menu_sc_settlement_order",
+        "smart_construction_core.action_sc_settlement_order",
+        "sc.settlement.order",
+    ),
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _ref(xmlid: str):
+    return env.ref(xmlid, raise_if_not_found=False)  # noqa: F821
+
+
+def _group_ids() -> tuple[list[int], list[str]]:
+    ids: list[int] = []
+    missing: list[str] = []
+    for xmlid in GROUP_XMLIDS:
+        rec = _ref(xmlid)
+        if rec:
+            ids.append(int(rec.id))
+        else:
+            missing.append(xmlid)
+    return ids, missing
+
+
+def _scene_row(scene_key: str, menu_xmlid: str, action_xmlid: str, model: str) -> dict:
+    menu = _ref(menu_xmlid)
+    action = _ref(action_xmlid)
+    count = 0
+    if model in env:  # noqa: F821
+        count = int(env[model].sudo().search_count([]))  # noqa: F821
+    return {
+        "scene_key": scene_key,
+        "menu_xmlid": menu_xmlid,
+        "menu_id": int(menu.id) if menu else 0,
+        "action_xmlid": action_xmlid,
+        "action_id": int(action.id) if action else 0,
+        "model": model,
+        "action_model": str(getattr(action, "res_model", "") or "") if action else "",
+        "row_count": count,
+        "ok": bool(menu) and bool(action) and str(getattr(action, "res_model", "") or "") == model and count > 0,
+    }
+
+
+group_ids, missing_groups = _group_ids()
+if missing_groups:
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": False,
+        "login": LOGIN,
+        "missing_groups": missing_groups,
+    }
+    _write_report(payload)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)
+
+User = env["res.users"].sudo()  # noqa: F821
+Partner = env["res.partner"].sudo()  # noqa: F821
+user = User.search([("login", "=", LOGIN)], limit=1)
+if not user:
+    partner = Partner.search([("name", "=", "Ledger Readonly Smoke")], limit=1)
+    if not partner:
+        partner = Partner.create({"name": "Ledger Readonly Smoke"})
+    user = User.create(
+        {
+            "name": "Ledger Readonly Smoke",
+            "login": LOGIN,
+            "password": PASSWORD,
+            "partner_id": partner.id,
+            "company_id": env.company.id,  # noqa: F821
+            "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+            "groups_id": [(6, 0, group_ids)],
+        }
+    )
+
+user.write(
+    {
+        "name": "Ledger Readonly Smoke",
+        "password": PASSWORD,
+        "active": True,
+        "company_id": env.company.id,  # noqa: F821
+        "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+        "groups_id": [(6, 0, group_ids)],
+    }
+)
+
+checks = [_scene_row(*spec) for spec in SCENES]
+errors = []
+for row in checks:
+    if not row["ok"]:
+        errors.append(
+            {
+                "scene_key": row["scene_key"],
+                "menu_id": row["menu_id"],
+                "action_id": row["action_id"],
+                "model": row["model"],
+                "action_model": row["action_model"],
+                "row_count": row["row_count"],
+            }
+        )
+
+env.cr.commit()  # noqa: F821
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": not errors,
+    "login": LOGIN,
+    "user_id": int(user.id),
+    "company_id": int(env.company.id),  # noqa: F821
+    "group_xmlids": GROUP_XMLIDS,
+    "group_ids": group_ids,
+    "checks": checks,
+    "errors": errors,
+}
+_write_report(payload)
+print(REPORT_PATH)
+print("[ledger_snapshot_seed] PASS" if payload["ok"] else "[ledger_snapshot_seed] FAIL")
+if errors:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)

--- a/scripts/verify/ledger_snapshot_smoke.py
+++ b/scripts/verify/ledger_snapshot_smoke.py
@@ -1,0 +1,353 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from python_http_smoke_utils import get_base_url, http_post_json
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
+SEED_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_seed.json"
+
+DB_NAME = os.getenv("DB_NAME") or os.getenv("E2E_DB") or "sc_demo"
+LOGIN = os.getenv("ROLE_LEDGER_READONLY_LOGIN") or "ledger_readonly_smoke"
+PASSWORD = os.getenv("ROLE_LEDGER_READONLY_PASSWORD") or os.getenv("E2E_PASSWORD") or "demo"
+
+SCENES = [
+    {
+        "scene_key": "finance.payment_ledger",
+        "model": "payment.ledger",
+        "fields": ["id", "display_name", "ref", "project_id", "partner_id", "amount", "write_date"],
+        "search_fields": ["ref"],
+    },
+    {
+        "scene_key": "finance.treasury_ledger",
+        "model": "sc.treasury.ledger",
+        "fields": ["id", "display_name", "name", "project_id", "partner_id", "amount", "state", "date", "write_date"],
+        "search_fields": ["name"],
+    },
+    {
+        "scene_key": "finance.settlement_orders",
+        "model": "sc.settlement.order",
+        "fields": ["id", "display_name", "name", "project_id", "partner_id", "amount_total", "settlement_amount", "state", "company_id", "write_date"],
+        "search_fields": ["name"],
+    },
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _intent_url() -> str:
+    return f"{get_base_url().rstrip('/')}/api/v1/intent?db={DB_NAME}"
+
+
+def _headers(token: str | None = None, *, anonymous: bool = False) -> dict[str, str]:
+    headers = {"X-Odoo-DB": DB_NAME}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if anonymous:
+        headers["X-Anonymous-Intent"] = "1"
+    return headers
+
+
+def _intent(intent: str, params: dict | None = None, token: str | None = None, *, anonymous: bool = False) -> tuple[int, dict]:
+    status, payload = http_post_json(
+        _intent_url(),
+        {"intent": intent, "params": params or {}},
+        headers=_headers(token, anonymous=anonymous),
+    )
+    return status, payload if isinstance(payload, dict) else {}
+
+
+def _login() -> tuple[str, int]:
+    status, payload = _intent(
+        "login",
+        {"db": DB_NAME, "login": LOGIN, "password": PASSWORD},
+        anonymous=True,
+    )
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    token = str(data.get("token") or "").strip()
+    user = data.get("user") if isinstance(data.get("user"), dict) else {}
+    try:
+        company_id = int(user.get("company_id") or 0)
+    except Exception:
+        company_id = 0
+    if status >= 400 or payload.get("ok") is not True or not token:
+        raise AssertionError(f"login failed status={status} error={payload.get('error')}")
+    return token, company_id
+
+
+def _load_seed() -> dict:
+    if not SEED_REPORT_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(SEED_REPORT_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _seed_rows(seed: dict) -> dict[str, dict]:
+    rows = seed.get("checks") if isinstance(seed.get("checks"), list) else []
+    return {str(row.get("scene_key") or ""): row for row in rows if isinstance(row, dict)}
+
+
+def _records(payload: dict) -> list[dict]:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    rows = data.get("records") if isinstance(data.get("records"), list) else []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _total(payload: dict) -> int:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    for key in ("total", "count"):
+        try:
+            return int(data.get(key) or 0)
+        except Exception:
+            pass
+    return 0
+
+
+def _count_params(spec: dict, *, context: dict | None = None) -> dict:
+    params = {
+        "op": "count",
+        "model": spec["model"],
+        "domain": [],
+    }
+    if context:
+        params["context"] = context
+    return params
+
+
+def _contract_model(payload: dict) -> str:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    action = data.get("action") if isinstance(data.get("action"), dict) else {}
+    entry = data.get("entry") if isinstance(data.get("entry"), dict) else {}
+    return str(action.get("res_model") or entry.get("model") or data.get("model") or "").strip()
+
+
+def _walk(value: Any):
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _scene_values(payload: dict) -> set[str]:
+    values: set[str] = set()
+    for item in _walk(payload):
+        if not isinstance(item, dict):
+            continue
+        for key in ("scene_key", "sceneKey", "scene", "code", "key"):
+            value = item.get(key)
+            if isinstance(value, str) and "." in value:
+                values.add(value.strip())
+    return values
+
+
+def _first_search_anchor(row: dict, search_fields: list[str]) -> tuple[str, str]:
+    for field in search_fields:
+        value = row.get(field)
+        if isinstance(value, str) and value.strip():
+            return field, value.strip()
+        if isinstance(value, list) and len(value) >= 2 and isinstance(value[1], str) and value[1].strip():
+            return field, value[1].strip()
+    return "", ""
+
+
+def _api_params(spec: dict, *, context: dict | None = None, search_term: str = "") -> dict:
+    params = {
+        "op": "list",
+        "model": spec["model"],
+        "fields": spec["fields"],
+        "domain": [],
+        "limit": 5,
+        "order": "id desc",
+    }
+    if context:
+        params["context"] = context
+    if search_term:
+        params["search_term"] = search_term
+    return params
+
+
+def _scene_startup_check(token: str) -> dict:
+    required = [spec["scene_key"] for spec in SCENES]
+    status, payload = _intent("system.init", {"scene_key": "finance.payment_ledger", "with_preload": False}, token)
+    scenes = _scene_values(payload)
+    missing = [scene for scene in required if scene not in scenes]
+    return {
+        "step": "system.init.ledger_scenes",
+        "ok": status < 400 and payload.get("ok") is True and not missing,
+        "status": status,
+        "required_scenes": required,
+        "found_scenes": sorted(scene for scene in scenes if scene in set(required)),
+        "missing_scenes": missing,
+    }
+
+
+def _ledger_scene_check(token: str, spec: dict, seed_row: dict, company_id: int) -> dict:
+    scene_key = spec["scene_key"]
+    model = spec["model"]
+    action_id = int(seed_row.get("action_id") or 0)
+    menu_id = int(seed_row.get("menu_id") or 0)
+    context = {"allowed_company_ids": [company_id], "company_id": company_id} if company_id > 0 else {}
+    steps: list[dict] = []
+    errors: list[str] = []
+
+    if action_id <= 0:
+        errors.append("action_id_missing")
+    if menu_id <= 0:
+        errors.append("menu_id_missing")
+
+    if action_id > 0:
+        status, contract_payload = _intent(
+            "ui.contract",
+            {
+                "op": "action_open",
+                "action_id": action_id,
+                "source_mode": "backend_internal",
+                "contract_surface": "native",
+                "scene_key": scene_key,
+            },
+            token,
+        )
+        contract_ok = status < 400 and contract_payload.get("ok") is True
+        contract_model = _contract_model(contract_payload)
+        steps.append({"step": "ui.contract.action_open", "ok": contract_ok, "status": status, "model": contract_model, "action_id": action_id})
+        if not contract_ok:
+            errors.append("action_contract_failed")
+        if contract_model and contract_model != model:
+            errors.append(f"action_model_mismatch:{contract_model}")
+
+    status, first_payload = _intent("api.data", _api_params(spec), token)
+    first_rows = _records(first_payload)
+    first_ids = [int(row.get("id") or 0) for row in first_rows]
+    first_total = _total(first_payload)
+    steps.append({"step": "api.data.list", "ok": status < 400 and first_payload.get("ok") is True and bool(first_ids), "status": status, "total": first_total, "ids": first_ids})
+    if not first_ids:
+        errors.append("list_empty")
+
+    status, count_payload = _intent("api.data", _count_params(spec), token)
+    count_total = _total(count_payload)
+    count_ok = status < 400 and count_payload.get("ok") is True and count_total >= len(first_ids)
+    steps.append({"step": "api.data.count", "ok": count_ok, "status": status, "count": count_total})
+    if not count_ok:
+        errors.append("count_failed")
+
+    status, repeat_payload = _intent("api.data", _api_params(spec), token)
+    repeat_rows = _records(repeat_payload)
+    repeat_ids = [int(row.get("id") or 0) for row in repeat_rows]
+    repeat_total = _total(repeat_payload)
+    repeat_ok = status < 400 and repeat_payload.get("ok") is True and repeat_ids == first_ids and repeat_total == first_total
+    steps.append({"step": "api.data.list_repeat", "ok": repeat_ok, "status": status, "total": repeat_total, "ids": repeat_ids})
+    if not repeat_ok:
+        errors.append("list_repeat_mismatch")
+
+    if context:
+        status, scoped_payload = _intent("api.data", _api_params(spec, context=context), token)
+        scoped_rows = _records(scoped_payload)
+        scoped_ids = [int(row.get("id") or 0) for row in scoped_rows]
+        scoped_total = _total(scoped_payload)
+        scoped_ok = status < 400 and scoped_payload.get("ok") is True and bool(scoped_ids)
+        steps.append({"step": "api.data.company_scope_list", "ok": scoped_ok, "status": status, "total": scoped_total, "ids": scoped_ids, "context": context})
+        if not scoped_ok:
+            errors.append("company_scope_list_empty")
+
+        status, scoped_count_payload = _intent("api.data", _count_params(spec, context=context), token)
+        scoped_count = _total(scoped_count_payload)
+        scoped_count_ok = status < 400 and scoped_count_payload.get("ok") is True and scoped_count >= len(scoped_ids)
+        steps.append({"step": "api.data.company_scope_count", "ok": scoped_count_ok, "status": status, "count": scoped_count, "context": context})
+        if not scoped_count_ok:
+            errors.append("company_scope_count_failed")
+
+    search_field, search_term = _first_search_anchor(first_rows[0], spec["search_fields"]) if first_rows else ("", "")
+    if search_term:
+        search_params = _api_params(spec)
+        search_params["domain"] = [[search_field, "ilike", search_term]]
+        status, search_payload = _intent("api.data", search_params, token)
+        search_rows = _records(search_payload)
+        search_ids = {int(row.get("id") or 0) for row in search_rows}
+        search_ok = status < 400 and search_payload.get("ok") is True and bool(search_ids.intersection(first_ids))
+        steps.append(
+            {
+                "step": "api.data.search_domain",
+                "ok": search_ok,
+                "status": status,
+                "search_field": search_field,
+                "search_term": search_term,
+                "domain": search_params["domain"],
+                "matched_ids": sorted(search_ids),
+            }
+        )
+        if not search_ok:
+            errors.append("search_missed_snapshot_record")
+    else:
+        steps.append({"step": "api.data.search_domain", "ok": True, "skipped": "empty_search_term"})
+
+    return {
+        "scene_key": scene_key,
+        "model": model,
+        "ok": not errors,
+        "record_count": count_total,
+        "snapshot_ids": first_ids,
+        "domain_trace": {
+            "domain": [],
+            "order": "id desc",
+            "limit": 5,
+            "company_context": context,
+        },
+        "steps": steps,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    token, company_id = _login()
+    seed = _load_seed()
+    seed_by_scene = _seed_rows(seed)
+    checks = [_scene_startup_check(token)]
+    for spec in SCENES:
+        checks.append(_ledger_scene_check(token, spec, seed_by_scene.get(spec["scene_key"], {}), company_id))
+    failures = [row for row in checks if not row.get("ok")]
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": not failures,
+        "db": DB_NAME,
+        "base_url": get_base_url().rstrip("/"),
+        "login": LOGIN,
+        "company_id": company_id,
+        "seed_present": bool(seed),
+        "seed_ok": bool(seed.get("ok")) if seed else False,
+        "summary": {
+            "check_count": len(checks),
+            "pass_count": len(checks) - len(failures),
+            "failed_count": len(failures),
+        },
+        "checks": checks,
+    }
+    REPORT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(REPORT_JSON)
+    if failures:
+        print("[ledger_snapshot_smoke] FAIL")
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 2
+    print("[ledger_snapshot_smoke] PASS")
+    print(json.dumps(payload["summary"], ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- Add repeatable ledger snapshot seed and smoke coverage for delivery readiness.
- Create/repair a dedicated `ledger_readonly_smoke` finance read-only user.
- Verify `finance.payment_ledger`, `finance.treasury_ledger`, and `finance.settlement_orders` scene visibility, native action contracts, list repeat stability, explicit count, company-scope count/list, and business-field search domain replay.
- Wire the smoke into the Makefile and delivery readiness scoreboard refresh.
- Mark the P1 treasury/settlement ledger snapshot item done and refresh the scoreboard evidence row.

## Validation

- `python3 -m py_compile scripts/verify/ledger_snapshot_seed.py scripts/verify/ledger_snapshot_smoke.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.ledger.snapshot DB_NAME=sc_demo`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`