### PR TITLE
Add project journey trace archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3977,6 +3977,10 @@ verify.delivery.project_task.action_smoke: guard.prod.forbid check-compose-proje
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_PM_LOGIN=$(or $(ROLE_PM_LOGIN),demo_role_pm) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/project_task_action_seed.py
 	@python3 scripts/verify/project_task_action_smoke.py
 
+.PHONY: verify.delivery.project_journey.trace_archive
+verify.delivery.project_journey.trace_archive: guard.prod.forbid verify.delivery.journey.role_matrix.guard verify.delivery.project_task.action_smoke
+	@python3 scripts/verify/project_journey_trace_archive.py
+
 .PHONY: verify.delivery.material.action_replay
 verify.delivery.material.action_replay: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_MATERIAL_LOGIN=$(or $(ROLE_MATERIAL_LOGIN),demo_business_full) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/material_action_replay_seed.py

--- a/docs/ops/audit/project_journey_trace_archive.md
+++ b/docs/ops/audit/project_journey_trace_archive.md
@@ -1,0 +1,21 @@
+# Project Journey Trace Archive
+
+- generated_at_utc: 2026-06-30T08:59:19Z
+- ok: True
+- role: `pm`
+- project_id: `4697`
+- task_id: `76593`
+
+## Trace Chain
+
+| kind | key | ok | detail |
+|---|---|---|---|
+| scene_visibility | `projects.intake` | True | `` |
+| scene_visibility | `projects.list` | True | `` |
+| scene_visibility | `projects.ledger` | True | `` |
+| scene_visibility | `projects.dashboard` | True | `` |
+| action_step | `project.execution.enter` | True | `OK` |
+| action_step | `project.execution.block.fetch.execution_tasks` | True | `OK` |
+| action_step | `project.execution.block.fetch.next_actions` | True | `OK` |
+| action_step | `project.execution.advance` | True | `EXECUTION_TRANSITION_READY_TO_IN_PROGRESS` |
+| action_step | `project.execution.block.fetch.execution_tasks.after_advance` | True | `OK` |

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:59:27Z
+- generated_at_utc: 2026-06-30T08:59:54Z
 - branch: `topic/project-journey-trace-archive`
-- commit_ref: `d633e86cd`
+- commit_ref: `41a2b146a`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:55:36Z
-- branch: `topic/default-scene-semantic-monitoring`
-- commit_ref: `996020225`
+- generated_at_utc: 2026-06-30T08:59:27Z
+- branch: `topic/project-journey-trace-archive`
+- commit_ref: `d633e86cd`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -29,6 +29,7 @@
 | Product delivery module capability smoke | PASS | `artifacts/backend/product_delivery_module9_smoke_report.json` |
 | Payment approval chain smoke | PASS | `artifacts/backend/payment_request_approval_chain_summary.json` |
 | Project task action smoke | PASS | `artifacts/backend/project_task_action_smoke.json` |
+| Project journey trace archive | PASS | `artifacts/backend/project_journey_trace_archive.json` |
 | Material action replay smoke | PASS | `artifacts/backend/material_action_replay_smoke.json` |
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
@@ -40,8 +41,8 @@
 
 | Module | Entry Scenes | Key Roles | Data Prerequisites | Smoke/Gate Status | Known Limits |
 |---|---|---|---|---|---|
-| 项目立项与台账 | `projects.intake`, `projects.list`, `projects.ledger` | PM, 采购经理 | 项目类型、组织字典、用户 | Covered by strict scene gate (`PASS`) | 需补旅程级 trace 固化 |
-| 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Strict scene gate (`PASS`), project task action smoke (`PASS`) | 任务动作推进已脚本化；后续补旅程级 trace 趋势 |
+| 项目立项与台账 | `projects.intake`, `projects.list`, `projects.ledger` | PM, 采购经理 | 项目类型、组织字典、用户 | Strict scene gate (`PASS`), project journey trace archive (`PASS`) | 旅程 trace 已归档；后续补立项动作推进证据 |
+| 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Strict scene gate (`PASS`), project task action smoke (`PASS`), project journey trace archive (`PASS`) | 任务动作与 PM 旅程 trace 已脚本化；后续补长期趋势 |
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`) | 动作回放已脚本化；后续补跨单据状态推进证据 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Strict scene gate (`PASS`), quality safety closure smoke (`PASS`) | 质量/安全闭环已脚本化；后续补现场日报联动证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -21,6 +21,7 @@ ACTION_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_
 MODULE9_SMOKE_REPORT_PATH = ROOT / "artifacts" / "backend" / "product_delivery_module9_smoke_report.json"
 PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_request_approval_chain_summary.json"
 PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
+PROJECT_JOURNEY_TRACE_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_journey_trace_archive.json"
 MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_action_replay_smoke.json"
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
@@ -429,6 +430,11 @@ def main() -> int:
     project_task_ok = bool(project_task_payload.get("ok")) if project_task_present else False
     project_task_label = _bool_status_label(project_task_ok) if project_task_present else "UNKNOWN"
 
+    project_journey_trace_payload = _load_json(PROJECT_JOURNEY_TRACE_REPORT_PATH)
+    project_journey_trace_present = bool(project_journey_trace_payload)
+    project_journey_trace_ok = bool(project_journey_trace_payload.get("ok")) if project_journey_trace_present else False
+    project_journey_trace_label = _bool_status_label(project_journey_trace_ok) if project_journey_trace_present else "UNKNOWN"
+
     material_replay_payload = _load_json(MATERIAL_ACTION_REPLAY_REPORT_PATH)
     material_replay_present = bool(material_replay_payload)
     material_replay_ok = bool(material_replay_payload.get("ok")) if material_replay_present else False
@@ -505,6 +511,12 @@ def main() -> int:
         "Project task action smoke",
         project_task_label,
         str(PROJECT_TASK_ACTION_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Project journey trace archive",
+        project_journey_trace_label,
+        str(PROJECT_JOURNEY_TRACE_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _upsert_evidence_row(
         lines,

--- a/scripts/verify/project_journey_trace_archive.py
+++ b/scripts/verify/project_journey_trace_archive.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "project_journey_trace_archive.json"
+REPORT_MD = ROOT / "docs" / "ops" / "audit" / "project_journey_trace_archive.md"
+ROLE_MATRIX_PATH = ROOT / "artifacts" / "backend" / "delivery_journey_role_matrix_report.json"
+TASK_ACTION_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
+
+REQUIRED_PM_SCENES = ["projects.intake", "projects.list", "projects.ledger", "projects.dashboard"]
+REQUIRED_ACTION_STEPS = [
+    "project.execution.enter",
+    "project.execution.block.fetch.execution_tasks",
+    "project.execution.block.fetch.next_actions",
+    "project.execution.advance",
+    "project.execution.block.fetch.execution_tasks.after_advance",
+]
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _as_list(value: Any) -> list:
+    return value if isinstance(value, list) else []
+
+
+def _text(value: Any) -> str:
+    return str(value or "").strip()
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _task_step_index(task_action: dict) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for row in _as_list(task_action.get("steps")):
+        if not isinstance(row, dict):
+            continue
+        step = _text(row.get("step"))
+        if step:
+            out[step] = row
+    return out
+
+
+def _build_trace_chain(pm_row: dict, task_action: dict) -> list[dict]:
+    chain: list[dict] = []
+    for scene in _as_list(pm_row.get("required_scenes")):
+        scene_key = _text(scene)
+        if not scene_key:
+            continue
+        chain.append(
+            {
+                "kind": "scene_visibility",
+                "scene_key": scene_key,
+                "ok": scene_key not in set(_as_list(pm_row.get("missing_scenes"))),
+                "source": ROLE_MATRIX_PATH.relative_to(ROOT).as_posix(),
+            }
+        )
+
+    step_index = _task_step_index(task_action)
+    for step_name in REQUIRED_ACTION_STEPS:
+        row = step_index.get(step_name, {})
+        chain.append(
+            {
+                "kind": "action_step",
+                "step": step_name,
+                "ok": bool(row.get("ok")),
+                "reason_code": _text(row.get("reason_code")),
+                "result": _text(row.get("result")),
+                "from_state": _text(row.get("from_state")),
+                "to_state": _text(row.get("to_state")),
+                "source": TASK_ACTION_PATH.relative_to(ROOT).as_posix(),
+            }
+        )
+    return chain
+
+
+def _to_markdown(payload: dict) -> str:
+    lines = [
+        "# Project Journey Trace Archive",
+        "",
+        f"- generated_at_utc: {payload.get('generated_at_utc', '')}",
+        f"- ok: {payload.get('ok')}",
+        f"- role: `{payload.get('role', '')}`",
+        f"- project_id: `{payload.get('project_id', '')}`",
+        f"- task_id: `{payload.get('task_id', '')}`",
+        "",
+        "## Trace Chain",
+        "",
+        "| kind | key | ok | detail |",
+        "|---|---|---|---|",
+    ]
+    for row in _as_list(payload.get("trace_chain")):
+        if not isinstance(row, dict):
+            continue
+        key = _text(row.get("scene_key") or row.get("step"))
+        detail = _text(row.get("reason_code") or row.get("result") or row.get("to_state"))
+        lines.append(f"| {_text(row.get('kind'))} | `{key}` | {bool(row.get('ok'))} | `{detail}` |")
+    errors = _as_list(payload.get("errors"))
+    if errors:
+        lines.extend(["", "## Errors", ""])
+        lines.extend(f"- {item}" for item in errors)
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    errors: list[str] = []
+    role_matrix = _load_json(ROLE_MATRIX_PATH)
+    task_action = _load_json(TASK_ACTION_PATH)
+
+    if not role_matrix:
+        errors.append(f"missing_role_matrix:{ROLE_MATRIX_PATH.relative_to(ROOT).as_posix()}")
+    if not task_action:
+        errors.append(f"missing_task_action:{TASK_ACTION_PATH.relative_to(ROOT).as_posix()}")
+    if role_matrix and not bool(role_matrix.get("ok")):
+        errors.append("role_matrix_not_ok")
+    if task_action and not bool(task_action.get("ok")):
+        errors.append("project_task_action_not_ok")
+
+    journeys = role_matrix.get("journeys") if isinstance(role_matrix.get("journeys"), dict) else {}
+    pm_row = journeys.get("pm") if isinstance(journeys.get("pm"), dict) else {}
+    observed_pm_scenes = set(_as_list(pm_row.get("required_scenes")))
+    missing_required_pm_scenes = [scene for scene in REQUIRED_PM_SCENES if scene not in observed_pm_scenes]
+    if missing_required_pm_scenes:
+        errors.append(f"pm_required_scene_missing:{missing_required_pm_scenes}")
+    if _as_list(pm_row.get("missing_scenes")):
+        errors.append(f"pm_role_matrix_missing_scenes:{pm_row.get('missing_scenes')}")
+
+    step_index = _task_step_index(task_action)
+    missing_action_steps = [step for step in REQUIRED_ACTION_STEPS if step not in step_index]
+    if missing_action_steps:
+        errors.append(f"project_action_step_missing:{missing_action_steps}")
+    failed_action_steps = [step for step in REQUIRED_ACTION_STEPS if step in step_index and not bool(step_index[step].get("ok"))]
+    if failed_action_steps:
+        errors.append(f"project_action_step_failed:{failed_action_steps}")
+
+    advance = step_index.get("project.execution.advance", {})
+    if advance and _text(advance.get("result")) != "success":
+        errors.append("project_execution_advance_not_success")
+
+    trace_chain = _build_trace_chain(pm_row, task_action)
+    payload = {
+        "generated_at_utc": _utc_now(),
+        "ok": not errors,
+        "archive": "project_journey_trace_archive",
+        "role": "pm",
+        "project_id": task_action.get("project_id") or 0,
+        "task_id": task_action.get("task_id") or 0,
+        "trace_chain": trace_chain,
+        "summary": {
+            "scene_step_count": len([row for row in trace_chain if row.get("kind") == "scene_visibility"]),
+            "action_step_count": len([row for row in trace_chain if row.get("kind") == "action_step"]),
+            "required_scene_count": len(REQUIRED_PM_SCENES),
+            "required_action_step_count": len(REQUIRED_ACTION_STEPS),
+        },
+        "sources": {
+            "role_matrix": ROLE_MATRIX_PATH.relative_to(ROOT).as_posix(),
+            "project_task_action": TASK_ACTION_PATH.relative_to(ROOT).as_posix(),
+        },
+        "reports": {
+            "json": REPORT_JSON.relative_to(ROOT).as_posix(),
+            "md": REPORT_MD.relative_to(ROOT).as_posix(),
+        },
+        "errors": errors,
+    }
+    _write(REPORT_JSON, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+    _write(REPORT_MD, _to_markdown(payload))
+
+    print(REPORT_JSON)
+    print(REPORT_MD)
+    if errors:
+        print("[project_journey_trace_archive] FAIL")
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+        return 1
+    print("[project_journey_trace_archive] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a project journey trace archive that combines PM scene visibility and project task action evidence
- wire the archive into Make and delivery readiness scoreboard refresh
- update the project module scoreboard rows to mark journey trace evidence as script-bound

## Validation
- `python3 -m py_compile scripts/verify/project_journey_trace_archive.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.project_journey.trace_archive DB_NAME=sc_demo`
- `python3 scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`