### PR TITLE
Fix project dashboard contract compatibility

### DIFF
--- a/addons/smart_construction_core/core_extension.py
+++ b/addons/smart_construction_core/core_extension.py
@@ -1505,6 +1505,14 @@ def smart_core_register(registry):
     """Legacy loader shim for smart_core.core.extension_loader."""
     if not isinstance(registry, dict):
         return
+    try:
+        from odoo.addons.smart_construction_core.handlers.project_dashboard import (
+            ProjectDashboardHandler,
+        )
+
+        registry["project.dashboard"] = ProjectDashboardHandler
+    except Exception as exc:
+        _logger.warning("[smart_core_register] skip project.dashboard explicit registration: %s", exc)
     for item in get_intent_handler_contributions():
         if not isinstance(item, dict):
             continue

--- a/addons/smart_construction_core/handlers/project_dashboard.py
+++ b/addons/smart_construction_core/handlers/project_dashboard.py
@@ -21,6 +21,22 @@ class ProjectDashboardHandler(ProjectContextResolverMixin, BaseIntentHandler):
     PROJECT_ID_PROJECT_CONTEXT = False
     PROJECT_ID_CTX_RECORD_MODEL_ONLY = "project.project"
 
+    def _resolve_project_id(self, params, ctx):
+        payload = self.payload if isinstance(getattr(self, "payload", None), dict) else {}
+        model = str((ctx or {}).get("model") or "").strip()
+        candidates = [
+            (params or {}).get("project_id"),
+            payload.get("project_id"),
+            (ctx or {}).get("project_id"),
+        ]
+        if model == "project.project":
+            candidates.append((ctx or {}).get("record_id"))
+        for raw in candidates:
+            project_id = self._coerce_project_id(raw)
+            if project_id > 0:
+                return project_id
+        return 0
+
     def handle(self, payload=None, ctx=None):
         params = payload or self.params or {}
         ctx = ctx or {}

--- a/addons/smart_construction_core/services/project_dashboard_service.py
+++ b/addons/smart_construction_core/services/project_dashboard_service.py
@@ -44,6 +44,15 @@ class ProjectDashboardService:
         ("risks", "风险提醒", "deferred"),
         ("next_actions", "下一步动作", "deferred"),
     )
+    ZONE_BLOCKS = (
+        ("header", "项目头部信息", "hero", "stack", "block.project.header"),
+        ("metrics", "关键指标", "primary", "grid", "block.project.metrics"),
+        ("progress", "项目进度", "primary", "stack", "block.project.progress"),
+        ("contract", "合同执行", "secondary", "stack", "block.project.contract"),
+        ("cost", "成本控制", "secondary", "stack", "block.project.cost"),
+        ("finance", "资金情况", "secondary", "stack", "block.project.finance"),
+        ("risk", "风险提醒", "supporting", "stack", "block.project.risk"),
+    )
     RUNTIME_BLOCK_MAP = {
         "progress": "block.project.progress",
         "risks": "block.project.risk",
@@ -96,6 +105,41 @@ class ProjectDashboardService:
         summary_rows = self.build_summary_rows(project)
         flow_map = self.build_flow_map(project)
         completion = self.build_completion(project)
+        zones = {
+            "header": {
+                "project": project_data,
+                "state_explain": state_explain,
+                "resolution": diagnostics,
+            },
+            "metrics": {
+                "items": metrics_explain,
+            },
+            "progress": {
+                "summary_rows": summary_rows,
+                "flow_map": flow_map,
+                "completion": completion,
+                "block": self.build_block("progress", project=project, context=request_context),
+            },
+            "contract": {
+                "summary_rows": [
+                    row for row in summary_rows if str(row.get("key") or "") in {"stage_label", "milestone_label"}
+                ],
+            },
+            "cost": {
+                "summary_rows": [row for row in summary_rows if str(row.get("key") or "") == "cost_total"],
+            },
+            "finance": {
+                "summary_rows": [
+                    row
+                    for row in summary_rows
+                    if str(row.get("key") or "") in {"payment_total", "payment_executed_total"}
+                ],
+                "next_actions": self.build_block("next_actions", project=project, context=request_context),
+            },
+            "risk": {
+                "block": self.build_block("risks", project=project, context=request_context),
+            },
+        }
 
         return {
             "scene": {
@@ -106,11 +150,7 @@ class ProjectDashboardService:
                 "key": "project.management.dashboard",
                 "route": "/s/project.management",
             },
-            "route_context": {
-                "primary_protocol": "/s/project.management?project_id=<id>",
-                "query_key": "project_id",
-                "project_id": int(project_data.get("id") or 0),
-            },
+            "route_context": self._route_context(project),
             "project": project_data,
             "source_authority": self.source_authority_contract(),
             "summary_rows": summary_rows,
@@ -118,41 +158,18 @@ class ProjectDashboardService:
             "metrics_explain": metrics_explain,
             "flow_map": flow_map,
             "completion": completion,
-            "zones": {
-                "header": {
-                    "project": project_data,
-                    "state_explain": state_explain,
-                    "resolution": diagnostics,
-                },
-                "metrics": {
-                    "items": metrics_explain,
-                },
-                "progress": {
-                    "summary_rows": summary_rows,
-                    "flow_map": flow_map,
-                    "completion": completion,
-                    "block": self.build_block("progress", project=project, context=request_context),
-                },
-                "contract": {
-                    "summary_rows": [
-                        row for row in summary_rows if str(row.get("key") or "") in {"stage_label", "milestone_label"}
-                    ],
-                },
-                "cost": {
-                    "summary_rows": [row for row in summary_rows if str(row.get("key") or "") == "cost_total"],
-                },
-                "finance": {
-                    "summary_rows": [
-                        row
-                        for row in summary_rows
-                        if str(row.get("key") or "") in {"payment_total", "payment_executed_total"}
-                    ],
-                    "next_actions": self.build_block("next_actions", project=project, context=request_context),
-                },
-                "risk": {
-                    "block": self.build_block("risks", project=project, context=request_context),
-                },
-            },
+            "zones": zones,
+        }
+
+    def _route_context(self, project):
+        project_id = int(getattr(project, "id", 0) or 0)
+        return {
+            "primary_protocol": "/s/project.management?project_id=<id>",
+            "query_key": "project_id",
+            "scene_route": "/s/project.management",
+            "project_route_template": "/s/project.management?project_id={project_id}",
+            "project_route": "/s/project.management?project_id=%s" % project_id,
+            "project_id": project_id,
         }
 
     def build_block(self, block_key, project=None, context=None):

--- a/docs/contract/project_management_capability_mapping_v2.json
+++ b/docs/contract/project_management_capability_mapping_v2.json
@@ -7,7 +7,7 @@
     {
       "zone_key": "zone.header",
       "block_key": "block.project.header",
-      "capability_key": "project.dashboard.open",
+      "capability_key": "project.dashboard.enter",
       "source_model": "project.project",
       "source_action": "smart_construction_core.action_sc_project_kanban_lifecycle",
       "intent_key": "project.dashboard"
@@ -15,7 +15,7 @@
     {
       "zone_key": "zone.metrics",
       "block_key": "block.project.metrics",
-      "capability_key": "project.dashboard.open",
+      "capability_key": "project.dashboard.enter",
       "source_model": "project.project",
       "source_action": "smart_construction_core.action_project_dashboard",
       "intent_key": "project.dashboard"

--- a/docs/product/workbench_product_acceptance_checklist_v1.en.md
+++ b/docs/product/workbench_product_acceptance_checklist_v1.en.md
@@ -36,8 +36,7 @@ Validate that the workbench has moved from a "capability summary page" to an "ac
 
 ## F. Regression chain
 
-- [ ] `make verify.frontend.build`
-- [ ] `make verify.frontend.typecheck.strict`
-- [ ] `make verify.project.dashboard.contract`
+- [x] `make verify.frontend.build`
+- [x] `make verify.frontend.typecheck.strict`
+- [x] `make verify.project.dashboard.contract`
 - [ ] `make verify.phase_next.evidence.bundle`
-

--- a/docs/product/workbench_product_acceptance_checklist_v1.md
+++ b/docs/product/workbench_product_acceptance_checklist_v1.md
@@ -36,8 +36,7 @@
 
 ## F. 回归链路
 
-- [ ] `make verify.frontend.build`
-- [ ] `make verify.frontend.typecheck.strict`
-- [ ] `make verify.project.dashboard.contract`
+- [x] `make verify.frontend.build`
+- [x] `make verify.frontend.typecheck.strict`
+- [x] `make verify.project.dashboard.contract`
 - [ ] `make verify.phase_next.evidence.bundle`
-

--- a/frontend/apps/web/src/views/ProjectManagementDashboardView.vue
+++ b/frontend/apps/web/src/views/ProjectManagementDashboardView.vue
@@ -333,10 +333,12 @@ function normalizeDatasetByBlock(block: RawBlock) {
     const delayedTasks = asNumber(data.task_overdue);
     const delayedMilestones = asNumber(data.milestone_delay);
     const upcomingDays = asNumber(data.milestone_upcoming_days);
+    const criticalPathHealth = metricStatusLabel(data.critical_path_health);
     return [
       { key: 'completion_percent', label: '总体完成率', value: completion, unit: '%' },
       { key: 'task_done_rate', label: '任务完成率', value: doneRate, unit: '%' },
       { key: 'milestone_progress', label: '里程碑完成率', value: milestoneProgress, unit: '%' },
+      { key: 'critical_path_health', label: '关键路径健康度', value: criticalPathHealth },
       { key: 'task_open', label: '未完成任务', value: openCount, unit: '项' },
       { key: 'task_critical', label: '关键任务', value: criticalTasks, unit: '项' },
       { key: 'task_blocked', label: '阻塞任务', value: blockedTasks, unit: '项' },


### PR DESCRIPTION
## Summary
- Restore project dashboard contract compatibility by adding explicit zone block metadata, route context helper, and runtime chain registration.
- Align project management capability mapping with canonical `project.dashboard.enter` capability keys.
- Surface `critical_path_health` in the Project Management dashboard progress block and update the workbench acceptance checklist for verified regression gates.

## Verification
- PASS: `PYTHONPYCACHEPREFIX=/tmp/sce-pycache make verify.project.dashboard.contract`
- PASS: `make verify.workspace_home.sections_schema.guard verify.workspace_home.orchestration_schema.guard verify.workspace_home.provider_split.guard verify.frontend.workbench_block_migration`
- PASS: `make verify.frontend.typecheck.strict`
- PASS: `make verify.frontend.build`
- FAIL, existing broader gate: `PYTHONPYCACHEPREFIX=/tmp/sce-pycache make verify.phase_next.evidence.bundle` stops at `verify.contract.assembler.semantic.smoke` because `ui.contract.form.user field_count=266 exceeds max=25` for executive and pm roles.
