### PR TITLE
Add ledger reconciliation trend evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4000,6 +4000,10 @@ verify.delivery.ledger.snapshot: guard.prod.forbid check-compose-project check-c
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/ledger_snapshot_seed.py
 	@ROLE_LEDGER_READONLY_LOGIN=$(or $(ROLE_LEDGER_READONLY_LOGIN),ledger_readonly_smoke) ROLE_LEDGER_READONLY_PASSWORD=$(or $(ROLE_LEDGER_READONLY_PASSWORD),demo) python3 scripts/verify/ledger_snapshot_smoke.py
 
+.PHONY: verify.delivery.ledger.reconciliation_trend
+verify.delivery.ledger.reconciliation_trend: guard.prod.forbid verify.delivery.ledger.snapshot
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/ledger_reconciliation_trend.py
+
 .PHONY: verify.delivery.cost.search_pagination
 verify.delivery.cost.search_pagination: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ROLE_COST_READONLY_LOGIN=$(or $(ROLE_COST_READONLY_LOGIN),cost_readonly_smoke) ROLE_COST_READONLY_PASSWORD=$(or $(ROLE_COST_READONLY_PASSWORD),demo) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/cost_search_pagination_seed.py

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T09:03:40Z
-- branch: `topic/material-cross-document-progress`
-- commit_ref: `5af7de140`
+- generated_at_utc: 2026-06-30T09:07:00Z
+- branch: `topic/ledger-reconciliation-trend`
+- commit_ref: `416002a60`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 
@@ -34,6 +34,7 @@
 | Material cross-document progress audit | PASS | `artifacts/backend/material_cross_document_progress_audit.json` |
 | Executive readonly smoke | PASS | `artifacts/backend/executive_readonly_smoke.json` |
 | Ledger snapshot smoke | PASS | `artifacts/backend/ledger_snapshot_smoke.json` |
+| Ledger reconciliation trend | PASS | `artifacts/backend/ledger_reconciliation_trend.json` |
 | Cost search pagination smoke | PASS | `artifacts/backend/cost_search_pagination_smoke.json` |
 | Quality safety closure smoke | PASS | `artifacts/backend/site_quality_safety_closure_audit.json` |
 | Lifecycle audit export | PASS | `artifacts/backend/lifecycle_audit_export.json` |
@@ -47,7 +48,7 @@
 | 采购与物资协同 | `material.center`, `material.procurement`, `material.inbound`, `labor.request`, `equipment.request`, `subcontract.request` | 采购经理, PM | BOQ、供应商主数据、物资目录 | Strict scene gate (`PASS`), material action replay smoke (`PASS`), material cross-document progress audit (`PASS`) | 跨单据状态推进已脚本化；后续补采购申请到验收链路细化 |
 | 现场执行与质量安全 | `construction.plan`, `construction.plan_report`, `construction.diary`, `quality.center`, `safety.center` | PM, 领导/老板 | 项目、现场执行角色、质量安全基础字典 | Strict scene gate (`PASS`), quality safety closure smoke (`PASS`) | 质量/安全闭环已脚本化；后续补现场日报联动证据 |
 | 付款申请与审批 | `finance.payment_requests`, `finance.center` | 财务, PM | 付款申请、审批角色 | Strict scene gate (`PASS`), payment approval chain smoke (`PASS`) | field consumer audit deprecated refs remain non-strict follow-up |
-| 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`) | 台账快照已脚本化；后续补对账差异趋势证据 |
+| 资金与结算台账 | `finance.payment_ledger`, `finance.treasury_ledger`, `finance.settlement_orders` | 财务 | 账户、结算基础数据 | Strict scene gate (`PASS`), ledger snapshot smoke (`PASS`), ledger reconciliation trend (`PASS`) | 对账差异趋势已脚本化；后续补异常 drill-down 样本 |
 | 成本预算与利润分析 | `cost.project_budget`, `cost.project_cost_ledger`, `cost.profit_compare` | PM, 财务 | 预算、成本流水、BOQ | Strict scene gate (`PASS`), cost search pagination smoke (`PASS`) | 搜索/分页已脚本化；后续补成本偏差趋势证据 |
 | 经营指标与领导看板 | `portal.dashboard`, `finance.operating_metrics` | 领导/老板 | 指标快照数据 | Strict scene gate (`PASS`), executive readonly smoke (`PASS`) | 只读验收已脚本化；后续补长周期趋势证据 |
 | 生命周期与治理审计 | `portal.lifecycle`, `portal.capability_matrix` | 管理员, 领导 | capability/scene baseline | Strict scene gate (`PASS`), lifecycle audit export (`PASS`) | 审计导出已脚本化；后续补长期趋势归档 |

--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-06-30T09:07:00Z
+- generated_at_utc: 2026-06-30T09:07:43Z
 - branch: `topic/ledger-reconciliation-trend`
-- commit_ref: `416002a60`
+- commit_ref: `098d897f8`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 

--- a/scripts/verify/delivery_readiness_scoreboard_refresh.py
+++ b/scripts/verify/delivery_readiness_scoreboard_refresh.py
@@ -26,6 +26,7 @@ MATERIAL_ACTION_REPLAY_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_
 MATERIAL_CROSS_DOCUMENT_PROGRESS_REPORT_PATH = ROOT / "artifacts" / "backend" / "material_cross_document_progress_audit.json"
 EXECUTIVE_READONLY_REPORT_PATH = ROOT / "artifacts" / "backend" / "executive_readonly_smoke.json"
 LEDGER_SNAPSHOT_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
+LEDGER_RECONCILIATION_TREND_REPORT_PATH = ROOT / "artifacts" / "backend" / "ledger_reconciliation_trend.json"
 COST_SEARCH_PAGINATION_REPORT_PATH = ROOT / "artifacts" / "backend" / "cost_search_pagination_smoke.json"
 QUALITY_SAFETY_CLOSURE_REPORT_PATH = ROOT / "artifacts" / "backend" / "site_quality_safety_closure_audit.json"
 LIFECYCLE_AUDIT_EXPORT_REPORT_PATH = ROOT / "artifacts" / "backend" / "lifecycle_audit_export.json"
@@ -456,6 +457,11 @@ def main() -> int:
     ledger_snapshot_ok = bool(ledger_snapshot_payload.get("ok")) if ledger_snapshot_present else False
     ledger_snapshot_label = _bool_status_label(ledger_snapshot_ok) if ledger_snapshot_present else "UNKNOWN"
 
+    ledger_trend_payload = _load_json(LEDGER_RECONCILIATION_TREND_REPORT_PATH)
+    ledger_trend_present = bool(ledger_trend_payload)
+    ledger_trend_ok = bool(ledger_trend_payload.get("ok")) if ledger_trend_present else False
+    ledger_trend_label = _bool_status_label(ledger_trend_ok) if ledger_trend_present else "UNKNOWN"
+
     cost_search_payload = _load_json(COST_SEARCH_PAGINATION_REPORT_PATH)
     cost_search_present = bool(cost_search_payload)
     cost_search_ok = bool(cost_search_payload.get("ok")) if cost_search_present else False
@@ -547,6 +553,12 @@ def main() -> int:
         "Ledger snapshot smoke",
         ledger_snapshot_label,
         str(LEDGER_SNAPSHOT_REPORT_PATH.relative_to(ROOT)),
+    )
+    lines = _upsert_evidence_row(
+        lines,
+        "Ledger reconciliation trend",
+        ledger_trend_label,
+        str(LEDGER_RECONCILIATION_TREND_REPORT_PATH.relative_to(ROOT)),
     )
     lines = _upsert_evidence_row(
         lines,

--- a/scripts/verify/ledger_reconciliation_trend.py
+++ b/scripts/verify/ledger_reconciliation_trend.py
@@ -1,0 +1,229 @@
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+ROOT = Path("/mnt") if Path("/mnt/artifacts").exists() else Path.cwd()
+REPORT_JSON = ROOT / "artifacts" / "backend" / "ledger_reconciliation_trend.json"
+REPORT_MD = ROOT / "artifacts" / "backend" / "ledger_reconciliation_trend.md"
+HISTORY_JSONL = ROOT / "artifacts" / "backend" / "history" / "ledger_reconciliation_trend_samples.jsonl"
+LEDGER_SNAPSHOT_PATH = ROOT / "artifacts" / "backend" / "ledger_snapshot_smoke.json"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _scalar(sql: str, params: tuple = ()):
+    env.cr.execute(sql, params)  # noqa: F821
+    row = env.cr.fetchone()  # noqa: F821
+    return row[0] if row else None
+
+
+def _rows(sql: str, params: tuple = ()) -> list[dict]:
+    env.cr.execute(sql, params)  # noqa: F821
+    columns = [desc[0] for desc in env.cr.description]  # noqa: F821
+    return [dict(zip(columns, row)) for row in env.cr.fetchall()]  # noqa: F821
+
+
+def _num(value) -> float:
+    try:
+        return float(value or 0.0)
+    except Exception:
+        return 0.0
+
+
+def _count(value) -> int:
+    try:
+        return int(value or 0)
+    except Exception:
+        return 0
+
+
+def _state_distribution(table: str) -> list[dict]:
+    return _rows(
+        f"""
+        SELECT COALESCE(state, '') AS state, COUNT(*)::integer AS count
+          FROM {table}
+         GROUP BY COALESCE(state, '')
+         ORDER BY count DESC, state
+        """
+    )
+
+
+def _last_history_sample() -> dict:
+    if not HISTORY_JSONL.is_file():
+        return {}
+    last = ""
+    for line in HISTORY_JSONL.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            last = line
+    if not last:
+        return {}
+    try:
+        payload = json.loads(last)
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _delta(current: dict, previous: dict) -> dict:
+    keys = [
+        "payment_ledger_count",
+        "payment_ledger_missing_request_count",
+        "treasury_ledger_count",
+        "treasury_ledger_source_less_count",
+        "settlement_order_count",
+        "settlement_positive_payable_count",
+        "treasury_reconciliation_count",
+        "treasury_reconciliation_nonzero_difference_count",
+        "treasury_reconciliation_without_ledger_count",
+    ]
+    out = {}
+    for key in keys:
+        out[key] = _count(current.get(key)) - _count(previous.get(key))
+    return out
+
+
+def _to_markdown(payload: dict) -> str:
+    observed = payload.get("observed") if isinstance(payload.get("observed"), dict) else {}
+    trend = payload.get("trend") if isinstance(payload.get("trend"), dict) else {}
+    lines = [
+        "# Ledger Reconciliation Trend",
+        "",
+        f"- generated_at_utc: {payload.get('generated_at_utc', '')}",
+        f"- ok: {payload.get('ok')}",
+        f"- has_previous: {trend.get('has_previous', False)}",
+        "",
+        "## Observed",
+        "",
+        "| metric | value |",
+        "|---|---:|",
+    ]
+    for key in sorted(observed.keys()):
+        value = observed.get(key)
+        if isinstance(value, (int, float)):
+            lines.append(f"| {key} | {value} |")
+    if isinstance(trend.get("delta"), dict):
+        lines.extend(["", "## Delta", "", "| metric | delta |", "|---|---:|"])
+        for key, value in sorted(trend["delta"].items()):
+            lines.append(f"| {key} | {value} |")
+    errors = payload.get("errors") if isinstance(payload.get("errors"), list) else []
+    if errors:
+        lines.extend(["", "## Errors", ""])
+        lines.extend(f"- {item}" for item in errors)
+    return "\n".join(lines) + "\n"
+
+
+errors: list[str] = []
+snapshot = _load_json(LEDGER_SNAPSHOT_PATH)
+if not snapshot:
+    errors.append("ledger_snapshot_smoke_missing")
+elif not bool(snapshot.get("ok")):
+    errors.append("ledger_snapshot_smoke_not_ok")
+
+observed = {
+    "payment_ledger_count": _count(_scalar("SELECT COUNT(*) FROM payment_ledger")),
+    "payment_ledger_amount_sum": _num(_scalar("SELECT COALESCE(SUM(amount), 0.0) FROM payment_ledger")),
+    "payment_ledger_missing_request_count": _count(_scalar("SELECT COUNT(*) FROM payment_ledger WHERE payment_request_id IS NULL")),
+    "treasury_ledger_count": _count(_scalar("SELECT COUNT(*) FROM sc_treasury_ledger")),
+    "treasury_ledger_amount_sum": _num(_scalar("SELECT COALESCE(SUM(amount), 0.0) FROM sc_treasury_ledger WHERE COALESCE(state, '') != 'void'")),
+    "treasury_ledger_source_less_count": _count(
+        _scalar(
+            """
+            SELECT COUNT(*)
+              FROM sc_treasury_ledger
+             WHERE COALESCE(source_model, '') = ''
+               AND COALESCE(payment_request_id, 0) = 0
+               AND COALESCE(settlement_id, 0) = 0
+               AND COALESCE(state, '') != 'void'
+            """
+        )
+    ),
+    "settlement_order_count": _count(_scalar("SELECT COUNT(*) FROM sc_settlement_order")),
+    "settlement_amount_total_sum": _num(_scalar("SELECT COALESCE(SUM(amount_total), 0.0) FROM sc_settlement_order WHERE active IS TRUE")),
+    "settlement_amount_payable_sum": _num(_scalar("SELECT COALESCE(SUM(amount_payable), 0.0) FROM sc_settlement_order WHERE active IS TRUE")),
+    "settlement_positive_payable_count": _count(_scalar("SELECT COUNT(*) FROM sc_settlement_order WHERE active IS TRUE AND COALESCE(amount_payable, 0.0) > 0.0")),
+    "treasury_reconciliation_count": _count(_scalar("SELECT COUNT(*) FROM sc_treasury_reconciliation")),
+    "treasury_reconciliation_nonzero_difference_count": _count(
+        _scalar("SELECT COUNT(*) FROM sc_treasury_reconciliation WHERE COALESCE(system_difference, 0.0) != 0.0")
+    ),
+    "treasury_reconciliation_abs_difference_sum": _num(
+        _scalar("SELECT COALESCE(SUM(ABS(system_difference)), 0.0) FROM sc_treasury_reconciliation")
+    ),
+    "treasury_reconciliation_without_ledger_count": _count(
+        _scalar("SELECT COUNT(*) FROM sc_treasury_reconciliation WHERE treasury_ledger_id IS NULL")
+    ),
+}
+
+if observed["payment_ledger_count"] <= 0:
+    errors.append("payment_ledger_empty")
+if observed["treasury_ledger_count"] <= 0:
+    errors.append("treasury_ledger_empty")
+if observed["settlement_order_count"] <= 0:
+    errors.append("settlement_order_empty")
+if observed["treasury_reconciliation_count"] <= 0:
+    errors.append("treasury_reconciliation_empty")
+if observed["payment_ledger_missing_request_count"] > 0:
+    errors.append("payment_ledger_missing_request_count=%s" % observed["payment_ledger_missing_request_count"])
+
+previous = _last_history_sample()
+trend = {
+    "has_previous": bool(previous),
+    "history_path": str(HISTORY_JSONL.relative_to(ROOT)),
+    "delta": _delta(observed, previous.get("observed") if isinstance(previous.get("observed"), dict) else {}),
+}
+payload = {
+    "generated_at_utc": _utc_now(),
+    "ok": not errors,
+    "audit": "ledger_reconciliation_trend",
+    "db": env.cr.dbname,  # noqa: F821
+    "company_id": int(env.company.id),  # noqa: F821
+    "observed": observed,
+    "state_distribution": {
+        "treasury_ledger": _state_distribution("sc_treasury_ledger"),
+        "treasury_reconciliation": _state_distribution("sc_treasury_reconciliation"),
+        "settlement_order": _state_distribution("sc_settlement_order"),
+    },
+    "snapshot": {
+        "path": str(LEDGER_SNAPSHOT_PATH.relative_to(ROOT)),
+        "ok": bool(snapshot.get("ok")),
+    },
+    "trend": trend,
+    "reports": {
+        "json": str(REPORT_JSON.relative_to(ROOT)),
+        "md": str(REPORT_MD.relative_to(ROOT)),
+    },
+    "errors": errors,
+}
+
+_write(REPORT_JSON, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+_write(REPORT_MD, _to_markdown(payload))
+HISTORY_JSONL.parent.mkdir(parents=True, exist_ok=True)
+with HISTORY_JSONL.open("a", encoding="utf-8") as fh:
+    fh.write(json.dumps({"generated_at_utc": payload["generated_at_utc"], "observed": observed}, ensure_ascii=False, sort_keys=True) + "\n")
+
+print(REPORT_JSON)
+print(REPORT_MD)
+print("[ledger_reconciliation_trend] PASS" if payload["ok"] else "[ledger_reconciliation_trend] FAIL")
+if errors:
+    print(json.dumps(payload, ensure_ascii=False, indent=2))
+    raise SystemExit(1)


### PR DESCRIPTION
## Summary
- add a ledger reconciliation trend audit that records ledger/reconciliation counts, sums, source gaps, and deltas
- wire the audit into Make and delivery readiness scoreboard refresh
- mark the finance ledger Known Limit as script-bound trend evidence

## Validation
- `python3 -m py_compile scripts/verify/ledger_reconciliation_trend.py scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.delivery.ledger.reconciliation_trend DB_NAME=sc_demo`
- `python3 scripts/verify/delivery_readiness_scoreboard_refresh.py`
- `make verify.product.delivery.governance_truth DB_NAME=sc_demo`
- `make verify.docs.inventory verify.docs.temp_guard DB_NAME=sc_demo`
- `git diff --check`