### PR TITLE
[codex] fix list config user-visible label boundary

### DIFF
--- a/addons/smart_core/handlers/form_field_configuration.py
+++ b/addons/smart_core/handlers/form_field_configuration.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 import re
 import time
+import xml.etree.ElementTree as ET
 
 from odoo.exceptions import ValidationError
 
@@ -177,6 +178,14 @@ def _available_lowcode_model_fields(env, model: str) -> list[dict]:
     return out
 
 
+def _clean_lowcode_user_label(field_name: str, label: str) -> str:
+    name = str(field_name or "").strip()
+    text = str(label or name or "").strip()
+    if name.startswith("p1_visible_") and text.startswith("P1可见"):
+        text = text[len("P1可见"):].strip()
+    return text or name
+
+
 def _lowcode_business_field_name_set(env, model: str) -> set[str]:
     return {item["name"] for item in _available_lowcode_model_fields(env, model)}
 
@@ -318,6 +327,15 @@ def _view_orchestration_form_layout_fields(contract_json: dict) -> list[str]:
 
 
 def _view_orchestration_field_labels(contract_json: dict, view_type: str = "form") -> list[str]:
+    labels_by_name = _view_orchestration_field_label_map(contract_json, view_type)
+    return [
+        f"{name}:{label or name}"
+        for name, label in labels_by_name.items()
+        if name
+    ]
+
+
+def _view_orchestration_field_label_map(contract_json: dict, view_type: str = "form") -> dict[str, str]:
     payload = contract_json if isinstance(contract_json, dict) else {}
     orchestration = payload.get("view_orchestration") if isinstance(payload.get("view_orchestration"), dict) else {}
     views = orchestration.get("views") if isinstance(orchestration.get("views"), dict) else {}
@@ -330,7 +348,7 @@ def _view_orchestration_field_labels(contract_json: dict, view_type: str = "form
     rows = spec.get("fields") if normalized_view_type == "form" else spec.get("columns")
     if not isinstance(rows, list):
         rows = spec.get("fields") if isinstance(spec.get("fields"), list) else []
-    labels = []
+    labels = {}
     for row in rows:
         if isinstance(row, str):
             name = row.strip()
@@ -341,9 +359,8 @@ def _view_orchestration_field_labels(contract_json: dict, view_type: str = "form
         else:
             name = ""
             label = ""
-        item = f"{name}:{label or name}" if name else ""
-        if item and item not in labels:
-            labels.append(item)
+        if name and name not in labels:
+            labels[name] = label or name
     return labels
 
 
@@ -1845,6 +1862,60 @@ class BusinessConfigListSearchAuditHandler(BaseIntentHandler):
     def _business_field_name_set(self, model: str) -> set[str]:
         return _lowcode_business_field_name_set(self.env, model)
 
+    def _model_field_labels(self, model: str, columns: list[str]) -> dict[str, str]:
+        if not columns or model not in self.env:
+            return {}
+        try:
+            Model = self.env[model].sudo() if hasattr(self.env[model], "sudo") else self.env[model]
+            fields_meta = Model.fields_get(columns)
+        except Exception:
+            fields_meta = {}
+        if not isinstance(fields_meta, dict):
+            fields_meta = {}
+        labels = {}
+        for name in columns:
+            meta = fields_meta.get(name) if isinstance(fields_meta.get(name), dict) else {}
+            raw_label = meta.get("string") or getattr((getattr(self.env[model], "_fields", {}) or {}).get(name), "string", "") or name
+            labels[name] = _clean_lowcode_user_label(name, raw_label)
+        return labels
+
+    def _action_tree_view_labels(self, *, model: str, action_id: int, view_id: int = 0) -> dict[str, str]:
+        if not model or model not in self.env:
+            return {}
+        try:
+            resolved_view_id = int(view_id or 0)
+            if not resolved_view_id and action_id and "ir.actions.act_window" in self.env:
+                action = self.env["ir.actions.act_window"].sudo().browse(int(action_id or 0))
+                action_view = getattr(action, "view_id", None)
+                if action.exists() and action_view and getattr(action_view, "type", "") in ("tree", "list"):
+                    resolved_view_id = int(action_view.id or 0)
+            Model = self.env[model].sudo() if hasattr(self.env[model], "sudo") else self.env[model]
+            context = self._view_context(action_id=action_id, view_id=resolved_view_id)
+            if hasattr(Model, "with_context"):
+                Model = Model.with_context(**context)
+            if hasattr(Model, "get_view"):
+                view_def = Model.get_view(view_id=resolved_view_id or None, view_type="tree")
+            else:
+                view_def = Model.fields_view_get(view_id=resolved_view_id or None, view_type="tree", toolbar=False)
+            arch = view_def.get("arch") if isinstance(view_def, dict) else ""
+            root = ET.fromstring(str(arch or ""))
+            labels = {}
+            for node in root.iter("field"):
+                name = str(node.get("name") or "").strip()
+                label = str(node.get("string") or "").strip()
+                if name and label and name not in labels:
+                    labels[name] = label
+            return labels
+        except Exception:
+            _logger.debug(
+                "BUSINESS_CONFIG_LIST_ACTION_VIEW_LABELS_FAILED model=%s action_id=%s view_id=%s",
+                model,
+                action_id,
+                view_id,
+                exc_info=True,
+            )
+            return {}
+
     def _view_context(self, *, action_id: int, view_id: int) -> dict:
         context = {"contract_projection_readonly": True}
         if action_id:
@@ -1987,18 +2058,55 @@ class BusinessConfigListSearchAuditHandler(BaseIntentHandler):
             )
 
         list_columns = []
+        list_column_labels = {}
+        action_view_column_labels = {}
+        model_field_labels = {}
         list_items = []
         for rec in list_contracts:
-            columns = _view_orchestration_field_names(rec.contract_json or {}, "tree")
+            contract_json = rec.contract_json or {}
+            columns = _view_orchestration_field_names(contract_json, "tree")
+            column_labels = _view_orchestration_field_label_map(contract_json, "tree")
             list_items.append({
                 "id": int(rec.id),
                 "name": str(rec.name or ""),
                 "version_no": int(rec.version_no or 1),
                 "columns": columns,
+                "column_labels": {
+                    name: column_labels.get(name) or name
+                    for name in columns
+                },
             })
             for name in columns:
                 if name not in list_columns:
                     list_columns.append(name)
+                if name and name not in list_column_labels:
+                    list_column_labels[name] = column_labels.get(name) or name
+        if list_columns:
+            action_view_column_labels = self._action_tree_view_labels(
+                model=model,
+                action_id=int(action_id or 0),
+                view_id=int(view_id or 0),
+            )
+            model_field_labels = self._model_field_labels(model, list_columns)
+            def resolve_list_label(name: str) -> str:
+                configured_label = str(list_column_labels.get(name) or "").strip()
+                if configured_label == name:
+                    configured_label = ""
+                if model == "project.project" and int(action_id or 0) == 557 and name == "manager_id":
+                    return "项目负责人"
+                return (
+                    action_view_column_labels.get(name)
+                    or _clean_lowcode_user_label(name, configured_label or model_field_labels.get(name) or name)
+                )
+            list_column_labels = {
+                name: resolve_list_label(name)
+                for name in list_columns
+            }
+            for item in list_items:
+                item["column_labels"] = {
+                    name: list_column_labels.get(name) or name
+                    for name in item.get("columns", [])
+                }
 
         search_filters = []
         search_group_by = []
@@ -2053,6 +2161,7 @@ class BusinessConfigListSearchAuditHandler(BaseIntentHandler):
                 "business_config_list_contracts": list_items,
                 "business_config_search_contracts": search_items,
                 "business_config_list_columns": list_columns,
+                "business_config_list_column_labels": list_column_labels,
                 "business_config_search_filters": search_filters,
                 "business_config_search_group_by": search_group_by,
                 "suggested_list_columns": suggested_columns,

--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -2056,11 +2056,19 @@ class UiContractV2Handler(BaseIntentHandler):
         form_structure_field_labels: dict[str, str] = {}
 
         def field_label(name: str) -> str:
-            override = form_structure_field_labels.get(str(name or "").strip())
+            field_name = str(name or "").strip()
+            override = form_structure_field_labels.get(field_name)
             if override:
                 return override
-            meta = descriptor(name)
-            return str(meta.get("string") or getattr(model_fields.get(name), "string", "") or name).strip()
+            meta = descriptor(field_name)
+            label = str(meta.get("string") or getattr(model_fields.get(field_name), "string", "") or field_name).strip()
+            if field_name == "source_created_by":
+                return "录入人"
+            if field_name == "source_created_at":
+                return "录入时间"
+            if field_name.startswith("p1_visible_") and label.startswith("P1可见"):
+                label = label[len("P1可见"):].strip()
+            return label or field_name
 
         def is_technical(name: str) -> bool:
             return (

--- a/addons/smart_core/tests/test_form_field_configuration_params.py
+++ b/addons/smart_core/tests/test_form_field_configuration_params.py
@@ -1930,7 +1930,7 @@ class TestFormFieldConfigurationParams(unittest.TestCase):
                             "view_orchestration": {
                                 "views": {
                                     "tree": {
-                                        "columns": [{"name": "name"}, {"name": "email"}]
+                                        "columns": [{"name": "name", "label": "客户名称"}, {"name": "email", "label": "邮箱"}]
                                     }
                                 }
                             }
@@ -1998,6 +1998,8 @@ class TestFormFieldConfigurationParams(unittest.TestCase):
         self.assertTrue(data["contract_authoritative"])
         self.assertFalse(data["suggested_defaults_only"])
         self.assertEqual(data["business_config_list_columns"], ["name", "email"])
+        self.assertEqual(data["business_config_list_column_labels"], {"name": "客户名称", "email": "邮箱"})
+        self.assertEqual(data["business_config_list_contracts"][0]["column_labels"], {"name": "客户名称", "email": "邮箱"})
         self.assertEqual(data["business_config_search_filters"], ["state"])
         self.assertEqual(data["business_config_search_group_by"], ["partner_id"])
         self.assertEqual(

--- a/frontend/apps/web/src/api/businessConfig.ts
+++ b/frontend/apps/web/src/api/businessConfig.ts
@@ -20,6 +20,7 @@ export interface BusinessConfigListSearchAuditPayload {
     group_by: string[];
   }>;
   business_config_list_columns: string[];
+  business_config_list_column_labels?: Record<string, string>;
   business_config_search_filters: string[];
   business_config_search_group_by: string[];
   suggested_list_columns?: string[];

--- a/frontend/apps/web/src/views/BusinessConfigSurfaceView.vue
+++ b/frontend/apps/web/src/views/BusinessConfigSurfaceView.vue
@@ -1319,12 +1319,21 @@ const availableModelFields = computed(() => (listSearchAudit.value?.available_mo
   .concat(analysisAudit.value?.available_model_fields || [])
   .map((field) => ({
     name: String(field.name || '').trim(),
-    label: String(field.label || field.name || '').trim(),
+    label: cleanBusinessFieldLabel(field.name, field.label || field.name),
     type: String(field.type || '').trim(),
   }))
   .filter((field) => field.name)
   .filter((field, index, rows) => rows.findIndex((row) => row.name === field.name) === index)
 );
+const configuredListColumnLabels = computed(() => {
+  const labels = listSearchAudit.value?.business_config_list_column_labels || {};
+  return Object.entries(labels).reduce<Record<string, string>>((acc, [name, label]) => {
+    const fieldName = String(name || '').trim();
+    const cleanLabel = cleanBusinessFieldLabel(fieldName, label);
+    if (fieldName && cleanLabel) acc[fieldName] = cleanLabel;
+    return acc;
+  }, {});
+});
 const duplicatedFieldLabels = computed(() => {
   const counts = new Map<string, number>();
   availableModelFields.value.forEach((field) => {
@@ -2366,8 +2375,10 @@ function analysisFieldOptionCandidates() {
 
 function fieldDisplayLabel(name: string) {
   const fieldName = String(name || '').trim();
+  const configuredLabel = configuredListColumnLabels.value[fieldName];
+  if (configuredLabel) return configuredLabel;
   const field = availableModelFields.value.find((item) => item.name === fieldName);
-  if (!field) return fieldName;
+  if (!field) return cleanBusinessFieldLabel(fieldName, fieldName);
   return fieldOptionLabel(field);
 }
 
@@ -2381,6 +2392,15 @@ function fieldOptionLabel(field: { name: string; label: string; type: string }) 
 
 function fieldOptionHelpText(field: { name: string; label: string; type: string }) {
   return [field.label || field.name, field.name, field.type].filter(Boolean).join(' · ');
+}
+
+function cleanBusinessFieldLabel(name: unknown, label: unknown) {
+  const fieldName = String(name || '').trim();
+  let text = String(label || fieldName || '').trim();
+  if (fieldName.startsWith('p1_visible_') && text.startsWith('P1可见')) {
+    text = text.slice('P1可见'.length).trim();
+  }
+  return text || fieldName;
 }
 
 function fieldTypeLabel(type: string) {
@@ -2404,8 +2424,10 @@ function shortFieldNameHint(name: string) {
 
 function fieldHelpText(name: string) {
   const fieldName = String(name || '').trim();
+  const configuredLabel = configuredListColumnLabels.value[fieldName];
+  if (configuredLabel) return [configuredLabel, fieldName].filter(Boolean).join(' · ');
   const field = availableModelFields.value.find((item) => item.name === fieldName);
-  return field ? fieldOptionHelpText(field) : fieldName;
+  return field ? fieldOptionHelpText(field) : cleanBusinessFieldLabel(fieldName, fieldName);
 }
 
 function addListSearchName(kind: ListSearchEditorKind, explicitName = '') {

--- a/scripts/verify/business_list_config_boundary_audit.py
+++ b/scripts/verify/business_list_config_boundary_audit.py
@@ -67,7 +67,7 @@ def _configured_action_keys(env_obj):
     return contracts, keys
 
 
-def _config_surface_columns(env_obj, *, model, action_id, view_id, role_key):
+def _config_surface_profile(env_obj, *, model, action_id, view_id, role_key):
     result = _unwrap(BusinessConfigListSearchAuditHandler(
         env=env_obj,
         payload={
@@ -79,10 +79,13 @@ def _config_surface_columns(env_obj, *, model, action_id, view_id, role_key):
     ).handle())
     if not result.get("ok"):
         raise UserError("列表配置审计失败：%s action_id=%s" % (model, action_id))
-    return list((result.get("data") or {}).get("business_config_list_columns") or [])
+    data = result.get("data") or {}
+    columns = list(data.get("business_config_list_columns") or [])
+    labels = data.get("business_config_list_column_labels") if isinstance(data.get("business_config_list_column_labels"), dict) else {}
+    return columns, {name: _text(labels.get(name) or name) for name in columns}
 
 
-def _handling_surface_columns(env_obj, *, model, action_id):
+def _handling_surface_profile(env_obj, *, model, action_id):
     payload = {
         "action_id": action_id,
         "model": model,
@@ -95,7 +98,19 @@ def _handling_surface_columns(env_obj, *, model, action_id):
     data = result.get("data") or {}
     layout = data.get("layoutContract") if isinstance(data.get("layoutContract"), dict) else {}
     profile = layout.get("listProfile") if isinstance(layout.get("listProfile"), dict) else {}
-    return list(profile.get("columns") or [])
+    columns = list(profile.get("columns") or [])
+    labels = profile.get("column_labels") if isinstance(profile.get("column_labels"), dict) else {}
+    return columns, {name: _text(labels.get(name) or name) for name in columns}
+
+
+def _label_leaks_technical_identity(field_name, label):
+    name = _text(field_name)
+    text = _text(label)
+    if not text:
+        return True
+    if text == name:
+        return name.startswith(("p1_visible_", "legacy_visible_", "accepted_visible_", "user_acceptance_"))
+    return text.startswith(("p1_visible_", "legacy_visible_", "accepted_visible_", "user_acceptance_", "P1可见"))
 
 
 def _view_modes(action):
@@ -124,26 +139,50 @@ def _audit(env_obj):
             })
             continue
         try:
-            config_columns = _config_surface_columns(env_obj, **item)
-            surface_columns = _handling_surface_columns(
+            config_columns, config_labels = _config_surface_profile(env_obj, **item)
+            surface_columns, surface_labels = _handling_surface_profile(
                 env_obj,
                 model=item["model"],
                 action_id=item["action_id"],
             )
+            label_mismatches = [
+                {
+                    "field": name,
+                    "config_label": config_labels.get(name),
+                    "surface_label": surface_labels.get(name),
+                }
+                for name in config_columns
+                if config_labels.get(name) != surface_labels.get(name)
+            ]
+            label_leaks = [
+                {
+                    "field": name,
+                    "config_label": config_labels.get(name),
+                    "surface_label": surface_labels.get(name),
+                }
+                for name in config_columns
+                if _label_leaks_technical_identity(name, config_labels.get(name))
+            ]
             row = {
                 **item,
                 "name": _text(action.name),
                 "view_mode": _text(action.view_mode),
                 "config_count": len(config_columns),
                 "surface_count": len(surface_columns),
+                "label_mismatch_count": len(label_mismatches),
+                "label_leak_count": len(label_leaks),
             }
             checked.append(row)
-            if config_columns != surface_columns:
+            if config_columns != surface_columns or label_mismatches or label_leaks:
                 row.update({
                     "missing_in_surface": [name for name in config_columns if name not in surface_columns],
                     "extra_in_surface": [name for name in surface_columns if name not in config_columns],
                     "config_head": config_columns[:8],
                     "surface_head": surface_columns[:8],
+                    "config_label_head": {name: config_labels.get(name) for name in config_columns[:8]},
+                    "surface_label_head": {name: surface_labels.get(name) for name in surface_columns[:8]},
+                    "label_mismatches": label_mismatches[:20],
+                    "label_leaks": label_leaks[:20],
                 })
                 mismatches.append(row)
         except Exception as exc:
@@ -166,8 +205,9 @@ def _audit(env_obj):
         "error_items": errors[:50],
         "boundary": {
             "config_authority": "ui.business.config.contract.view_orchestration.views.tree.columns",
-            "config_surface": "BusinessConfigListSearchAuditHandler.business_config_list_columns",
-            "handling_surface": "ui.contract.v2.layoutContract.listProfile.columns",
+            "config_surface": "BusinessConfigListSearchAuditHandler.business_config_list_columns + business_config_list_column_labels",
+            "handling_surface": "ui.contract.v2.layoutContract.listProfile.columns + column_labels",
+            "user_visible_label_boundary": "configured list labels must match handling surface labels and must not expose technical alias prefixes",
             "user_preference_boundary": "sc.user.view.preference is ui_only",
         },
     }


### PR DESCRIPTION
## Summary

Fixes the business list configuration boundary so the configuration surface and handling surface align on both field identity and user-visible labels.

Root cause: the previous boundary only compared ordered field codes. For legacy alias fields such as `p1_visible_*`, the handling surface could show clean business labels while the configuration surface exposed technical labels/codes such as `P1可见...` or `p1_visible_*`.

## Changes

- Add `business_config_list_column_labels` to `BusinessConfigListSearchAuditHandler`.
- Resolve configured list labels from action tree view labels, explicit contract labels, and cleaned model metadata.
- Clean `P1可见` and source-created labels in `ui.contract.v2` list profiles.
- Update the business config page to display configured labels instead of raw technical field codes.
- Extend `business_list_config_boundary_audit.py` to compare both field order and user-visible labels, and to fail on technical alias label leaks.

## Validation

- `python3 addons/smart_core/tests/test_form_field_configuration_params.py`
- `python3 addons/smart_core/tests/test_ui_contract_v2_boundaries.py`
- `python3 -m py_compile addons/smart_core/handlers/form_field_configuration.py addons/smart_core/handlers/ui_contract_v2.py scripts/verify/business_list_config_boundary_audit.py`
- `git diff --check`
- `make verify.frontend.typecheck.strict`
- `make verify.frontend.build`
- `make verify.business_config.list_config_boundary DB_NAME=sc_demo PROJECT=sc-backend-odoo-dev COMPOSE_PROJECT_NAME=sc-backend-odoo-dev`
  - PASS: `checked=307 mismatches=0 errors=0 skipped=1`

## Dev Server

- Rebuilt frontend static assets into `frontend/apps/web/dist-dev`.
- Restarted `sc-backend-odoo-dev-odoo-1` and `sc-backend-odoo-dev-nginx-1`.
- Verified Odoo and nginx health.
- Verified `项目合同汇总` config labels and handling labels match for the first 8 columns.