### PR TITLE
Persist default non-demo audit evidence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2212,8 +2212,17 @@ demo.full: guard.prod.forbid check-compose-project check-compose-env
 seed.run: check-compose-project check-compose-env
 	@$(RUN_ENV) STEPS=$(STEPS) bash scripts/seed/run.sh
 
+.PHONY: verify.non_demo_data_contamination
 verify.non_demo_data_contamination: check-compose-project check-compose-env
-	@$(RUN_ENV) DB_NAME=$(DB_NAME) scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py
+	@mkdir -p artifacts/backend
+	@status=0; \
+	$(RUN_ENV) \
+		NON_DEMO_DATA_CONTAMINATION_GUARD_JSON=/tmp/non_demo_data_contamination_guard.json \
+		NON_DEMO_DATA_CONTAMINATION_GUARD_MD=/tmp/non_demo_data_contamination_guard.md \
+		DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py || status=$$?; \
+	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.json artifacts/backend/non_demo_data_contamination_guard.json >/dev/null 2>&1 || true; \
+	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.md artifacts/backend/non_demo_data_contamination_guard.md >/dev/null 2>&1 || true; \
+	exit $$status
 
 audit.project.actions: guard.prod.danger check-compose-project check-compose-env
 	@$(RUN_ENV) OUT=$(OUT) bash scripts/ops/audit_project_actions.sh

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -58,6 +58,12 @@
   - Rejects treating the original 23 migration asset packages as the full user data baseline.
   - Ensures P1 industry modules do not carry P2 real-user data payloads such as `legacy_user_sc_*` or `user_master_v1.xml`.
   - Ensures form preference initializers do not perform hidden data dictionary creation or partner backfill.
+- `make verify.non_demo_data_contamination`
+  - Default non-demo contamination audit for a selected `DB_NAME`.
+  - Demo databases such as `sc_demo` may return `SKIP`; release hardening must use `make verify.product.no_demo_data` instead.
+  - Copies runtime evidence back from the Odoo container for SKIP/PASS/FAIL:
+    - `artifacts/backend/non_demo_data_contamination_guard.json`
+    - `artifacts/backend/non_demo_data_contamination_guard.md`
 - `make verify.product.no_demo_data`
   - Formal release hardening sub-gate used by `verify.product.surface.clean`.
   - Forces no-demo mode even on development databases; demo databases may skip only when the command is not run with `PRODUCT_REQUIRE_NO_DEMO_DATA=1`.


### PR DESCRIPTION
## Summary

- persist evidence for the default `verify.non_demo_data_contamination` audit entry
- keep default audit semantics unchanged: demo DBs may return `SKIP`
- document the difference between default audit and formal no-demo hardening

## Verification

- `make verify.non_demo_data_contamination`
- `python3 -m py_compile scripts/verify/non_demo_data_contamination_guard.py`
- `make verify.product.no_demo_data` returns status 2 on current `sc_demo`
- `git diff --check`
