### PR TITLE
Close phase next evidence bundle gates

### DIFF
--- a/addons/smart_core/handlers/ui_contract_v2.py
+++ b/addons/smart_core/handlers/ui_contract_v2.py
@@ -400,13 +400,7 @@ class UiContractV2Handler(BaseIntentHandler):
             "locked_columns": [],
             "must_request_columns": list(locked_profile.get("fact_columns") or columns),
         }
-        layout_contract = contract.get("layoutContract") if isinstance(contract.get("layoutContract"), dict) else {}
-        layout_contract["listProfile"] = self._v2_policy_projection(
-            locked_profile,
-            runtime_carrier="ui.contract.v2.layoutContract.listProfile",
-            source_key="list_profile.business_config_contract_authoritative",
-        )
-        contract["layoutContract"] = layout_contract
+        self._project_v2_source_policies(contract, {"list_profile": locked_profile})
 
     def _merge_user_list_preference_columns(self, source_contract: dict[str, Any], columns: list[str]) -> list[str]:
         action_id = self._source_action_id(source_contract)

--- a/addons/smart_core/utils/contract_governance.py
+++ b/addons/smart_core/utils/contract_governance.py
@@ -1836,6 +1836,29 @@ def _filter_project_form_layout(data: dict, selected_fields: list[str]) -> None:
     data["views"] = views
 
 
+def _trim_contract_field_maps(data: dict, selected_fields: list[str]) -> None:
+    selected = [_safe_text(name) for name in selected_fields if _safe_text(name)]
+    if not selected:
+        return
+    allowed = set(selected)
+    fields_map = _as_dict(data.get("fields"))
+    if fields_map:
+        data["fields"] = {name: fields_map[name] for name in selected if name in fields_map}
+    field_policies = _as_dict(data.get("field_policies"))
+    if field_policies:
+        data["field_policies"] = {name: field_policies[name] for name in selected if name in field_policies}
+    field_semantics = _as_dict(data.get("field_semantics"))
+    if field_semantics:
+        data["field_semantics"] = {name: field_semantics[name] for name in selected if name in field_semantics}
+    validation_rules = data.get("validation_rules")
+    if isinstance(validation_rules, list):
+        data["validation_rules"] = [
+            row
+            for row in validation_rules
+            if not isinstance(row, dict) or not _safe_text(row.get("field")) or _safe_text(row.get("field")) in allowed
+        ]
+
+
 def _govern_project_form_search(data: dict) -> None:
     search = _as_dict(data.get("search"))
     filters = search.get("filters")
@@ -2019,10 +2042,7 @@ def _build_project_lifecycle_summary(data: dict) -> None:
 
 def _govern_project_form_contract_for_user(data: dict) -> None:
     selected = _pick_project_form_fields(data)
-    fields_map = _as_dict(data.get("fields"))
-    # Keep full field map for native form-structure fidelity. Restricting fields to
-    # selected subset can prune page containers indirectly in user surface.
-    data["fields"] = fields_map
+    _trim_contract_field_maps(data, selected)
     data["visible_fields"] = selected
     views = _as_dict(data.get("views"))
     form = _as_dict(views.get("form"))

--- a/docs/product/workbench_product_acceptance_checklist_v1.en.md
+++ b/docs/product/workbench_product_acceptance_checklist_v1.en.md
@@ -39,4 +39,4 @@ Validate that the workbench has moved from a "capability summary page" to an "ac
 - [x] `make verify.frontend.build`
 - [x] `make verify.frontend.typecheck.strict`
 - [x] `make verify.project.dashboard.contract`
-- [ ] `make verify.phase_next.evidence.bundle`
+- [x] `make verify.phase_next.evidence.bundle`

--- a/docs/product/workbench_product_acceptance_checklist_v1.md
+++ b/docs/product/workbench_product_acceptance_checklist_v1.md
@@ -39,4 +39,4 @@
 - [x] `make verify.frontend.build`
 - [x] `make verify.frontend.typecheck.strict`
 - [x] `make verify.project.dashboard.contract`
-- [ ] `make verify.phase_next.evidence.bundle`
+- [x] `make verify.phase_next.evidence.bundle`

--- a/frontend/apps/web/src/app/contractPolicies.ts
+++ b/frontend/apps/web/src/app/contractPolicies.ts
@@ -45,7 +45,6 @@ type PolicyContext = {
   profile: RenderProfile;
   formData: Record<string, unknown>;
   capabilities: Set<string>;
-  userGroups: Set<string>;
   roleCode: string;
   submittedFields?: Set<string>;
 };
@@ -182,13 +181,6 @@ export function evaluateActionPolicy(
   if (requiredCapabilities.length) {
     const missingCaps = requiredCapabilities.filter((key) => !ctx.capabilities.has(key));
     if (missingCaps.length) enabled = false;
-  }
-  const requiredGroups = Array.isArray(enabledWhen.required_groups)
-    ? enabledWhen.required_groups.map((x) => String(x || '').trim()).filter(Boolean)
-    : [];
-  if (requiredGroups.length) {
-    const matched = requiredGroups.some((group) => ctx.userGroups.has(group));
-    if (!matched) enabled = false;
   }
   const requiredRoles = Array.isArray(enabledWhen.required_roles)
     ? enabledWhen.required_roles.map((x) => String(x || '').trim().toLowerCase()).filter(Boolean)

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -3823,21 +3823,10 @@ const runtimeCapabilities = computed(() => {
   });
   return out;
 });
-const runtimeUserGroups = computed(() => {
-  const out = new Set<string>();
-  const user = (session.user || {}) as Record<string, unknown>;
-  const groups = Array.isArray(user.groups_xmlids) ? user.groups_xmlids : [];
-  groups.forEach((group) => {
-    const key = String(group || '').trim();
-    if (key) out.add(key);
-  });
-  return out;
-});
 const policyContext = computed(() => ({
   profile: renderProfile.value,
   formData: formData as Record<string, unknown>,
   capabilities: runtimeCapabilities.value,
-  userGroups: runtimeUserGroups.value,
   roleCode: runtimeRoleCode.value,
 }));
 


### PR DESCRIPTION
## Summary
- Trim project form user-mode contract field maps to the governed visible field set so semantic smoke no longer exposes the full native model field map.
- Remove ContractFormPage client-side user group checks from generic form policy evaluation; backend entitlement/status contracts remain authoritative.
- Route business list config V2 listProfile projection through the centralized V2 source policy helper and mark the phase-next evidence checklist complete.

## Verification
- PASS: `PYTHONPYCACHEPREFIX=/tmp/sce-pycache make verify.phase_next.evidence.bundle`
- PASS: `VERIFY_CACHE=0 PYTHONPYCACHEPREFIX=/tmp/sce-pycache make verify.contract.assembler.semantic.smoke verify.project.form.contract.surface.guard`
- PASS: `python3 scripts/verify/web_contract_v2_frontend_architecture_guard.py`
- PASS: `python3 scripts/verify/ui_contract_v2_contract_boundary_guard.py`
- PASS: `make verify.frontend.typecheck.strict`
- PASS: `python3 -m py_compile addons/smart_core/handlers/ui_contract_v2.py addons/smart_core/utils/contract_governance.py`
