### PR TITLE
release: include view richness in hardening

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4296,6 +4296,7 @@ verify.product.release.ready: guard.prod.forbid \
 	verify.product.bundle.isolation \
 	verify.product.tier.enforcement \
 	verify.product.delivery.productization.readiness.strict \
+	verify.frontend.widget_richness.post_ga.guard \
 	verify.ui.product.stability \
 	verify.delivery.reproducible \
 	verify.product.sla.baseline

--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -47,6 +47,10 @@ catalog complete before release.
 The readiness chain also includes `make verify.product.menu.release.ready`, so
 formal product menu changes, system configuration entries, and runtime user
 menu configuration boundaries must pass the menu release gate before release.
+The readiness chain also includes
+`make verify.frontend.widget_richness.post_ga.guard`, so x2many inline editing,
+backend subviews, kanban/view-type semantics, and v2 chatter/attachments
+projection remain part of formal hardening.
 
 The platform performance sub-gate must measure the Web boot path with
 `scene_ready_mode=registry`; full scene hydration remains a deep-link/runtime

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -26,6 +26,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Evidence | Command | Required Result | Artifact |
 |---|---|---|---|
 | Product release readiness | `make verify.release.v2_0_0.product_hardening` | PASS | `artifacts/backend/bundle_installation_report.json` and related product gate artifacts |
+| View richness hardening | included in `make verify.release.v2_0_0.product_hardening` | PASS | `docs/product/view_richness_post_ga_report_v1.md` |
 | Platform performance smoke | included in `make verify.release.v2_0_0.product_hardening` | PASS | `artifacts/backend/platform_performance_smoke.json` |
 
 ## Required Before Formal `v2.0.0`
@@ -45,14 +46,22 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 - Failed evidence is not overwritten without preserving the failure reason in an
   iteration record.
 
-## Current Blocker Status
+## Current Local Verification Status
 
 - Command: `make verify.release.v2_0_0.product_hardening`
-- Status: PASS in the local `sc_demo` dev verification environment.
+- Status: blocked in the current local `sc_demo` dev verification environment
+  because `smart_construction_demo` is installed and
+  `verify.product.no_demo_data` correctly fails release hardening on demo data.
+- Latest passing sub-gate in this batch:
+  `make verify.frontend.widget_richness.post_ga.guard`.
 - Closed sub-gates: `verify.bundle.installation.ready` and
-  `verify.platform.performance.smoke`.
+  `verify.platform.performance.smoke` passed in the prior local hardening run
+  before the demo-data repair step changed `sc_demo`.
+- Release hardening also includes
+  `verify.frontend.widget_richness.post_ga.guard` for x2many, subviews,
+  kanban/view-type semantics, and v2 chatter/attachments projection.
 - Artifacts:
   - `artifacts/backend/bundle_installation_report.json`
   - `artifacts/backend/platform_performance_smoke.json`
 - Note: before creating `gate-release-v2.0` or `v2.0.0-rc1`, rerun required
-  gates on the reviewed release commit and attach the fresh artifacts.
+  gates on a clean reviewed release database and attach the fresh artifacts.


### PR DESCRIPTION
## Summary
- Add `verify.frontend.widget_richness.post_ga.guard` to the formal `verify.product.release.ready` hardening chain.
- Update the v2.0.0 checklist and evidence manifest so view richness hardening is part of formal release evidence.
- Correct the manifest's local status note: the current `sc_demo` run is blocked by installed demo data, so a clean reviewed release DB must rerun full hardening before tags.

## Verification
- `make verify.frontend.widget_richness.post_ga.guard`
- `git diff --check`

## Notes
- `make verify.release.v2_0_0.product_hardening` was attempted and stopped at `verify.product.no_demo_data` because the current local `sc_demo` has `smart_construction_demo` installed. This is now documented rather than reported as green.
