### PR TITLE
Guard no-demo contamination evidence schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2222,6 +2222,8 @@ verify.non_demo_data_contamination: check-compose-project check-compose-env
 		DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py || status=$$?; \
 	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.json artifacts/backend/non_demo_data_contamination_guard.json >/dev/null 2>&1 || true; \
 	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.md artifacts/backend/non_demo_data_contamination_guard.md >/dev/null 2>&1 || true; \
+	schema_status=0; python3 scripts/verify/non_demo_data_contamination_guard_schema_guard.py || schema_status=$$?; \
+	if [ "$$status" -eq 0 ]; then status=$$schema_status; fi; \
 	exit $$status
 
 audit.project.actions: guard.prod.danger check-compose-project check-compose-env
@@ -4330,7 +4332,14 @@ verify.product.no_demo_data: guard.prod.forbid check-compose-project check-compo
 		DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/non_demo_data_contamination_guard.py || status=$$?; \
 	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.json artifacts/backend/non_demo_data_contamination_guard.json >/dev/null 2>&1 || true; \
 	$(RUN_ENV) $(COMPOSE_BASE) cp $(ODOO_SERVICE):/tmp/non_demo_data_contamination_guard.md artifacts/backend/non_demo_data_contamination_guard.md >/dev/null 2>&1 || true; \
+	schema_status=0; python3 scripts/verify/non_demo_data_contamination_guard_schema_guard.py || schema_status=$$?; \
+	if [ "$$status" -eq 0 ]; then status=$$schema_status; fi; \
 	exit $$status
+
+.PHONY: verify.product.no_demo_data.schema.guard
+verify.product.no_demo_data.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/non_demo_data_contamination_guard_schema_guard.py
+	@python3 scripts/verify/non_demo_data_contamination_guard_schema_guard.py
 
 verify.product.surface.clean: guard.prod.forbid verify.product.capability.matrix.ready verify.runtime_contract.test_placeholder.guard verify.lowcode_config.boundary.guard verify.lowcode_config.runtime_boundary.guard verify.product.no_demo_data
 	@echo "[OK] verify.product.surface.clean done"

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -55,6 +55,8 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 - Current blocker evidence:
   `artifacts/backend/non_demo_data_contamination_guard.json` and
   `artifacts/backend/non_demo_data_contamination_guard.md`.
+- Evidence shape guard:
+  `make verify.product.no_demo_data.schema.guard`.
 - Current blocker facts on `sc_demo`:
   `smart_construction_demo installed`, `res.partner active demo-name count=3`,
   and `smart_construction_demo xmlid count=112`.

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -64,6 +64,7 @@
   - Copies runtime evidence back from the Odoo container for SKIP/PASS/FAIL:
     - `artifacts/backend/non_demo_data_contamination_guard.json`
     - `artifacts/backend/non_demo_data_contamination_guard.md`
+  - Runs `make verify.product.no_demo_data.schema.guard` after copying evidence.
 - `make verify.product.no_demo_data`
   - Formal release hardening sub-gate used by `verify.product.surface.clean`.
   - Forces no-demo mode even on development databases; demo databases may skip only when the command is not run with `PRODUCT_REQUIRE_NO_DEMO_DATA=1`.
@@ -71,6 +72,9 @@
   - Copies runtime evidence back from the Odoo container even when the guard fails:
     - `artifacts/backend/non_demo_data_contamination_guard.json`
     - `artifacts/backend/non_demo_data_contamination_guard.md`
+- `make verify.product.no_demo_data.schema.guard`
+  - Verifies the no-demo contamination JSON/MD report shape.
+  - Enforces `ok/status/db_name/mode/require_no_demo_data/errors/demo_db_auto_skip/rules` fields in JSON and required Markdown summary tokens.
 - `make verify.user_module.data_baseline.runtime_audit`
   - Runtime acceptance after installing/upgrading `smart_construction_custom` on a target database.
   - Replays the legacy user data baseline twice and verifies user count, XMLID count, and duplicate-login safety remain stable.

--- a/scripts/verify/non_demo_data_contamination_guard_schema_guard.py
+++ b/scripts/verify/non_demo_data_contamination_guard_schema_guard.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "non_demo_data_contamination_guard.json"
+REPORT_MD = ROOT / "artifacts" / "backend" / "non_demo_data_contamination_guard.md"
+STATUSES = {"PASS", "FAIL", "SKIP"}
+MODES = {"default", "forced", "demo-db-default-skip"}
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main() -> int:
+    payload = _load_json(REPORT_JSON)
+    errors: list[str] = []
+
+    if not payload:
+        errors.append(f"missing or invalid json: {REPORT_JSON.relative_to(ROOT).as_posix()}")
+    else:
+        if not isinstance(payload.get("ok"), bool):
+            errors.append("ok must be bool")
+        if payload.get("status") not in STATUSES:
+            errors.append("status must be PASS|FAIL|SKIP")
+        if not isinstance(payload.get("db_name"), str):
+            errors.append("db_name must be string")
+        if payload.get("mode") not in MODES:
+            errors.append("mode must be default|forced|demo-db-default-skip")
+        if not isinstance(payload.get("require_no_demo_data"), bool):
+            errors.append("require_no_demo_data must be bool")
+        if not isinstance(payload.get("errors"), list):
+            errors.append("errors must be list")
+        elif not all(isinstance(item, str) for item in payload["errors"]):
+            errors.append("errors entries must be strings")
+        if not isinstance(payload.get("demo_db_auto_skip"), bool):
+            errors.append("demo_db_auto_skip must be bool")
+
+        rules = payload.get("rules")
+        if not isinstance(rules, dict):
+            errors.append("rules must be object")
+        else:
+            for key in ("forbidden_config", "forbidden_xmlid_modules", "demo_name_tokens"):
+                value = rules.get(key)
+                if not isinstance(value, list) or not all(isinstance(item, str) for item in value):
+                    errors.append(f"rules.{key} must be string list")
+            if not isinstance(rules.get("forbidden_module"), str):
+                errors.append("rules.forbidden_module must be string")
+
+        if payload.get("status") == "FAIL" and payload.get("ok") is not False:
+            errors.append("FAIL report must set ok=false")
+        if payload.get("status") in {"PASS", "SKIP"} and payload.get("ok") is not True:
+            errors.append("PASS/SKIP report must set ok=true")
+        if payload.get("status") == "SKIP" and payload.get("demo_db_auto_skip") is not True:
+            errors.append("SKIP report must set demo_db_auto_skip=true")
+
+    if not REPORT_MD.is_file():
+        errors.append(f"missing markdown report: {REPORT_MD.relative_to(ROOT).as_posix()}")
+    else:
+        md_text = REPORT_MD.read_text(encoding="utf-8")
+        for token in ("# Non-Demo Data Contamination Guard", "- status:", "- error_count:", "## Errors"):
+            if token not in md_text:
+                errors.append(f"markdown report missing token: {token}")
+
+    if errors:
+        print("[non_demo_data_contamination_guard_schema_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+
+    print("[non_demo_data_contamination_guard_schema_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a schema guard for no-demo contamination JSON/MD evidence
- run the schema guard after both default audit and formal no-demo hardening evidence copy
- document the schema guard in verify docs and v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/non_demo_data_contamination_guard.py scripts/verify/non_demo_data_contamination_guard_schema_guard.py`
- `make verify.non_demo_data_contamination`
- `make verify.product.no_demo_data.schema.guard`
- `make verify.product.no_demo_data` returns status 2 on current `sc_demo` while schema guard passes
- `git diff --check`
