### PR TITLE
Persist no-demo hardening blocker evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4313,7 +4313,15 @@ verify.lowcode_config.runtime_boundary.guard: guard.prod.forbid check-compose-pr
 
 .PHONY: verify.product.no_demo_data
 verify.product.no_demo_data: guard.prod.forbid check-compose-project check-compose-env
-	@$(RUN_ENV) PRODUCT_REQUIRE_NO_DEMO_DATA=1 DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py
+	@mkdir -p artifacts/backend
+	@status=0; \
+	$(RUN_ENV) PRODUCT_REQUIRE_NO_DEMO_DATA=1 \
+		NON_DEMO_DATA_CONTAMINATION_GUARD_JSON=/tmp/non_demo_data_contamination_guard.json \
+		NON_DEMO_DATA_CONTAMINATION_GUARD_MD=/tmp/non_demo_data_contamination_guard.md \
+		DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py || status=$$?; \
+	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.json artifacts/backend/non_demo_data_contamination_guard.json >/dev/null 2>&1 || true; \
+	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.md artifacts/backend/non_demo_data_contamination_guard.md >/dev/null 2>&1 || true; \
+	exit $$status
 
 verify.product.surface.clean: guard.prod.forbid verify.product.capability.matrix.ready verify.runtime_contract.test_placeholder.guard verify.lowcode_config.boundary.guard verify.lowcode_config.runtime_boundary.guard verify.product.no_demo_data
 	@echo "[OK] verify.product.surface.clean done"

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -52,6 +52,12 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 - Status: blocked in the current local `sc_demo` dev verification environment
   because `smart_construction_demo` is installed and
   `verify.product.no_demo_data` correctly fails release hardening on demo data.
+- Current blocker evidence:
+  `artifacts/backend/non_demo_data_contamination_guard.json` and
+  `artifacts/backend/non_demo_data_contamination_guard.md`.
+- Current blocker facts on `sc_demo`:
+  `smart_construction_demo installed`, `res.partner active demo-name count=3`,
+  and `smart_construction_demo xmlid count=112`.
 - Latest passing sub-gate in this batch:
   `make verify.frontend.widget_richness.post_ga.guard`.
 - Closed sub-gates: `verify.bundle.installation.ready` and

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -58,6 +58,13 @@
   - Rejects treating the original 23 migration asset packages as the full user data baseline.
   - Ensures P1 industry modules do not carry P2 real-user data payloads such as `legacy_user_sc_*` or `user_master_v1.xml`.
   - Ensures form preference initializers do not perform hidden data dictionary creation or partner backfill.
+- `make verify.product.no_demo_data`
+  - Formal release hardening sub-gate used by `verify.product.surface.clean`.
+  - Forces no-demo mode even on development databases; demo databases may skip only when the command is not run with `PRODUCT_REQUIRE_NO_DEMO_DATA=1`.
+  - Fails when demo environment flags, `smart_construction_demo`, demo XMLIDs, or active demo-name business records remain.
+  - Copies runtime evidence back from the Odoo container even when the guard fails:
+    - `artifacts/backend/non_demo_data_contamination_guard.json`
+    - `artifacts/backend/non_demo_data_contamination_guard.md`
 - `make verify.user_module.data_baseline.runtime_audit`
   - Runtime acceptance after installing/upgrading `smart_construction_custom` on a target database.
   - Replays the legacy user data baseline twice and verifies user count, XMLID count, and duplicate-login safety remain stable.

--- a/scripts/verify/non_demo_data_contamination_guard.py
+++ b/scripts/verify/non_demo_data_contamination_guard.py
@@ -1,9 +1,13 @@
 # Run with scripts/ops/odoo_shell_exec.sh.
+import json
 import os
+from pathlib import Path
 
 DEMO_DBS = {"sc_demo", "sc_test"}
 DEMO_NAME_TOKENS = ("演示", "示例", "某某", "空壳对照", "Demo-")
 DEMO_XMLID_MODULES = ("smart_construction_demo",)
+REPORT_JSON = Path(os.environ.get("NON_DEMO_DATA_CONTAMINATION_GUARD_JSON", "/tmp/non_demo_data_contamination_guard.json"))
+REPORT_MD = Path(os.environ.get("NON_DEMO_DATA_CONTAMINATION_GUARD_MD", "/tmp/non_demo_data_contamination_guard.md"))
 
 
 def _is_demo_db():
@@ -29,9 +33,48 @@ def _is_truthy(value):
     return str(value or "").strip() in {"1", "true", "True", "yes", "YES"}
 
 
+def _write_report(status, mode, errors=None):
+    errors = list(errors or [])
+    payload = {
+        "ok": status == "PASS" or status == "SKIP",
+        "status": status,
+        "db_name": str(env.cr.dbname or ""),
+        "mode": mode,
+        "require_no_demo_data": require_no_demo_data,
+        "errors": errors,
+        "demo_db_auto_skip": _is_demo_db() and not require_no_demo_data,
+        "rules": {
+            "forbidden_config": ["sc.login.env=demo", "sc.bootstrap.mode=demo"],
+            "forbidden_module": "smart_construction_demo installed",
+            "forbidden_xmlid_modules": list(DEMO_XMLID_MODULES),
+            "demo_name_tokens": list(DEMO_NAME_TOKENS),
+        },
+    }
+    REPORT_JSON.parent.mkdir(parents=True, exist_ok=True)
+    REPORT_JSON.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    lines = [
+        "# Non-Demo Data Contamination Guard",
+        "",
+        f"- status: {status}",
+        f"- db_name: `{payload['db_name']}`",
+        f"- mode: `{mode}`",
+        f"- require_no_demo_data: `{str(require_no_demo_data).lower()}`",
+        f"- error_count: {len(errors)}",
+        "",
+        "## Errors",
+        "",
+    ]
+    if errors:
+        lines.extend(f"- {error}" for error in errors)
+    else:
+        lines.append("- none")
+    REPORT_MD.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
 require_no_demo_data = _is_truthy(os.environ.get("PRODUCT_REQUIRE_NO_DEMO_DATA"))
 
 if _is_demo_db() and not require_no_demo_data:
+    _write_report("SKIP", "demo-db-default-skip")
     print("[non_demo_data_contamination_guard] SKIP demo db", env.cr.dbname)
 else:
     errors = []
@@ -58,10 +101,12 @@ else:
         errors.append(f"smart_construction_demo xmlid count={imd_count}")
 
     if errors:
+        _write_report("FAIL", "forced" if require_no_demo_data else "default", errors)
         print("[non_demo_data_contamination_guard] FAIL")
         for error in errors:
             print(" -", error)
         raise SystemExit(2)
 
     mode = "forced" if require_no_demo_data else "default"
+    _write_report("PASS", mode)
     print("[non_demo_data_contamination_guard] PASS db=%s mode=%s" % (env.cr.dbname, mode))


### PR DESCRIPTION
## Summary

- persist `verify.product.no_demo_data` runtime evidence even when the guard fails
- copy no-demo contamination JSON/MD reports back from the Odoo container
- document the current v2.0.0 product-hardening blocker and evidence paths

## Verification

- `python3 -m py_compile scripts/verify/non_demo_data_contamination_guard.py`
- `make verify.product.no_demo_data` returns status 2 on current `sc_demo` and writes blocker evidence
- `git diff --check`
