### PR TITLE
Add material cross-document progress evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3986,6 +3986,10 @@ verify.delivery.material.action_replay: guard.prod.forbid check-compose-project 
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_MATERIAL_LOGIN=$(or $(ROLE_MATERIAL_LOGIN),demo_business_full) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/material_action_replay_seed.py
 	@ROLE_MATERIAL_LOGIN=$(or $(ROLE_MATERIAL_LOGIN),demo_business_full) python3 scripts/verify/material_action_replay_smoke.py
 
+.PHONY: verify.delivery.material.cross_document_progress
+verify.delivery.material.cross_document_progress: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/material_settlement_payment_execution_traceability_audit.py
+
 .PHONY: verify.delivery.executive.readonly
 verify.delivery.executive.readonly: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_EXECUTIVE_READONLY_LOGIN=$(or $(ROLE_EXECUTIVE_READONLY_LOGIN),executive_readonly_smoke) ROLE_EXECUTIVE_READONLY_PASSWORD=$(or $(ROLE_EXECUTIVE_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/executive_readonly_seed.py

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T08:59:54Z
-- branch: `topic/project-journey-trace-archive`
-- commit_ref: `41a2b146a`
+- generated_at_utc: 2026-06-30T09:03:14Z
+- branch: `topic/material-cross-document-progress`
+- commit_ref: `6d7393acb`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -31,6 +31,7 @@
 | Project task action smoke | PASS | `artifacts/backend/project_task_action_smoke.json` |
 | Project journey trace archive | PASS | `artifacts/backend/project_journey_trace_archive.json` |
 | Material action replay smoke | PASS | `artifacts/backend/material_action_replay_smoke.json` |
+| Material cross-document progress audit | PASS | `artifacts/backend/material_cross_document_progress_audit.json` |
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
 | Cost search pagination smoke | PASS | `artifacts/backend/cost_search_pagination_smoke.json` |
@@ -43,7 +44,7 @@
 |---|---|---|---|---|---|
 | 项目立项与台账 | `projects.intake`, `projects.list`, `projects.ledger` | PM, 采购经理 | 项目类型、组织字典、用户 | Strict scene gate (`PASS`), project journey trace archive (`PASS`) | 旅程 trace 已归档；后续补立项动作推进证据 |
 | 项目执行与任务协同 | `projects.dashboard`, `projects.execution` | PM | 项目、任务、周报样例 | Strict scene gate (`PASS`), project task action smoke (`PASS`), project journey trace archive (`PASS`) | 任务动作与 PM 旅程 trace 已脚本化；后续补长期趋势 |
-| 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`) | 动作回放已脚本化；后续补跨单据状态推进证据 |
+| 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`), material cross-document progress audit (`PASS`) | 跨单据状态推进已脚本化；后续补采购申请到验收链路细化 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Strict scene gate (`PASS`), quality safety closure smoke (`PASS`) | 质量/安全闭环已脚本化；后续补现场日报联动证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
 | 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T09:03:14Z
+- generated_at_utc: 2026-06-30T09:03:40Z
 - branch: `topic/material-cross-document-progress`
-- commit_ref: `6d7393acb`
+- commit_ref: `5af7de140`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -23,6 +23,7 @@ PAYMENT_APPROVAL_CHAIN_REPORT_PATH = ROOT / "artifacts" / "backend" / "payment_r
 PROJECT_TASK_ACTION_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_task_action_smoke.json"
 PROJECT_JOURNEY_TRACE_REPORT_PATH = ROOT / "artifacts" / "backend" / "project_journey_trace_archive.json"
 MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_action_replay_smoke.json"
+MATERIAL_CROSS_DOCUMENT_PROGRESS_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_cross_document_progress_audit.json"
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
 COST_SEARCH_PAGINATION_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
@@ -440,6 +441,11 @@ def main() -> int:
     material_replay_ok = bool(material_replay_payload.get("ok")) if material_replay_present else False
     material_replay_label = _bool_status_label(material_replay_ok) if material_replay_present else "UNKNOWN"
 
+    material_progress_payload = _load_json(MATERIAL_CROSS_DOCUMENT_PROGRESS_REPORT_PATH)
+    material_progress_present = bool(material_progress_payload)
+    material_progress_ok = bool(material_progress_payload.get("ok")) if material_progress_present else False
+    material_progress_label = _bool_status_label(material_progress_ok) if material_progress_present else "UNKNOWN"
+
     executive_readonly_payload = _load_json(EXECUTIVE_READONLY_REPORT_PATH)
     executive_readonly_present = bool(executive_readonly_payload)
     executive_readonly_ok = bool(executive_readonly_payload.get("ok")) if executive_readonly_present else False
@@ -523,6 +529,12 @@ def main() -> int:
         "Material action replay smoke",
         material_replay_label,
         str(MATERIAL_ACTION_REPLAY_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Material cross-document progress audit",
+        material_progress_label,
+        str(MATERIAL_CROSS_DOCUMENT_PROGRESS_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _upsert_evidence_row(
         lines,

--- a/scripts/verify/material_settlement_payment_execution_traceability_audit.py
+++ b/scripts/verify/material_settlement_payment_execution_traceability_audit.py
@@ -3,8 +3,24 @@ import base64
 import json
 import sys
 import traceback
+from datetime import datetime, timezone
+from pathlib import Path
 
 from odoo import fields
+
+
+ROOT = Path("/mnt") if Path("/mnt/artifacts").exists() else Path.cwd()
+REPORT_JSON = ROOT / "artifacts" / "backend" / "material_cross_document_progress_audit.json"
+REPORT_MD = ROOT / "artifacts" / "backend" / "material_cross_document_progress_audit.md"
+
+
+def _utc_now():
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write(path, content):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
 
 
 def _token():
@@ -80,6 +96,105 @@ def _audit_count(record, event_code, action=False):
     if action:
         domain.append(("action", "=", action))
     return env["sc.audit.log"].sudo().search_count(domain)  # noqa: F821
+
+
+def _progress_chain(evidence, failures):
+    ok = not failures
+    return [
+        {
+            "kind": "document_state",
+            "document": "sc.material.settlement",
+            "record_id": evidence.get("settlement") or 0,
+            "from_state": "draft",
+            "to_state": "submitted",
+            "action": "action_submit",
+            "ok": ok and bool(evidence.get("settlement")),
+        },
+        {
+            "kind": "document_state",
+            "document": "sc.material.settlement",
+            "record_id": evidence.get("settlement") or 0,
+            "from_state": "submitted",
+            "to_state": "confirmed",
+            "action": "action_confirm",
+            "ok": ok and bool(evidence.get("settlement")),
+        },
+        {
+            "kind": "downstream_link",
+            "document": "payment.request",
+            "record_id": evidence.get("payment_request") or 0,
+            "source_document": "sc.material.settlement",
+            "source_record_id": evidence.get("settlement") or 0,
+            "action": "material_settlement_confirmed",
+            "ok": ok and bool(evidence.get("payment_request")),
+        },
+        {
+            "kind": "document_state",
+            "document": "payment.request",
+            "record_id": evidence.get("payment_request") or 0,
+            "from_state": "draft",
+            "to_state": "approved",
+            "action": "action_submit/action_on_tier_approved",
+            "ok": ok and bool(evidence.get("payment_request")),
+        },
+        {
+            "kind": "downstream_link",
+            "document": "sc.payment.execution",
+            "record_id": evidence.get("payment_execution") or 0,
+            "source_document": "payment.request",
+            "source_record_id": evidence.get("payment_request") or 0,
+            "action": "action_create_payment_execution",
+            "ok": ok and bool(evidence.get("payment_execution")),
+        },
+        {
+            "kind": "document_state",
+            "document": "sc.payment.execution",
+            "record_id": evidence.get("payment_execution") or 0,
+            "from_state": "draft",
+            "to_state": "paid",
+            "action": "action_confirm/action_paid",
+            "ok": ok and bool(evidence.get("payment_execution")),
+        },
+        {
+            "kind": "downstream_link",
+            "document": "payment.ledger",
+            "record_id": evidence.get("payment_ledger") or 0,
+            "source_document": "payment.request",
+            "source_record_id": evidence.get("payment_request") or 0,
+            "action": "payment_execution_paid",
+            "ok": ok and bool(evidence.get("payment_ledger")),
+        },
+    ]
+
+
+def _to_markdown(result):
+    lines = [
+        "# Material Cross-Document Progress Audit",
+        "",
+        f"- generated_at_utc: {result.get('generated_at_utc', '')}",
+        f"- ok: {result.get('ok')}",
+        f"- status: {result.get('status', '')}",
+        "",
+        "## Progress Chain",
+        "",
+        "| kind | document | record_id | action | ok |",
+        "|---|---|---|---|---|",
+    ]
+    for row in result.get("progress_chain") or []:
+        lines.append(
+            "| {kind} | `{document}` | `{record_id}` | `{action}` | {ok} |".format(
+                kind=row.get("kind", ""),
+                document=row.get("document", ""),
+                record_id=row.get("record_id", ""),
+                action=row.get("action", ""),
+                ok=bool(row.get("ok")),
+            )
+        )
+    failures = result.get("failures") or []
+    if failures:
+        lines.extend(["", "## Failures", ""])
+        lines.extend("- %s" % failure for failure in failures)
+    return "\n".join(lines) + "\n"
 
 
 def _project():
@@ -236,11 +351,22 @@ except Exception as err:
     failures.append(traceback.format_exc())
 
 result = {
+    "generated_at_utc": _utc_now(),
     "audit": "material_settlement_payment_execution_traceability_audit",
+    "ok": not failures,
     "status": "PASS" if not failures else "FAIL",
     "evidence": evidence,
+    "progress_chain": _progress_chain(evidence, failures),
+    "reports": {
+        "json": str(REPORT_JSON.relative_to(ROOT)),
+        "md": str(REPORT_MD.relative_to(ROOT)),
+    },
     "failures": failures,
 }
+_write(REPORT_JSON, json.dumps(result, ensure_ascii=False, indent=2) + "\n")
+_write(REPORT_MD, _to_markdown(result))
+print(REPORT_JSON)
+print(REPORT_MD)
 print("MATERIAL_SETTLEMENT_PAYMENT_EXECUTION_TRACEABILITY_AUDIT: %s" % json.dumps(result, ensure_ascii=False, sort_keys=True))
 if failures:
     print("FAILURES:")


### PR DESCRIPTION
## Summary
- add a delivery Make target for material cross-document progress evidence
- extend the existing material settlement/payment execution traceability audit to write JSON/Markdown artifacts
- wire the new artifact into scoreboard refresh and mark the material Known Limit as script-bound

## Validation
- `python3 -m py_compile scripts/verify/material_settlement_payment_execution_traceability_audit.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.material.cross_document_progress DB_NAME=sc_demo`
- `python3 scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`