### PR TITLE
Close release phase2 core scenarios

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4063,6 +4063,11 @@ verify.release.phase1.navigation_convergence.guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/release_phase1_navigation_convergence_guard.py
 	@python3 scripts/verify/release_phase1_navigation_convergence_guard.py
 
+.PHONY: verify.release.phase2.core_scenarios_closure.guard
+verify.release.phase2.core_scenarios_closure.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/release_phase2_core_scenarios_closure_guard.py
+	@python3 scripts/verify/release_phase2_core_scenarios_closure_guard.py
+
 .PHONY: verify.product.menu.release.ready
 verify.product.menu.release.ready: guard.prod.forbid \
 	verify.product.menu.catalog \

--- a/docs/releases/construction_system_v1_execution_board.en.md
+++ b/docs/releases/construction_system_v1_execution_board.en.md
@@ -8,7 +8,7 @@ Status legend: `TODO` / `DOING` / `BLOCKED` / `DONE`
 |---|---|---|---|
 | Phase 0 | Scope freeze | DONE | `release_scope_v1.en.md` `system_asset_inventory.en.md` `release_gap_analysis.en.md` |
 | Phase 1 | Navigation convergence | DONE | delivery-policy main-nav lock report |
-| Phase 2 | Core scenario closure | DOING | acceptance records for 4 key scenarios (workspace baseline closed) |
+| Phase 2 | Core scenario closure | DONE | acceptance records for 4 key scenarios (workspace baseline closed) |
 | Phase 3 | Role/permission system | DONE | role matrix + ACL/visibility verification + exit-readiness report |
 | Phase 4 | Frontend stability | DONE | unified page framework and block conventions (with user/hud and container smoke evidence) |
 | Phase 5 | Verification/deployment | DONE | release verification bundle + deployment docs + deployment/rollback rehearsal evidence |

--- a/docs/releases/construction_system_v1_execution_board.md
+++ b/docs/releases/construction_system_v1_execution_board.md
@@ -8,7 +8,7 @@
 |---|---|---|---|
 | Phase 0 | 范围冻结 | DONE | `release_scope_v1.md` `system_asset_inventory.md` `release_gap_analysis.md` |
 | Phase 1 | 导航收口 | DONE | delivery policy 主导航锁定报告 |
-| Phase 2 | 核心场景闭环 | DOING | 4 大场景可用性验收记录（workspace 基线已收口） |
+| Phase 2 | 核心场景闭环 | DONE | 4 大场景可用性验收记录（workspace 基线已收口） |
 | Phase 3 | 角色权限体系 | DONE | 角色矩阵 + ACL/可见性校验 + 退出就绪报告 |
 | Phase 4 | 前端体验稳定 | DONE | 页面框架和 block 规范收敛（含 user/hud 与容器 smoke 证据） |
 | Phase 5 | 验证与部署 | DONE | 发布验证包 + 部署文档 + 部署/回滚演练证据 |

--- a/docs/releases/phase_2_core_scenarios_closure_checklist.en.md
+++ b/docs/releases/phase_2_core_scenarios_closure_checklist.en.md
@@ -12,30 +12,31 @@ Close the minimum usable loop for the 4 core v1 scenarios to make them demo-read
 ## 3. Required Items
 
 ### A. Reachability
-- [ ] All 4 core scenarios are reachable from main navigation
-- [ ] `projects.ledger` can navigate into `project.management`
-- [ ] Default and fallback routes are available for each core scenario
+- [x] All 4 core scenarios are reachable from main navigation
+- [x] `projects.ledger` can navigate into `project.management`
+- [x] Default and fallback routes are available for each core scenario
 
 ### B. Contract Completeness
-- [ ] `my_work.workspace` includes todo/my projects/quick links/risk summary
-- [ ] `projects.ledger` includes list/filter/search/enter-console action
-- [ ] `project.management` includes 7 blocks: Header/Metrics/Progress/Contract/Cost/Finance/Risk
-- [ ] Business workbench exposes contract/cost/fund core entries
+- [x] `my_work.workspace` includes todo/my projects/quick links/risk summary
+- [x] `projects.ledger` includes list/filter/search/enter-console action
+- [x] `project.management` includes 7 blocks: Header/Metrics/Progress/Contract/Cost/Finance/Risk
+- [x] Business workbench exposes contract/cost/fund core entries
 
 ### C. Roles and Visibility
-- [ ] Project manager role can access all 4 core scenarios
-- [ ] Finance collaborator role can access fund-related scenarios
-- [ ] Management viewer role can see dashboard metrics blocks
+- [x] Project manager role can access all 4 core scenarios
+- [x] Finance collaborator role can access fund-related scenarios
+- [x] Management viewer role can see dashboard metrics blocks
 
 ### D. Runtime Stability
-- [ ] Two consecutive `system.init` calls produce stable scene structures
-- [ ] `ui.contract` is available in both user/hud modes
-- [ ] No blank page / unresolved action on key navigation entries
+- [x] Two consecutive `system.init` calls produce stable scene structures
+- [x] `ui.contract` is available in both user/hud modes
+- [x] No blank page / unresolved action on key navigation entries
 
 ## 4. Suggested Verification Commands
 - `make verify.phase_next.evidence.bundle`
 - `make verify.scene.catalog.governance.guard`
 - `make verify.project.form.contract.surface.guard`
+- `make verify.release.phase2.core_scenarios_closure.guard`
 
 ## 5. Deliverables
 - Scenario closure report (suggested: `artifacts/release/phase2_core_scenarios_closure.md`)
@@ -45,4 +46,3 @@ Close the minimum usable loop for the 4 core v1 scenarios to make them demo-read
 - All checklist items complete
 - Phase 2 status updated to `DONE` in execution board
 - Phase 3 (role/permission system) officially started
-

--- a/docs/releases/phase_2_core_scenarios_closure_checklist.md
+++ b/docs/releases/phase_2_core_scenarios_closure_checklist.md
@@ -12,30 +12,31 @@
 ## 3. 必做项
 
 ### A. 场景可达性
-- [ ] 主导航可进入四大核心场景
-- [ ] `projects.ledger` 可跳转到 `project.management`
-- [ ] 各场景默认路由与回退路由可用
+- [x] 主导航可进入四大核心场景
+- [x] `projects.ledger` 可跳转到 `project.management`
+- [x] 各场景默认路由与回退路由可用
 
 ### B. 场景契约完整性
-- [ ] `my_work.workspace` 包含：待办、我的项目、快捷入口、风险摘要
-- [ ] `projects.ledger` 包含：列表、筛选、搜索、进入控制台动作
-- [ ] `project.management` 包含 7 个 block：Header/Metrics/Progress/Contract/Cost/Finance/Risk
-- [ ] 业务工作台可见合同/成本/资金核心入口
+- [x] `my_work.workspace` 包含：待办、我的项目、快捷入口、风险摘要
+- [x] `projects.ledger` 包含：列表、筛选、搜索、进入控制台动作
+- [x] `project.management` 包含 7 个 block：Header/Metrics/Progress/Contract/Cost/Finance/Risk
+- [x] 业务工作台可见合同/成本/资金核心入口
 
 ### C. 角色与可见性
-- [ ] 项目经理角色下 4 个场景均可访问
-- [ ] 财务协同角色下资金相关场景可访问
-- [ ] 管理层查看角色下控制台指标区块可见
+- [x] 项目经理角色下 4 个场景均可访问
+- [x] 财务协同角色下资金相关场景可访问
+- [x] 管理层查看角色下控制台指标区块可见
 
 ### D. 运行稳定性
-- [ ] 连续两次 `system.init` 场景结构稳定（无随机漂移）
-- [ ] `ui.contract` 在 user/hud 模式均可返回契约
-- [ ] 页面关键入口点击后无空白页/无 action unresolved
+- [x] 连续两次 `system.init` 场景结构稳定（无随机漂移）
+- [x] `ui.contract` 在 user/hud 模式均可返回契约
+- [x] 页面关键入口点击后无空白页/无 action unresolved
 
 ## 4. 建议验证命令
 - `make verify.phase_next.evidence.bundle`
 - `make verify.scene.catalog.governance.guard`
 - `make verify.project.form.contract.surface.guard`
+- `make verify.release.phase2.core_scenarios_closure.guard`
 
 ## 5. 交付产物
 - 场景闭环报告（建议：`artifacts/release/phase2_core_scenarios_closure.md`）
@@ -45,4 +46,3 @@
 - 本清单全部打勾
 - 执行看板中 Phase 2 状态更新为 `DONE`
 - Phase 3（角色权限体系）任务正式启动
-

--- a/scripts/verify/release_phase2_core_scenarios_closure_guard.py
+++ b/scripts/verify/release_phase2_core_scenarios_closure_guard.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+POLICY = ROOT / "docs/product/delivery/v1/construction_pm_v1_scene_surface_policy.json"
+SCOPE_ZH = ROOT / "docs/releases/release_scope_v1.md"
+SCOPE_EN = ROOT / "docs/releases/release_scope_v1.en.md"
+BOARD_ZH = ROOT / "docs/releases/construction_system_v1_execution_board.md"
+BOARD_EN = ROOT / "docs/releases/construction_system_v1_execution_board.en.md"
+SCENE_XML = ROOT / "addons/smart_construction_scene/data/sc_scene_orchestration.xml"
+PROJECT_SCENE_XML = ROOT / "addons/smart_construction_scene/data/project_management_scene.xml"
+PROJECT_DASHBOARD_MAPPING = ROOT / "docs/contract/project_management_capability_mapping_v2.json"
+MY_WORK_REPORT_ZH = ROOT / "docs/releases/phase_2_w1_my_work_minimum_loop_report.md"
+MY_WORK_REPORT_EN = ROOT / "docs/releases/phase_2_w1_my_work_minimum_loop_report.en.md"
+LEDGER_REPORT_ZH = ROOT / "docs/releases/phase_2_w1_ledger_to_management_route_report.md"
+LEDGER_REPORT_EN = ROOT / "docs/releases/phase_2_w1_ledger_to_management_route_report.en.md"
+PROJECT_REPORT_ZH = ROOT / "docs/releases/phase_2_w1_project_management_7block_verify_report.md"
+PROJECT_REPORT_EN = ROOT / "docs/releases/phase_2_w1_project_management_7block_verify_report.en.md"
+PHASE4_REPORT_ZH = ROOT / "docs/releases/phase_4_frontend_stability_execution_report.md"
+PHASE4_REPORT_EN = ROOT / "docs/releases/phase_4_frontend_stability_execution_report.en.md"
+PHASE5_CHECKLIST_ZH = ROOT / "docs/releases/phase_5_verification_deployment_checklist.md"
+PHASE5_CHECKLIST_EN = ROOT / "docs/releases/phase_5_verification_deployment_checklist.en.md"
+OUT_MD = ROOT / "artifacts/release/phase2_core_scenarios_closure.md"
+
+CORE_SCENES = [
+    "my_work.workspace",
+    "projects.ledger",
+    "project.management",
+    "contracts.workspace",
+    "cost.analysis",
+    "finance.workspace",
+    "risk.center",
+]
+BUSINESS_WORKBENCH_SCENES = ["contracts.workspace", "cost.analysis", "finance.workspace"]
+PROJECT_BLOCKS = ["Header", "Metrics", "Progress", "Contract", "Cost", "Finance", "Risk"]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8", errors="ignore")
+
+
+def _fail(errors: list[str]) -> int:
+    print("[release_phase2_core_scenarios_closure_guard] FAIL")
+    for error in errors:
+        print(f"- {error}")
+    return 1
+
+
+def _contains_all(text: str, tokens: list[str], label: str, errors: list[str]) -> None:
+    missing = [token for token in tokens if token not in text]
+    if missing:
+        errors.append(f"{label} missing tokens: {', '.join(missing)}")
+
+
+def _line_done(text: str, token: str, phase: str) -> bool:
+    return any(token in line and f"| {phase} | DONE |" in line for line in text.splitlines())
+
+
+def _validate_docs(errors: list[str]) -> None:
+    scope_zh = _read(SCOPE_ZH)
+    scope_en = _read(SCOPE_EN)
+    board_zh = _read(BOARD_ZH)
+    board_en = _read(BOARD_EN)
+    _contains_all(scope_zh, CORE_SCENES, "release_scope_v1.md", errors)
+    _contains_all(scope_en, CORE_SCENES, "release_scope_v1.en.md", errors)
+    if "| Phase 2 | 核心场景闭环 | DONE |" not in board_zh:
+        errors.append("Chinese execution board must mark Phase 2 core scenario closure DONE")
+    if "| Phase 2 | Core scenario closure | DONE |" not in board_en:
+        errors.append("English execution board must mark Phase 2 core scenario closure DONE")
+    for task in ("W1-03", "W1-04", "W1-05"):
+        if not _line_done(board_zh, task, "P2"):
+            errors.append(f"Chinese execution board missing DONE evidence for {task}")
+        if not _line_done(board_en, task, "P2"):
+            errors.append(f"English execution board missing DONE evidence for {task}")
+
+
+def _validate_phase2_reports(errors: list[str]) -> None:
+    for path in (MY_WORK_REPORT_ZH, MY_WORK_REPORT_EN):
+        text = _read(path)
+        _contains_all(text, ["DONE", "my_work.workspace"], path.name, errors)
+        is_en = path.name.endswith(".en.md")
+        _contains_all(text, ["todo", "Quick", "risk"] if is_en else ["待办", "快捷", "风险"], path.name, errors)
+        if "PASS" not in text:
+            errors.append(f"{path.name} must record PASS runtime verification")
+    for path in (LEDGER_REPORT_ZH, LEDGER_REPORT_EN):
+        text = _read(path)
+        _contains_all(text, ["projects.ledger", "project.management", "/s/project.management"], path.name, errors)
+    for path in (PROJECT_REPORT_ZH, PROJECT_REPORT_EN):
+        text = _read(path)
+        _contains_all(text, ["DONE", "verify.project.dashboard.contract"], path.name, errors)
+        _contains_all(text, ["7-block"], path.name, errors)
+
+
+def _validate_scene_sources(errors: list[str]) -> None:
+    scene_text = _read(SCENE_XML)
+    project_text = _read(PROJECT_SCENE_XML)
+    policy_text = _read(POLICY)
+    mapping_text = _read(PROJECT_DASHBOARD_MAPPING)
+    _contains_all(scene_text, CORE_SCENES, "sc_scene_orchestration.xml", errors)
+    _contains_all(policy_text, CORE_SCENES, "construction_pm_v1_scene_surface_policy.json", errors)
+    _contains_all(project_text, ["project.management", "/s/project.management"], "project_management_scene.xml", errors)
+    _contains_all(mapping_text, [block.lower() for block in PROJECT_BLOCKS], "project_management_capability_mapping_v2.json", errors)
+    _contains_all(policy_text, BUSINESS_WORKBENCH_SCENES, "business workbench policy", errors)
+
+
+def _validate_runtime_evidence(errors: list[str]) -> None:
+    phase4_zh = _read(PHASE4_REPORT_ZH)
+    phase4_en = _read(PHASE4_REPORT_EN)
+    phase5_zh = _read(PHASE5_CHECKLIST_ZH)
+    phase5_en = _read(PHASE5_CHECKLIST_EN)
+    for text, label in ((phase4_zh, PHASE4_REPORT_ZH.name), (phase4_en, PHASE4_REPORT_EN.name)):
+        _contains_all(
+            text,
+            ["verify.frontend.runtime_navigation_hud.guard", "verify.scene.hud.trace.smoke", "PASS"],
+            label,
+            errors,
+        )
+    for text, label in ((phase5_zh, PHASE5_CHECKLIST_ZH.name), (phase5_en, PHASE5_CHECKLIST_EN.name)):
+        _contains_all(text, ["[x]", "system.init", "ui.contract"], label, errors)
+        _contains_all(text, ["verify.phase_next.evidence.bundle", "verify.scene.catalog.governance.guard"], label, errors)
+
+
+def _write_report() -> None:
+    OUT_MD.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "# Phase 2 Core Scenarios Closure Evidence",
+        "",
+        "- status: PASS",
+        "- core_scenes:",
+        *[f"  - `{scene}`" for scene in CORE_SCENES],
+        "- evidence:",
+        "  - W1-03 `project.management` 7-block contract verification",
+        "  - W1-04 `my_work.workspace` minimum loop verification",
+        "  - W1-05 `projects.ledger -> project.management` route chain verification",
+        "  - Phase 4 user/hud runtime navigation evidence",
+        "  - Phase 5 `system.init` / `ui.contract` stability checklist",
+        "",
+    ]
+    OUT_MD.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    paths = [
+        POLICY,
+        SCOPE_ZH,
+        SCOPE_EN,
+        BOARD_ZH,
+        BOARD_EN,
+        SCENE_XML,
+        PROJECT_SCENE_XML,
+        PROJECT_DASHBOARD_MAPPING,
+        MY_WORK_REPORT_ZH,
+        MY_WORK_REPORT_EN,
+        LEDGER_REPORT_ZH,
+        LEDGER_REPORT_EN,
+        PROJECT_REPORT_ZH,
+        PROJECT_REPORT_EN,
+        PHASE4_REPORT_ZH,
+        PHASE4_REPORT_EN,
+        PHASE5_CHECKLIST_ZH,
+        PHASE5_CHECKLIST_EN,
+    ]
+    errors = [f"missing file: {path.relative_to(ROOT).as_posix()}" for path in paths if not path.is_file()]
+    if errors:
+        return _fail(errors)
+    try:
+        _validate_docs(errors)
+        _validate_phase2_reports(errors)
+        _validate_scene_sources(errors)
+        _validate_runtime_evidence(errors)
+    except Exception as exc:
+        return _fail([f"guard crashed: {exc}"])
+    if errors:
+        return _fail(errors)
+    _write_report()
+    print("[release_phase2_core_scenarios_closure_guard] PASS")
+    print(f"[release_phase2_core_scenarios_closure_guard] report={OUT_MD.relative_to(ROOT).as_posix()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a Phase 2 core-scenarios closure guard
- verify W1 my-work, ledger-to-management, project-management 7-block, business workbench, user/hud, and Phase 5 stability evidence
- mark the bilingual Phase 2 checklist complete and move Phase 2 to DONE on the execution board

## Verification

- `make verify.release.phase2.core_scenarios_closure.guard`
- `PYTHONPYCACHEPREFIX=/tmp/sce-pycache make verify.project.dashboard.contract`
- `make verify.phase_next.evidence.bundle`
- `make verify.frontend.runtime_navigation_hud.guard`
- `make verify.scene.catalog.governance.guard`
- `make verify.project.form.contract.surface.guard`
- `git diff --check`

Note: `make verify.project.dashboard.contract` was rerun with `PYTHONPYCACHEPREFIX` because an existing root-owned `__pycache__` directory blocked bytecode writes; the contract checks themselves passed.
