### PR TITLE
Add lifecycle audit export delivery evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4001,6 +4001,10 @@ verify.delivery.cost.search_pagination: guard.prod.forbid check-compose-project 
 verify.delivery.quality_safety.closure: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/site_quality_safety_closure_audit.py
 
+.PHONY: verify.delivery.lifecycle.audit_export
+verify.delivery.lifecycle.audit_export: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/lifecycle_audit_export.py
+
 .PHONY: verify.product.delivery.module_capability.smoke verify.product.delivery.module9.smoke
 verify.product.delivery.module_capability.smoke: guard.prod.forbid
 	@python3 scripts/verify/product_delivery_module9_smoke.py

--- a/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
+++ b/docs/ops/iterations/delivery_action_evidence_iteration_plan_20260630.md
@@ -67,7 +67,9 @@ green. The next iteration should not reopen release blockers unless a live gate 
 
 2. Lifecycle audit export evidence
    - Scope: `portal.lifecycle`, `portal.capability_matrix`
-   - Target: audit export or equivalent machine-readable evidence is produced and linked.
+   - Status: done
+   - Target: lifecycle dashboard and capability matrix machine-readable export is produced and linked.
+   - Evidence target: `make verify.delivery.lifecycle.audit_export`, `artifacts/backend/lifecycle_audit_export.json`, and the scoreboard row `Lifecycle audit export`.
 
 3. Default scene semantic monitoring
    - Scope: `default`

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:45:49Z
-- branch: `topic/quality-safety-closure-evidence`
-- commit_ref: `76030b841`
+- generated_at_utc: 2026-06-30T08:49:26Z
+- branch: `topic/lifecycle-audit-export-evidence`
+- commit_ref: `a345c497c`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -34,6 +34,7 @@
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
 | Cost search pagination smoke | PASS | `artifacts/backend/cost_search_pagination_smoke.json` |
 | Quality safety closure smoke | PASS | `artifacts/backend/site_quality_safety_closure_audit.json` |
+| Lifecycle audit export | PASS | `artifacts/backend/lifecycle_audit_export.json` |
 ## 10-Module Readiness Board
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
@@ -46,7 +47,7 @@
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Strict scene gate (`PASS`), cost search pagination smoke (`PASS`) | 搜索/分页已脚本化；后续补成本偏差趋势证据 |
 | 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Strict scene gate (`PASS`), executive readonly smoke (`PASS`) | 只读验收已脚本化；后续补长周期趋势证据 |
-| 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Covered by strict scene gate (`PASS`) | 需补审计导出证据链 |
+| 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Strict scene gate (`PASS`), lifecycle audit export (`PASS`) | 审计导出已脚本化；后续补长期趋势归档 |
 | 主数据与工作台 | `data.dictionary`, `default` | 全角色 | 用户角色、字典主数据 | Covered by strict scene gate (`PASS`) | `default` 场景需持续监控占位语义 |
 
 ## 4 Key Journey Status

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -26,6 +26,7 @@ EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_rea
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
 COST_SEARCH_PAGINATION_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
 QUALITY_SAFETY_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "site_quality_safety_closure_audit.json"
+LIFECYCLE_AUDIT_EXPORT_REPORT_PATH = ROOT / "artifacts" / "backend" / "lifecycle_audit_export.json"
 
 PROFILE_COMMANDS = {
     "strict": "CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness",
@@ -452,6 +453,11 @@ def main() -> int:
     quality_safety_ok = bool(quality_safety_payload.get("ok")) if quality_safety_present else False
     quality_safety_label = _bool_status_label(quality_safety_ok) if quality_safety_present else "UNKNOWN"
 
+    lifecycle_audit_payload = _load_json(LIFECYCLE_AUDIT_EXPORT_REPORT_PATH)
+    lifecycle_audit_present = bool(lifecycle_audit_payload)
+    lifecycle_audit_ok = bool(lifecycle_audit_payload.get("ok")) if lifecycle_audit_present else False
+    lifecycle_audit_label = _bool_status_label(lifecycle_audit_ok) if lifecycle_audit_present else "UNKNOWN"
+
     lines = _upsert_evidence_row(
         lines,
         "CI strict profile readiness",
@@ -523,6 +529,12 @@ def main() -> int:
         "Quality safety closure smoke",
         quality_safety_label,
         str(QUALITY_SAFETY_CLOSURE_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Lifecycle audit export",
+        lifecycle_audit_label,
+        str(LIFECYCLE_AUDIT_EXPORT_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _normalize_evidence_table(lines)
     lines = _upsert_release_gap_profile_posture(lines, strict_label, restricted_label)

--- a/scripts/verify/lifecycle_audit_export.py
+++ b/scripts/verify/lifecycle_audit_export.py
@@ -1,0 +1,134 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path("/mnt") if Path("/mnt/scripts").exists() else Path(__file__).resolve().parents[2]
+REPORT_PATH = ROOT / "artifacts" / "backend" / "lifecycle_audit_export.json"
+
+SCENE_KEYS = ["portal.lifecycle", "portal.capability_matrix"]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write_report(payload: dict) -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_PATH.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def _capability_items(matrix: dict) -> list[dict]:
+    sections = matrix.get("sections") if isinstance(matrix.get("sections"), list) else []
+    out: list[dict] = []
+    for section in sections:
+        if not isinstance(section, dict):
+            continue
+        items = section.get("items") if isinstance(section.get("items"), list) else []
+        for item in items:
+            if isinstance(item, dict):
+                row = dict(item)
+                row["section_key"] = section.get("key")
+                out.append(row)
+    return out
+
+
+def _scene_exports() -> list[dict]:
+    Scene = env["sc.scene"].sudo()  # noqa: F821
+    rows = []
+    for scene_key in SCENE_KEYS:
+        scene = Scene.search([("code", "=", scene_key)], limit=1)
+        active_version = scene.active_version_id if scene else False
+        rows.append(
+            {
+                "scene_key": scene_key,
+                "exists": bool(scene),
+                "scene_id": int(scene.id) if scene else 0,
+                "active_version_id": int(active_version.id) if active_version else 0,
+                "active_version_state": str(getattr(active_version, "state", "") or "") if active_version else "",
+            }
+        )
+    return rows
+
+
+def _matrix_meta_exists(lifecycle: dict) -> bool:
+    matrix_meta = lifecycle.get("matrix_meta") if isinstance(lifecycle.get("matrix_meta"), dict) else {}
+    path = str(matrix_meta.get("path") or "").strip()
+    return bool(path) and Path(path).is_file()
+
+
+errors: list[str] = []
+try:
+    from odoo.addons.smart_construction_portal.services.portal_contract_service import PortalContractService
+    from odoo.addons.smart_construction_core.services.capability_matrix_service import CapabilityMatrixService
+
+    lifecycle = PortalContractService(env).build_lifecycle_dashboard(  # noqa: F821
+        route="/portal/lifecycle",
+        trace_id="delivery-lifecycle-audit-export",
+    )
+    capability_matrix = CapabilityMatrixService(env).build_matrix()  # noqa: F821
+except Exception as exc:
+    lifecycle = {}
+    capability_matrix = {}
+    errors.append(f"service_export_failed:{type(exc).__name__}:{exc}")
+
+scene_exports = _scene_exports()
+capability_items = _capability_items(capability_matrix)
+allowed_items = [item for item in capability_items if item.get("allowed") is True]
+lifecycle_codes = lifecycle.get("capability_codes") if isinstance(lifecycle.get("capability_codes"), list) else []
+lifecycle_states = lifecycle.get("lifecycle_states") if isinstance(lifecycle.get("lifecycle_states"), list) else []
+
+if lifecycle.get("schema_version") != "portal-lifecycle-v1":
+    errors.append("lifecycle_schema_version_mismatch")
+if lifecycle.get("route") != "/portal/lifecycle":
+    errors.append("lifecycle_route_mismatch")
+if len(lifecycle_states) < 5:
+    errors.append("lifecycle_states_too_few")
+if len(lifecycle_codes) < 5:
+    errors.append("lifecycle_capability_codes_too_few")
+if not _matrix_meta_exists(lifecycle):
+    errors.append("lifecycle_matrix_meta_path_missing")
+if not capability_items:
+    errors.append("capability_matrix_items_empty")
+if not allowed_items:
+    errors.append("capability_matrix_allowed_items_empty")
+missing_scenes = [row["scene_key"] for row in scene_exports if not row["exists"]]
+if missing_scenes:
+    errors.append(f"missing_scenes:{','.join(missing_scenes)}")
+
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": not errors,
+    "export": "lifecycle_audit_export",
+    "db": env.cr.dbname,  # noqa: F821
+    "company_id": int(env.company.id),  # noqa: F821
+    "scenes": scene_exports,
+    "lifecycle": {
+        "schema_version": lifecycle.get("schema_version"),
+        "contract_version": lifecycle.get("contract_version"),
+        "route": lifecycle.get("route"),
+        "subject": lifecycle.get("subject"),
+        "trace_id": lifecycle.get("trace_id"),
+        "lifecycle_states": lifecycle_states,
+        "capability_codes": lifecycle_codes,
+        "matrix_meta": lifecycle.get("matrix_meta") if isinstance(lifecycle.get("matrix_meta"), dict) else {},
+        "layout": lifecycle.get("layout") if isinstance(lifecycle.get("layout"), dict) else {},
+    },
+    "capability_matrix": {
+        "section_count": len(capability_matrix.get("sections") if isinstance(capability_matrix.get("sections"), list) else []),
+        "item_count": len(capability_items),
+        "allowed_item_count": len(allowed_items),
+        "scene_keys": sorted({str(item.get("scene_key") or "") for item in capability_items if str(item.get("scene_key") or "").strip()}),
+    },
+    "errors": errors,
+    "report_path": str(REPORT_PATH.relative_to(ROOT)),
+}
+_write_report(payload)
+print(REPORT_PATH)
+print("[lifecycle_audit_export] PASS" if payload["ok"] else "[lifecycle_audit_export] FAIL")
+if errors:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)


### PR DESCRIPTION
## Summary

- Add a repeatable lifecycle audit export for delivery readiness.
- Export lifecycle dashboard service facts and capability matrix service facts to `artifacts/backend/lifecycle_audit_export.json`.
- Validate `portal.lifecycle` and `portal.capability_matrix` scene records, lifecycle schema/route/states, lifecycle capability codes, matrix source path, and capability matrix item coverage.
- Add `make verify.delivery.lifecycle.audit_export` and wire the report into the delivery readiness scoreboard refresh.
- Mark the P2 lifecycle audit export item done and refresh the scoreboard row.

## Validation

- `python3 -m py_compile scripts/verify/lifecycle_audit_export.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.lifecycle.audit_export DB_NAME=sc_demo`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`