### PR TITLE
Add cost search pagination delivery evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3992,6 +3992,11 @@ verify.delivery.ledger.snapshot: guard.prod.forbid check-compose-project check-c
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/ledger_snapshot_seed.py
 	@ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) python3 scripts/verify/ledger_snapshot_smoke.py
 
+.PHONY: verify.delivery.cost.search_pagination
+verify.delivery.cost.search_pagination: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_COST_READONLY_LOGIN=$(or $(ROLE_COST_READONLY_LOGIN),cost_readonly_smoke) ROLE_COST_READONLY_PASSWORD=$(or $(ROLE_COST_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/cost_search_pagination_seed.py
+	@ROLE_COST_READONLY_LOGIN=$(or $(ROLE_COST_READONLY_LOGIN),cost_readonly_smoke) ROLE_COST_READONLY_PASSWORD=$(or $(ROLE_COST_READONLY_PASSWORD),demo) python3 scripts/verify/cost_search_pagination_smoke.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -52,9 +52,10 @@ green. The next iteration should not reopen release blockers unless a live gate 
    - Evidence target: `make verify.delivery.ledger.snapshot`, `artifacts/backend/ledger_snapshot_smoke.json`, and the scoreboard row `Ledger snapshot smoke`.
 
 3. Cost search and pagination smoke
+   - Status: done
    - Scope: `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare`
    - Target: search, pagination, and detail open actions work under PM and finance roles.
-   - Evidence target: API-level smoke report.
+   - Evidence target: `make verify.delivery.cost.search_pagination`, `artifacts/backend/cost_search_pagination_smoke.json`, and the scoreboard row `Cost search pagination smoke`.
 
 ## P2: Governance and Long-Run Proof
 

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:37:03Z
-- branch: `topic/ledger-snapshot-evidence`
-- commit_ref: `55b4e4792`
+- generated_at_utc: 2026-06-30T08:42:16Z
+- branch: `topic/cost-search-pagination-evidence`
+- commit_ref: `a03d94cd0`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -32,6 +32,7 @@
 | Material action replay smoke | PASS | `artifacts/backend/material_action_replay_smoke.json` |
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
+| Cost search pagination smoke | PASS | `artifacts/backend/cost_search_pagination_smoke.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
@@ -42,7 +43,7 @@
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Covered by strict scene gate (`PASS`) | 需补质量安全闭环动作证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |
-| 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Covered by strict scene gate (`PASS`) | 需补搜索/分页动作证据 |
+| 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Strict scene gate (`PASS`), cost search pagination smoke (`PASS`) | 搜索/分页已脚本化；后续补成本偏差趋势证据 |
 | 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Strict scene gate (`PASS`), executive readonly smoke (`PASS`) | 只读验收已脚本化；后续补长周期趋势证据 |
 | 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Covered by strict scene gate (`PASS`) | 需补审计导出证据链 |
 | 主数据与工作台 | `data.dictionary`, `default` | 全角色 | 用户角色、字典主数据 | Covered by strict scene gate (`PASS`) | `default` 场景需持续监控占位语义 |

--- a/scripts/verify/cost_search_pagination_seed.py
+++ b/scripts/verify/cost_search_pagination_seed.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_seed.json"
+
+LOGIN = os.getenv("ROLE_COST_READONLY_LOGIN") or "cost_readonly_smoke"
+PASSWORD = os.getenv("ROLE_COST_READONLY_PASSWORD") or "demo"
+
+GROUP_XMLIDS = [
+    "base.group_user",
+    "smart_construction_core.group_sc_internal_user",
+    "smart_construction_core.group_sc_cap_project_read",
+    "smart_construction_core.group_sc_cap_cost_read",
+    "smart_construction_core.group_sc_cap_finance_read",
+    "smart_construction_custom.group_sc_role_finance",
+]
+
+SCENES = [
+    ("cost.project_budget", "smart_construction_core.menu_project_budget", "smart_construction_core.action_project_budget", "project.budget"),
+    ("cost.project_cost_ledger", "smart_construction_core.menu_sc_project_cost_ledger", "smart_construction_core.action_project_cost_ledger", "project.cost.ledger"),
+    ("cost.profit_compare", "smart_construction_core.menu_sc_profit_reports", "smart_construction_core.action_project_profit_compare", "project.profit.compare"),
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _ref(xmlid: str):
+    return env.ref(xmlid, raise_if_not_found=False)  # noqa: F821
+
+
+def _group_ids() -> tuple[list[int], list[str]]:
+    ids: list[int] = []
+    missing: list[str] = []
+    for xmlid in GROUP_XMLIDS:
+        rec = _ref(xmlid)
+        if rec:
+            ids.append(int(rec.id))
+        else:
+            missing.append(xmlid)
+    return ids, missing
+
+
+def _scene_row(scene_key: str, menu_xmlid: str, action_xmlid: str, model: str) -> dict:
+    menu = _ref(menu_xmlid)
+    action = _ref(action_xmlid)
+    count = int(env[model].sudo().search_count([])) if model in env else 0  # noqa: F821
+    return {
+        "scene_key": scene_key,
+        "menu_xmlid": menu_xmlid,
+        "menu_id": int(menu.id) if menu else 0,
+        "action_xmlid": action_xmlid,
+        "action_id": int(action.id) if action else 0,
+        "model": model,
+        "action_model": str(getattr(action, "res_model", "") or "") if action else "",
+        "row_count": count,
+        "ok": bool(menu) and bool(action) and str(getattr(action, "res_model", "") or "") == model and count > 0,
+    }
+
+
+group_ids, missing_groups = _group_ids()
+if missing_groups:
+    payload = {"generated_at_utc": _utc_now(), "ok": False, "login": LOGIN, "missing_groups": missing_groups}
+    _write_report(payload)
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)
+
+User = env["res.users"].sudo()  # noqa: F821
+Partner = env["res.partner"].sudo()  # noqa: F821
+user = User.search([("login", "=", LOGIN)], limit=1)
+if not user:
+    partner = Partner.search([("name", "=", "Cost Readonly Smoke")], limit=1)
+    if not partner:
+        partner = Partner.create({"name": "Cost Readonly Smoke"})
+    user = User.create(
+        {
+            "name": "Cost Readonly Smoke",
+            "login": LOGIN,
+            "password": PASSWORD,
+            "partner_id": partner.id,
+            "company_id": env.company.id,  # noqa: F821
+            "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+            "groups_id": [(6, 0, group_ids)],
+        }
+    )
+
+user.write(
+    {
+        "name": "Cost Readonly Smoke",
+        "password": PASSWORD,
+        "active": True,
+        "company_id": env.company.id,  # noqa: F821
+        "company_ids": [(6, 0, [env.company.id])],  # noqa: F821
+        "groups_id": [(6, 0, group_ids)],
+    }
+)
+
+checks = [_scene_row(*spec) for spec in SCENES]
+errors = [row for row in checks if not row["ok"]]
+env.cr.commit()  # noqa: F821
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": not errors,
+    "login": LOGIN,
+    "user_id": int(user.id),
+    "company_id": int(env.company.id),  # noqa: F821
+    "group_xmlids": GROUP_XMLIDS,
+    "group_ids": group_ids,
+    "checks": checks,
+    "errors": errors,
+}
+_write_report(payload)
+print(REPORT_PATH)
+print("[cost_search_pagination_seed] PASS" if payload["ok"] else "[cost_search_pagination_seed] FAIL")
+if errors:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)

--- a/scripts/verify/cost_search_pagination_smoke.py
+++ b/scripts/verify/cost_search_pagination_smoke.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from python_http_smoke_utils import get_base_url, http_post_json
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
+SEED_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_seed.json"
+
+DB_NAME = os.getenv("DB_NAME") or os.getenv("E2E_DB") or "sc_demo"
+LOGIN = os.getenv("ROLE_COST_READONLY_LOGIN") or "cost_readonly_smoke"
+PASSWORD = os.getenv("ROLE_COST_READONLY_PASSWORD") or os.getenv("E2E_PASSWORD") or "demo"
+
+SCENES = [
+    {
+        "scene_key": "cost.project_budget",
+        "model": "project.budget",
+        "fields": ["id", "display_name", "name", "project_id", "company_id", "write_date"],
+        "search_anchor": "name",
+    },
+    {
+        "scene_key": "cost.project_cost_ledger",
+        "model": "project.cost.ledger",
+        "fields": ["id", "display_name", "project_id", "cost_code_id", "amount", "date", "company_id", "write_date"],
+        "search_anchor": "cost_code_id",
+    },
+    {
+        "scene_key": "cost.profit_compare",
+        "model": "project.profit.compare",
+        "fields": ["id", "display_name", "project_id"],
+        "search_anchor": "project_id",
+    },
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _intent_url() -> str:
+    return f"{get_base_url().rstrip('/')}/api/v1/intent?db={DB_NAME}"
+
+
+def _headers(token: str | None = None, *, anonymous: bool = False) -> dict[str, str]:
+    headers = {"X-Odoo-DB": DB_NAME}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    if anonymous:
+        headers["X-Anonymous-Intent"] = "1"
+    return headers
+
+
+def _intent(intent: str, params: dict | None = None, token: str | None = None, *, anonymous: bool = False) -> tuple[int, dict]:
+    status, payload = http_post_json(
+        _intent_url(),
+        {"intent": intent, "params": params or {}},
+        headers=_headers(token, anonymous=anonymous),
+    )
+    return status, payload if isinstance(payload, dict) else {}
+
+
+def _login() -> str:
+    status, payload = _intent("login", {"db": DB_NAME, "login": LOGIN, "password": PASSWORD}, anonymous=True)
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    token = str(data.get("token") or "").strip()
+    if status >= 400 or payload.get("ok") is not True or not token:
+        raise AssertionError(f"login failed status={status} error={payload.get('error')}")
+    return token
+
+
+def _load_seed() -> dict:
+    if not SEED_REPORT_PATH.exists():
+        return {}
+    try:
+        payload = json.loads(SEED_REPORT_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _seed_rows(seed: dict) -> dict[str, dict]:
+    rows = seed.get("checks") if isinstance(seed.get("checks"), list) else []
+    return {str(row.get("scene_key") or ""): row for row in rows if isinstance(row, dict)}
+
+
+def _records(payload: dict) -> list[dict]:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    rows = data.get("records") if isinstance(data.get("records"), list) else []
+    return [row for row in rows if isinstance(row, dict)]
+
+
+def _count(payload: dict) -> int:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    for key in ("total", "count"):
+        try:
+            return int(data.get(key) or 0)
+        except Exception:
+            pass
+    return 0
+
+
+def _contract_model(payload: dict) -> str:
+    data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+    action = data.get("action") if isinstance(data.get("action"), dict) else {}
+    entry = data.get("entry") if isinstance(data.get("entry"), dict) else {}
+    return str(action.get("res_model") or entry.get("model") or data.get("model") or "").strip()
+
+
+def _walk(value: Any):
+    yield value
+    if isinstance(value, dict):
+        for child in value.values():
+            yield from _walk(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk(child)
+
+
+def _scene_values(payload: dict) -> set[str]:
+    values: set[str] = set()
+    for item in _walk(payload):
+        if isinstance(item, dict):
+            for key in ("scene_key", "sceneKey", "scene", "code", "key"):
+                value = item.get(key)
+                if isinstance(value, str) and "." in value:
+                    values.add(value.strip())
+    return values
+
+
+def _list_params(spec: dict, *, offset: int = 0, domain: list | None = None) -> dict:
+    return {
+        "op": "list",
+        "model": spec["model"],
+        "fields": spec["fields"],
+        "domain": domain or [],
+        "limit": 2,
+        "offset": offset,
+        "order": "id desc",
+    }
+
+
+def _anchor_domain(row: dict, anchor: str) -> list:
+    value = row.get(anchor)
+    if isinstance(value, list) and value:
+        return [[anchor, "=", int(value[0] or 0)]]
+    if isinstance(value, str) and value.strip():
+        return [[anchor, "ilike", value.strip()]]
+    return []
+
+
+def _startup_check(token: str) -> dict:
+    required = [spec["scene_key"] for spec in SCENES]
+    status, payload = _intent("system.init", {"scene_key": "cost.project_budget", "with_preload": False}, token)
+    scenes = _scene_values(payload)
+    missing = [scene for scene in required if scene not in scenes]
+    return {
+        "step": "system.init.cost_scenes",
+        "ok": status < 400 and payload.get("ok") is True and not missing,
+        "status": status,
+        "required_scenes": required,
+        "found_scenes": sorted(scene for scene in scenes if scene in set(required)),
+        "missing_scenes": missing,
+    }
+
+
+def _scene_check(token: str, spec: dict, seed_row: dict) -> dict:
+    errors: list[str] = []
+    steps: list[dict] = []
+    action_id = int(seed_row.get("action_id") or 0)
+    if action_id <= 0:
+        errors.append("action_id_missing")
+    else:
+        status, contract_payload = _intent(
+            "ui.contract",
+            {
+                "op": "action_open",
+                "action_id": action_id,
+                "source_mode": "backend_internal",
+                "contract_surface": "native",
+                "scene_key": spec["scene_key"],
+            },
+            token,
+        )
+        model = _contract_model(contract_payload)
+        ok = status < 400 and contract_payload.get("ok") is True and model == spec["model"]
+        steps.append({"step": "ui.contract.action_open", "ok": ok, "status": status, "model": model, "action_id": action_id})
+        if not ok:
+            errors.append("action_contract_failed")
+
+    status, count_payload = _intent("api.data", {"op": "count", "model": spec["model"], "domain": []}, token)
+    total = _count(count_payload)
+    count_ok = status < 400 and count_payload.get("ok") is True and total > 0
+    steps.append({"step": "api.data.count", "ok": count_ok, "status": status, "count": total})
+    if not count_ok:
+        errors.append("count_failed")
+
+    status, page1_payload = _intent("api.data", _list_params(spec, offset=0), token)
+    page1 = _records(page1_payload)
+    page1_ids = [int(row.get("id") or 0) for row in page1]
+    page1_ok = status < 400 and page1_payload.get("ok") is True and bool(page1_ids)
+    steps.append({"step": "api.data.page_1", "ok": page1_ok, "status": status, "ids": page1_ids})
+    if not page1_ok:
+        errors.append("page_1_empty")
+
+    status, page2_payload = _intent("api.data", _list_params(spec, offset=2), token)
+    page2 = _records(page2_payload)
+    page2_ids = [int(row.get("id") or 0) for row in page2]
+    page2_ok = status < 400 and page2_payload.get("ok") is True and (total <= 2 or bool(page2_ids)) and not set(page1_ids).intersection(page2_ids)
+    steps.append({"step": "api.data.page_2", "ok": page2_ok, "status": status, "ids": page2_ids, "offset": 2})
+    if not page2_ok:
+        errors.append("page_2_invalid")
+
+    domain = _anchor_domain(page1[0], str(spec.get("search_anchor") or "")) if page1 else []
+    if domain:
+        status, search_payload = _intent("api.data", _list_params(spec, offset=0, domain=domain), token)
+        search_ids = [int(row.get("id") or 0) for row in _records(search_payload)]
+        search_ok = status < 400 and search_payload.get("ok") is True and bool(set(page1_ids).intersection(search_ids))
+        steps.append({"step": "api.data.search_domain", "ok": search_ok, "status": status, "domain": domain, "ids": search_ids})
+        if not search_ok:
+            errors.append("search_domain_missed_record")
+    else:
+        steps.append({"step": "api.data.search_domain", "ok": True, "skipped": "missing_anchor"})
+
+    return {
+        "scene_key": spec["scene_key"],
+        "model": spec["model"],
+        "ok": not errors,
+        "record_count": total,
+        "page_1_ids": page1_ids,
+        "page_2_ids": page2_ids,
+        "steps": steps,
+        "errors": errors,
+    }
+
+
+def main() -> int:
+    token = _login()
+    seed = _load_seed()
+    seed_by_scene = _seed_rows(seed)
+    checks = [_startup_check(token)]
+    checks.extend(_scene_check(token, spec, seed_by_scene.get(spec["scene_key"], {})) for spec in SCENES)
+    failures = [row for row in checks if not row.get("ok")]
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": not failures,
+        "db": DB_NAME,
+        "base_url": get_base_url().rstrip("/"),
+        "login": LOGIN,
+        "seed_present": bool(seed),
+        "seed_ok": bool(seed.get("ok")) if seed else False,
+        "summary": {"check_count": len(checks), "pass_count": len(checks) - len(failures), "failed_count": len(failures)},
+        "checks": checks,
+    }
+    REPORT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    print(REPORT_JSON)
+    if failures:
+        print("[cost_search_pagination_smoke] FAIL")
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 2
+    print("[cost_search_pagination_smoke] PASS")
+    print(json.dumps(payload["summary"], ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -24,6 +24,7 @@ PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task
 MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_action_replay_smoke.json"
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
+COST_SEARCH_PAGINATION_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -440,6 +441,11 @@ def main() -> int:
     ledger_snapshot_ok = bool(ledger_snapshot_payload.get("ok")) if ledger_snapshot_present else False
     ledger_snapshot_label = _bool_status_label(ledger_snapshot_ok) if ledger_snapshot_present else "UNKNOWN"
 
+    cost_search_payload = _load_json(COST_SEARCH_PAGINATION_REPORT_PATH)
+    cost_search_present = bool(cost_search_payload)
+    cost_search_ok = bool(cost_search_payload.get("ok")) if cost_search_present else False
+    cost_search_label = _bool_status_label(cost_search_ok) if cost_search_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -499,6 +505,12 @@ def main() -> int:
         "Ledger snapshot smoke",
         ledger_snapshot_label,
         str(LEDGER_SNAPSHOT_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Cost search pagination smoke",
+        cost_search_label,
+        str(COST_SEARCH_PAGINATION_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)


### PR DESCRIPTION
## Summary

- Add repeatable cost search/pagination seed and smoke coverage for delivery readiness.
- Create/repair a dedicated `cost_readonly_smoke` user with cost/project/finance read groups.
- Verify `cost.project_budget`, `cost.project_cost_ledger`, and `cost.profit_compare` scene visibility, native action contracts, explicit count, first/second page pagination, and business-field domain search replay.
- Wire the smoke into the Makefile and delivery readiness scoreboard refresh.
- Mark the P1 cost search/pagination item done and refresh the scoreboard evidence row.

## Validation

- `python3 -m py_compile scripts/verify/cost_search_pagination_seed.py scripts/verify/cost_search_pagination_smoke.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.cost.search_pagination DB_NAME=sc_demo`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`