### PR TITLE
[codex] Keep configured list columns with duplicate labels

### DIFF
--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -3080,7 +3080,9 @@ class UiContractV2Handler(BaseIntentHandler):
                 view_column_labels[name] = label
         labels = {**{name: label_for(name) for name in columns}, **labels, **view_column_labels, **direct_orchestration_labels, **override_labels}
         deduped_columns: list[str] = []
-        preserve_duplicate_labels = bool(columns) and all(str(name or "").startswith("legacy_visible_") for name in columns)
+        preserve_duplicate_labels = bool(direct_orchestration_columns) or (
+            bool(columns) and all(str(name or "").startswith("legacy_visible_") for name in columns)
+        )
         seen_keys: set[str] = set()
         for name in columns:
             label = str(labels.get(name) or label_for(name) or name).strip()

--- a/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
+++ b/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
@@ -473,6 +473,77 @@ class TestUiContractV2Boundaries(unittest.TestCase):
             ["state", "name", "project_id"],
         )
 
+    def test_business_list_profile_keeps_configured_columns_with_duplicate_schema_labels(self):
+        class _Config:
+            contract_json = {
+                "view_orchestration": {
+                    "views": {
+                        "tree": {
+                            "columns": [
+                                {"name": "entry_user_text", "sequence": 10},
+                                {"name": "source_created_by", "sequence": 20},
+                                {"name": "entry_time", "sequence": 30},
+                                {"name": "source_created_at", "sequence": 40},
+                            ]
+                        }
+                    }
+                }
+            }
+
+        class _ConfigModel:
+            def _effective_view_orchestration_contracts(self, model_name, view_type, action_id=0):
+                return [_Config()]
+
+        class _Env(dict):
+            def __contains__(self, key):
+                return dict.__contains__(self, key)
+
+        labels = {
+            "entry_user_text": "录入人",
+            "source_created_by": "来源录入人",
+            "entry_time": "录入时间",
+            "source_created_at": "来源录入时间",
+        }
+        handler = self.module.UiContractV2Handler(env=_Env({
+            "ui.business.config.contract": _ConfigModel(),
+        }))
+        source_contract = {
+            "action_id": 949,
+            "model": "sc.demo",
+            "views": {
+                "tree": {
+                    "columns": [
+                        "entry_user_text",
+                        "source_created_by",
+                        "entry_time",
+                        "source_created_at",
+                    ],
+                    "columns_schema": [
+                        {"name": "entry_user_text", "label": "录入人"},
+                        {"name": "source_created_by", "label": "录入人"},
+                        {"name": "entry_time", "label": "录入时间"},
+                        {"name": "source_created_at", "label": "录入时间"},
+                    ],
+                }
+            },
+            "list_profile": {},
+        }
+
+        handler._merge_business_list_profile(
+            source_contract,
+            common_fields=[],
+            amount_fields=[],
+            note_field="",
+            status_field="",
+            label_for=lambda name: labels.get(name, name),
+            type_for=lambda name: "char",
+        )
+
+        self.assertEqual(
+            source_contract["list_profile"]["columns"],
+            ["entry_user_text", "source_created_by", "entry_time", "source_created_at"],
+        )
+
     def test_form_structure_contract_uses_generic_slots_not_contract_template(self):
         handler = self.module.UiContractV2Handler(env=object())
         field_types = {


### PR DESCRIPTION
## Summary
- Preserve distinct fields from direct business list configuration even when runtime schema labels collide.
- Add a regression test for configured list columns where `entry_user_text/source_created_by` and `entry_time/source_created_at` share schema labels.

## Fact Analysis
For `smart_construction_core.action_construction_contract_income_execution` in `sc_demo`:
- Action: `收入合同执行`, model `construction.contract.income`, action id `751`.
- Configuration audit returned 26 fields, including `source_created_by` and `source_created_at`.
- Before this fix, the user-visible `layoutContract.listProfile.columns` returned only 24 fields and dropped those two configured fields.
- The two fields exist on the model and are available in the list configuration surface.
- Root cause: runtime `columns_schema` labeled `source_created_by/source_created_at` as `录入人/录入时间`, colliding with `entry_user_text/entry_time`. `_merge_business_list_profile` deduped by label, so it removed configured fields even though field names were distinct.

## Impact
Users could configure fields in the list configuration surface, but the handling surface would not show them when schema labels collided. This made configuration appear ineffective for affected fields.

## Validation
- `python3 addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `python3 addons/smart_core/tests/test_form_field_configuration_params.py`
- `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `git diff --check`
- `DB_NAME=sc_demo make odoo.shell.exec` fact check: `收入合同执行` config columns count = 26, UI listProfile columns count = 26, `equal=true`, missing/extra both empty.