### PR TITLE
Enforce business list config authority

### DIFF
--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -2091,6 +2091,10 @@ def smart_core_finalize_projected_contract_data(env, data, context):
         action_id = int(data.get("action_id") or head.get("action_id") or 0)
     except Exception:
         action_id = 0
+    list_profile = data.get("list_profile") if isinstance(data.get("list_profile"), dict) else {}
+    column_policy = list_profile.get("column_policy") if isinstance(list_profile.get("column_policy"), dict) else {}
+    if str(column_policy.get("reason") or "").strip() == "business_list_config_contract_authoritative":
+        return None
     if not action_id or action_id not in _user_confirmed_formal_list_action_ids(env):
         return None
     action = env["ir.actions.act_window"].sudo().browse(action_id)

--- a/addons/smart_construction_core/tests/test_core_extension_v2_finalize.py
+++ b/addons/smart_construction_core/tests/test_core_extension_v2_finalize.py
@@ -132,3 +132,32 @@ class TestCoreExtensionV2Finalize(TransactionCase):
         )
 
         self.assertIsNone(projected)
+
+    def test_projected_data_finalize_does_not_override_business_list_config_columns(self):
+        data = {
+            "model": "project.material.plan",
+            "view_type": "tree",
+            "action_id": 525,
+            "list_profile": {
+                "columns": [
+                    "legacy_visible_01",
+                    "legacy_visible_02",
+                    "source_created_by",
+                    "source_created_at",
+                ],
+                "fact_columns": [
+                    "legacy_visible_01",
+                    "legacy_visible_02",
+                    "source_created_by",
+                    "source_created_at",
+                ],
+                "column_policy": {
+                    "mode": "strict",
+                    "reason": "business_list_config_contract_authoritative",
+                },
+            },
+        }
+
+        projected = core_extension.smart_core_finalize_projected_contract_data(self.env, data, {"view_type": "tree"})
+
+        self.assertIsNone(projected)

--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -277,6 +277,53 @@ class UiContractV2Handler(BaseIntentHandler):
             )
             contract["layoutContract"] = layout_contract
 
+    def _enforce_business_list_config_projection(self, contract: dict[str, Any], source_contract: dict[str, Any]) -> None:
+        if not isinstance(contract, dict) or not isinstance(source_contract, dict):
+            return
+        profile = source_contract.get("list_profile") if isinstance(source_contract.get("list_profile"), dict) else {}
+        policy = profile.get("column_policy") if isinstance(profile.get("column_policy"), dict) else {}
+        if str(policy.get("reason") or "").strip() != "business_list_config_contract_authoritative":
+            return
+        columns = [
+            str(name or "").strip()
+            for name in (profile.get("columns") if isinstance(profile.get("columns"), list) else [])
+            if str(name or "").strip()
+        ]
+        fact_columns = [
+            str(name or "").strip()
+            for name in (profile.get("fact_columns") if isinstance(profile.get("fact_columns"), list) else [])
+            if str(name or "").strip()
+        ]
+        if fact_columns and any(name not in columns for name in fact_columns):
+            columns = list(fact_columns)
+        if not columns:
+            return
+        locked_profile = deepcopy(profile)
+        locked_profile["columns"] = columns
+        locked_profile["fact_columns"] = list(fact_columns or columns)
+        locked_profile["hidden_columns"] = [
+            str(name or "").strip()
+            for name in (locked_profile.get("hidden_columns") if isinstance(locked_profile.get("hidden_columns"), list) else [])
+            if str(name or "").strip() in set(columns)
+        ]
+        pref = locked_profile.get("preference_policy") if isinstance(locked_profile.get("preference_policy"), dict) else {}
+        locked_profile["preference_policy"] = {
+            **pref,
+            "scope": "business_config_contract",
+            "allow_visibility": False,
+            "allow_order": False,
+            "allow_width": bool(pref.get("allow_width", True)),
+            "locked_columns": list(columns),
+            "must_request_columns": list(locked_profile.get("fact_columns") or columns),
+        }
+        layout_contract = contract.get("layoutContract") if isinstance(contract.get("layoutContract"), dict) else {}
+        layout_contract["listProfile"] = self._v2_policy_projection(
+            locked_profile,
+            runtime_carrier="ui.contract.v2.layoutContract.listProfile",
+            source_key="list_profile.business_config_contract_authoritative",
+        )
+        contract["layoutContract"] = layout_contract
+
     def handle(self, payload: Optional[Dict[str, Any]] = None, ctx: Optional[Dict[str, Any]] = None):
         params = self._params(payload)
         client_type = resolve_client_type(self._headers(), params)
@@ -466,6 +513,7 @@ class UiContractV2Handler(BaseIntentHandler):
         self._normalize_general_contract_company_form(contract_v2, source_contract=source_contract)
         self._normalize_construction_diary_form(contract_v2, source_contract=source_contract)
         self._apply_business_config_form_groups_to_v2(contract_v2, source_contract=source_contract)
+        self._enforce_business_list_config_projection(contract_v2, source_contract)
         contract_v2 = trim_unified_page_contract_v2(
             contract_v2,
             client_type=client_type,
@@ -2985,7 +3033,7 @@ class UiContractV2Handler(BaseIntentHandler):
             name = str(row.get("name") or "").strip()
             if name.startswith("legacy_visible_") and name not in legacy_view_columns:
                 legacy_view_columns.append(name)
-        legacy_override = self._scbs55_legacy_visible_list_override(source_contract)
+        legacy_override = None if direct_orchestration_columns else self._scbs55_legacy_visible_list_override(source_contract)
         columns: list[str] = []
         explicit_view_columns: list[str] = []
         has_explicit_view_columns = False
@@ -2996,15 +3044,15 @@ class UiContractV2Handler(BaseIntentHandler):
                 explicit_view_columns.append(name)
                 has_explicit_view_columns = True
         if direct_orchestration_columns:
-            tail = [name for name in columns if name and name not in set(direct_orchestration_columns) and name not in direct_orchestration_hidden]
-            columns = list(direct_orchestration_columns) + tail
+            columns = list(direct_orchestration_columns)
             explicit_view_columns = list(direct_orchestration_columns)
             has_explicit_view_columns = True
         profile = source_contract.get("list_profile") if isinstance(source_contract.get("list_profile"), dict) else {}
-        for name in profile.get("columns") if isinstance(profile.get("columns"), list) else []:
-            normalized = str(name or "").strip()
-            if normalized and normalized not in columns:
-                columns.append(normalized)
+        if not direct_orchestration_columns:
+            for name in profile.get("columns") if isinstance(profile.get("columns"), list) else []:
+                normalized = str(name or "").strip()
+                if normalized and normalized not in columns:
+                    columns.append(normalized)
         column_policy = profile.get("column_policy") if isinstance(profile.get("column_policy"), dict) else {}
         column_policy_mode = str(column_policy.get("mode") or "").strip().lower()
         strict_columns = column_policy_mode == "strict" or (has_explicit_view_columns and column_policy_mode != "extend")
@@ -3145,6 +3193,12 @@ class UiContractV2Handler(BaseIntentHandler):
                 "must_request_columns": columns,
             },
         })
+        if direct_orchestration_columns:
+            profile["column_policy"] = {
+                "mode": "strict",
+                "reason": "business_list_config_contract_authoritative",
+                "owner_layer": "ui.business.config.contract.view_orchestration",
+            }
         source_contract["list_profile"] = profile
 
         if tree:

--- a/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
+++ b/addons/smart_core/tests/test_ui_contract_v2_boundaries.py
@@ -544,6 +544,240 @@ class TestUiContractV2Boundaries(unittest.TestCase):
             ["entry_user_text", "source_created_by", "entry_time", "source_created_at"],
         )
 
+    def test_business_list_profile_prefers_config_over_legacy_visible_override(self):
+        class _Config:
+            contract_json = {
+                "view_orchestration": {
+                    "views": {
+                        "tree": {
+                            "columns": [
+                                {"name": "p1_visible_a", "sequence": 10},
+                                {"name": "p1_visible_b", "sequence": 20},
+                                {"name": "source_created_by", "sequence": 30},
+                                {"name": "source_created_at", "sequence": 40},
+                            ]
+                        }
+                    }
+                }
+            }
+
+        class _ConfigModel:
+            def _effective_view_orchestration_contracts(self, model_name, view_type, action_id=0):
+                return [_Config()]
+
+        class _Env(dict):
+            def __contains__(self, key):
+                return dict.__contains__(self, key)
+
+        handler = self.module.UiContractV2Handler(env=_Env({
+            "ui.business.config.contract": _ConfigModel(),
+        }))
+        handler._scbs55_legacy_visible_list_override = lambda source_contract: {
+            "columns": ["p1_visible_a", "p1_visible_b"],
+            "column_labels": {"p1_visible_a": "单据状态", "p1_visible_b": "项目名称"},
+        }
+        source_contract = {
+            "action_id": 856,
+            "model": "sc.demo",
+            "views": {
+                "tree": {
+                    "columns": ["p1_visible_a", "p1_visible_b", "source_created_by", "source_created_at"],
+                }
+            },
+            "list_profile": {},
+        }
+
+        handler._merge_business_list_profile(
+            source_contract,
+            common_fields=[],
+            amount_fields=[],
+            note_field="",
+            status_field="",
+            label_for=lambda name: name,
+            type_for=lambda name: "char",
+        )
+
+        self.assertEqual(
+            source_contract["list_profile"]["columns"],
+            ["p1_visible_a", "p1_visible_b", "source_created_by", "source_created_at"],
+        )
+        self.assertEqual(
+            source_contract["list_profile"]["column_policy"]["reason"],
+            "business_list_config_contract_authoritative",
+        )
+
+    def test_business_list_profile_does_not_append_native_tail_to_direct_config(self):
+        class _Config:
+            contract_json = {
+                "view_orchestration": {
+                    "views": {
+                        "tree": {
+                            "columns": [
+                                {"name": "contract_name", "sequence": 10},
+                                {"name": "contract_no", "sequence": 20},
+                                {"name": "amount_total", "sequence": 30},
+                            ]
+                        }
+                    }
+                }
+            }
+
+        class _ConfigModel:
+            def _effective_view_orchestration_contracts(self, model_name, view_type, action_id=0):
+                return [_Config()]
+
+        class _Env(dict):
+            def __contains__(self, key):
+                return dict.__contains__(self, key)
+
+        handler = self.module.UiContractV2Handler(env=_Env({
+            "ui.business.config.contract": _ConfigModel(),
+        }))
+        source_contract = {
+            "action_id": 669,
+            "model": "sc.general.contract",
+            "views": {
+                "tree": {
+                    "columns": [
+                        "contract_name",
+                        "contract_no",
+                        "amount_total",
+                        "state",
+                        "project_id",
+                    ],
+                }
+            },
+            "list_profile": {},
+        }
+
+        handler._merge_business_list_profile(
+            source_contract,
+            common_fields=[],
+            amount_fields=[],
+            note_field="",
+            status_field="",
+            label_for=lambda name: name,
+            type_for=lambda name: "char",
+        )
+
+        self.assertEqual(
+            source_contract["list_profile"]["columns"],
+            ["contract_name", "contract_no", "amount_total"],
+        )
+
+    def test_business_list_profile_does_not_extend_direct_config_with_existing_profile(self):
+        class _Config:
+            contract_json = {
+                "view_orchestration": {
+                    "views": {
+                        "tree": {
+                            "columns": [
+                                {"name": "legacy_visible_status", "sequence": 10},
+                                {"name": "legacy_visible_project", "sequence": 20},
+                                {"name": "source_created_by", "sequence": 30},
+                            ]
+                        }
+                    }
+                }
+            }
+
+        class _ConfigModel:
+            def _effective_view_orchestration_contracts(self, model_name, view_type, action_id=0):
+                return [_Config()]
+
+        class _Env(dict):
+            def __contains__(self, key):
+                return dict.__contains__(self, key)
+
+        handler = self.module.UiContractV2Handler(env=_Env({
+            "ui.business.config.contract": _ConfigModel(),
+        }))
+        source_contract = {
+            "action_id": 525,
+            "model": "sc.material.plan",
+            "views": {"tree": {"columns": []}},
+            "list_profile": {
+                "columns": ["name", "project_id", "state"],
+                "column_labels": {"name": "名称", "project_id": "项目", "state": "状态"},
+            },
+        }
+
+        handler._merge_business_list_profile(
+            source_contract,
+            common_fields=["name", "project_id", "state"],
+            amount_fields=[],
+            note_field="remark",
+            status_field="state",
+            label_for=lambda name: name,
+            type_for=lambda name: "char",
+        )
+
+        self.assertEqual(
+            source_contract["list_profile"]["columns"],
+            ["legacy_visible_status", "legacy_visible_project", "source_created_by"],
+        )
+        self.assertEqual(
+            source_contract["list_profile"]["column_policy"]["reason"],
+            "business_list_config_contract_authoritative",
+        )
+
+    def test_business_list_config_projection_enforces_exact_final_columns(self):
+        handler = self.module.UiContractV2Handler(env=object())
+        source_contract = {
+            "list_profile": {
+                "columns": ["name", "source_created_by"],
+                "fact_columns": ["name", "source_created_by"],
+                "column_labels": {"name": "名称", "source_created_by": "来源录入人"},
+                "column_policy": {
+                    "mode": "strict",
+                    "reason": "business_list_config_contract_authoritative",
+                },
+            }
+        }
+        contract = {
+            "layoutContract": {
+                "listProfile": {
+                    "columns": ["name", "source_created_by", "governance_extra"],
+                    "fact_columns": ["name", "source_created_by", "governance_extra"],
+                }
+            }
+        }
+
+        handler._enforce_business_list_config_projection(contract, source_contract)
+
+        profile = contract["layoutContract"]["listProfile"]
+        self.assertEqual(profile["columns"], ["name", "source_created_by"])
+        self.assertEqual(profile["preference_policy"]["locked_columns"], ["name", "source_created_by"])
+        self.assertEqual(profile["sourceAuthority"]["source_key"], "list_profile.business_config_contract_authoritative")
+
+    def test_business_list_config_projection_repairs_columns_from_fact_columns(self):
+        handler = self.module.UiContractV2Handler(env=object())
+        source_contract = {
+            "list_profile": {
+                "columns": ["legacy_visible_01", "legacy_visible_02"],
+                "fact_columns": [
+                    "legacy_visible_01",
+                    "legacy_visible_02",
+                    "source_created_by",
+                    "source_created_at",
+                ],
+                "column_policy": {
+                    "mode": "strict",
+                    "reason": "business_list_config_contract_authoritative",
+                },
+            }
+        }
+        contract = {"layoutContract": {"listProfile": {"columns": ["legacy_visible_01", "legacy_visible_02"]}}}
+
+        handler._enforce_business_list_config_projection(contract, source_contract)
+
+        profile = contract["layoutContract"]["listProfile"]
+        self.assertEqual(
+            profile["columns"],
+            ["legacy_visible_01", "legacy_visible_02", "source_created_by", "source_created_at"],
+        )
+        self.assertEqual(profile["preference_policy"]["locked_columns"], profile["columns"])
+
     def test_form_structure_contract_uses_generic_slots_not_contract_template(self):
         handler = self.module.UiContractV2Handler(env=object())
         field_types = {


### PR DESCRIPTION
## Summary
- Treat `ui.business.config.contract.view_orchestration.views.tree.columns` as the authoritative list-field contract once published.
- Prevent legacy visible overrides, native tree tails, existing generated profiles, and smart_construction projected-data hooks from changing configured list columns.
- Add final `ui.contract.v2` projection enforcement so `layoutContract.listProfile.columns` is locked to the business config contract, with a repair path when an intermediate layer preserved the configured fields only in `fact_columns`.

## Boundary Defined
- Business config source: `ui.business.config.contract.contract_json.view_orchestration.views.tree.columns`.
- Config page/audit source: `BusinessConfigListSearchAuditHandler.business_config_list_columns`.
- User-facing list surface: `ui.contract.v2.layoutContract.listProfile.columns`.
- `sc.user.view.preference` remains UI-only and cannot define formal business list columns.
- Legacy/native/governance defaults only apply when no formal business list config exists.

## Verification
- `python3 addons/smart_core/tests/test_ui_contract_v2_boundaries.py` PASS, 28 tests.
- `python3 addons/smart_core/tests/test_form_field_configuration_params.py` PASS, 61 tests.
- `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/tests/test_ui_contract_v2_boundaries.py addons/smart_construction_core/core_extension.py addons/smart_construction_core/tests/test_core_extension_v2_finalize.py` PASS.
- `git diff --check` PASS.
- Runtime `sc_demo` configured list audit: 309 published tree/list contracts, 308 unique configured action keys, 307 checked list actions, 307 exact matches, 0 mismatches, 1 skipped default non-list entry (`项目驾驶舱`, kanban first).