### PR TITLE
Add quality safety closure delivery evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3997,6 +3997,10 @@ verify.delivery.cost.search_pagination: guard.prod.forbid check-compose-project 
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_COST_READONLY_LOGIN=$(or $(ROLE_COST_READONLY_LOGIN),cost_readonly_smoke) ROLE_COST_READONLY_PASSWORD=$(or $(ROLE_COST_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/cost_search_pagination_seed.py
 	@ROLE_COST_READONLY_LOGIN=$(or $(ROLE_COST_READONLY_LOGIN),cost_readonly_smoke) ROLE_COST_READONLY_PASSWORD=$(or $(ROLE_COST_READONLY_PASSWORD),demo) python3 scripts/verify/cost_search_pagination_smoke.py
 
+.PHONY: verify.delivery.quality_safety.closure
+verify.delivery.quality_safety.closure: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/site_quality_safety_closure_audit.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -61,7 +61,9 @@ green. The next iteration should not reopen release blockers unless a live gate 
 
 1. Quality/safety closure action proof
    - Scope: `quality.center`, `safety.center`
-   - Target: close one safe quality/safety loop in demo data or prove no-op readonly closure.
+   - Status: done
+   - Target: close one safe quality/safety loop in demo data and prove audit/photo evidence guardrails.
+   - Evidence target: `make verify.delivery.quality_safety.closure`, `artifacts/backend/site_quality_safety_closure_audit.json`, and the scoreboard row `Quality safety closure smoke`.
 
 2. Lifecycle audit export evidence
    - Scope: `portal.lifecycle`, `portal.capability_matrix`

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:42:16Z
-- branch: `topic/cost-search-pagination-evidence`
-- commit_ref: `a03d94cd0`
+- generated_at_utc: 2026-06-30T08:45:49Z
+- branch: `topic/quality-safety-closure-evidence`
+- commit_ref: `76030b841`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -33,6 +33,7 @@
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
 | Cost search pagination smoke | PASS | `artifacts/backend/cost_search_pagination_smoke.json` |
+| Quality safety closure smoke | PASS | `artifacts/backend/site_quality_safety_closure_audit.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
@@ -40,7 +41,7 @@
 | 项目立项与台账 | `projects.intake`, `projects.list`, `projects.ledger` | PM, 采购经理 | 项目类型、组织字典、用户 | Covered by strict scene gate (`PASS`) | 需补旅程级 trace 固化 |
 | 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Strict scene gate (`PASS`), project task action smoke (`PASS`) | 任务动作推进已脚本化；后续补旅程级 trace 趋势 |
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`) | 动作回放已脚本化；后续补跨单据状态推进证据 |
-| 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Covered by strict scene gate (`PASS`) | 需补质量安全闭环动作证据 |
+| 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Strict scene gate (`PASS`), quality safety closure smoke (`PASS`) | 质量/安全闭环已脚本化；后续补现场日报联动证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Strict scene gate (`PASS`), cost search pagination smoke (`PASS`) | 搜索/分页已脚本化；后续补成本偏差趋势证据 |

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -25,6 +25,7 @@ MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
 COST_SEARCH_PAGINATION_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
+QUALITY_SAFETY_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "site_quality_safety_closure_audit.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -446,6 +447,11 @@ def main() -> int:
     cost_search_ok = bool(cost_search_payload.get("ok")) if cost_search_present else False
     cost_search_label = _bool_status_label(cost_search_ok) if cost_search_present else "UNKNOWN"
 
+    quality_safety_payload = _load_json(QUALITY_SAFETY_CLOSURE_REPORT_PATH)
+    quality_safety_present = bool(quality_safety_payload)
+    quality_safety_ok = bool(quality_safety_payload.get("ok")) if quality_safety_present else False
+    quality_safety_label = _bool_status_label(quality_safety_ok) if quality_safety_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -511,6 +517,12 @@ def main() -> int:
         "Cost search pagination smoke",
         cost_search_label,
         str(COST_SEARCH_PAGINATION_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Quality safety closure smoke",
+        quality_safety_label,
+        str(QUALITY_SAFETY_CLOSURE_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/site_quality_safety_closure_audit.py
+++ b/scripts/verify/site_quality_safety_closure_audit.py
@@ -2,8 +2,23 @@
 import base64
 import json
 import traceback
+from datetime import datetime, timezone
+from pathlib import Path
 
 from odoo import fields
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "site_quality_safety_closure_audit.json"
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_report(payload):
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
 
 
 def _token():
@@ -283,10 +298,15 @@ except Exception as err:
 
 result = {
     "audit": "site_quality_safety_closure_audit",
+    "generated_at_utc": _utc_now(),
+    "ok": not failures,
     "status": "PASS" if not failures else "FAIL",
     "evidence": evidence,
     "failures": failures,
+    "report_path": str(REPORT_PATH.relative_to(ROOT)),
 }
+_write_report(result)
+print(REPORT_PATH)
 print("SITE_QUALITY_SAFETY_CLOSURE_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
 if failures:
     print("FAILURES:")


### PR DESCRIPTION
## Summary

- Turn the existing site quality/safety closure audit into delivery readiness evidence.
- Persist `artifacts/backend/site_quality_safety_closure_audit.json` with `ok`, timestamp, and quality/safety closure evidence.
- Add `make verify.delivery.quality_safety.closure`.
- Wire the report into the delivery readiness scoreboard refresh.
- Mark the P2 quality/safety closure action proof item done and refresh the scoreboard row.

## Validation

- `python3 -m py_compile scripts/verify/site_quality_safety_closure_audit.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.quality_safety.closure DB_NAME=sc_demo`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`