### PR TITLE
Fix release policy runtime probe role surface

### DIFF
--- a/scripts/verify/platform_release_policy_runtime_probe.py
+++ b/scripts/verify/platform_release_policy_runtime_probe.py
@@ -24,6 +24,11 @@ from odoo.addons.smart_core.delivery.product_policy_service import ProductPolicy
 PRODUCT_KEYS = ("construction.standard", "construction.preview")
 REPORT_JSON = Path("/tmp/platform_release_policy_runtime_probe.json")
 REPORT_MD = Path("/tmp/platform_release_policy_runtime_probe.md")
+RUNTIME_USER_ROLE_SURFACE = {
+    "role_code": "runtime_user",
+    "is_platform_admin": False,
+    "is_business_config_admin": False,
+}
 
 
 def _env():
@@ -258,19 +263,19 @@ def main():
             user_env,
             product_key=product_key,
             native_nav=native_nav,
-            role_surface={"role_code": "runtime_user"},
+            role_surface=RUNTIME_USER_ROLE_SURFACE,
         )
         no_native_delivery = _delivery_summary(
             user_env,
             product_key=product_key,
             native_nav=[],
-            role_surface={"role_code": "runtime_user"},
+            role_surface=RUNTIME_USER_ROLE_SURFACE,
         )
         subset_delivery = _delivery_summary(
             user_env,
             product_key=product_key,
             native_nav=native_subset,
-            role_surface={"role_code": "runtime_user"},
+            role_surface=RUNTIME_USER_ROLE_SURFACE,
         )
         admin_delivery = _delivery_summary(
             user_env,


### PR DESCRIPTION
## Summary

- make the release policy runtime probe simulate ordinary runtime users with explicit non-admin role flags
- prevent probe-user group drift from turning the no-native/subset checks into business-config-admin delivery
- keep DeliveryEngine and product runtime behavior unchanged

## Verification

- `python3 -m py_compile scripts/verify/platform_release_policy_runtime_probe.py`
- `make verify.platform.release_policy.runtime`
- `make verify.release_v2_0_0.product_hardening` (not run; target name typo guard)
- `make verify.release.v2_0_0.product_hardening`
- `git diff --check`
