### PR TITLE
[codex] Preserve business list config column order

### DIFF
--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -2936,7 +2936,7 @@ class UiContractV2Handler(BaseIntentHandler):
                 if not isinstance(rows, list):
                     continue
                 normalized_rows = []
-                for row in rows:
+                for index, row in enumerate(rows):
                     if isinstance(row, str):
                         name = str(row or "").strip()
                         label = ""
@@ -2954,8 +2954,8 @@ class UiContractV2Handler(BaseIntentHandler):
                         continue
                     if not name:
                         continue
-                    normalized_rows.append((sequence, name, label, visible))
-                for _sequence, name, label, visible in sorted(normalized_rows, key=lambda item: (item[0], item[1])):
+                    normalized_rows.append((sequence, index, name, label, visible))
+                for _sequence, _index, name, label, visible in sorted(normalized_rows, key=lambda item: (item[0], item[1])):
                     if not visible:
                         direct_orchestration_hidden.add(name)
                         direct_orchestration_columns = [item for item in direct_orchestration_columns if item != name]

--- a/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
+++ b/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
@@ -417,6 +417,62 @@ class TestUiContractV2Boundaries(unittest.TestCase):
             profile_columns,
         )
 
+    def test_business_list_profile_preserves_business_config_column_order(self):
+        class _Config:
+            contract_json = {
+                "view_orchestration": {
+                    "views": {
+                        "tree": {
+                            "columns": [
+                                {"name": "state", "sequence": 10},
+                                {"name": "name", "sequence": 10},
+                                {"name": "project_id", "sequence": 10},
+                            ]
+                        }
+                    }
+                }
+            }
+
+        class _ConfigModel:
+            def _effective_view_orchestration_contracts(self, model_name, view_type, action_id=0):
+                self.request = (model_name, view_type, action_id)
+                return [_Config()]
+
+        class _Env(dict):
+            def __contains__(self, key):
+                return dict.__contains__(self, key)
+
+        config_model = _ConfigModel()
+        handler = self.module.UiContractV2Handler(env=_Env({
+            "ui.business.config.contract": config_model,
+        }))
+        source_contract = {
+            "action_id": 949,
+            "model": "sc.demo",
+            "views": {"tree": {"columns": [{"name": "id"}, {"name": "name"}]}},
+            "list_profile": {},
+        }
+
+        handler._merge_business_list_profile(
+            source_contract,
+            common_fields=["fallback_field"],
+            amount_fields=[],
+            note_field="",
+            status_field="",
+            label_for=lambda name: name,
+            type_for=lambda name: "char",
+        )
+
+        self.assertEqual(config_model.request, ("sc.demo", "tree", 949))
+        self.assertEqual(
+            source_contract["list_profile"]["columns"][:3],
+            ["state", "name", "project_id"],
+        )
+        self.assertEqual(
+            source_contract["views"]["tree"]["columns"][:3],
+            ["state", "name", "project_id"],
+        )
+
     def test_form_structure_contract_uses_generic_slots_not_contract_template(self):
         handler = self.module.UiContractV2Handler(env=object())
         field_types = {


### PR DESCRIPTION
## Summary
- Preserve business list configuration column order when merging direct business view orchestration into the user-visible action contract.
- Add a regression test covering non-alphabetical configured column order flowing into both `list_profile.columns` and `views.tree.columns`.

## Root Cause
The business list profile merge sorted configured columns by `(sequence, field_name)`. When configured rows shared the same sequence, or when older string-style rows used the default sequence, the user-configured order was replaced by field-name order.

## Impact
The list configuration screen could show the user's intended field order while the user-visible handling surface rendered a different column order, reducing the usability of saved list configurations.

## Validation
- `python3 addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `python3 addons/smart_core/tests/test_form_field_configuration_params.py`
- `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `git diff --check`