### PR TITLE
Guard delivery mainline summary schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4287,6 +4287,7 @@ verify.product.delivery.mainline: guard.prod.forbid
 	  --action-closure $$ACTION_STATUS \
 	  --module-capability $$MODULE9_STATUS \
 	  --governance $$GOVERNANCE_STATUS; \
+	python3 scripts/verify/delivery_mainline_run_summary_schema_guard.py; \
 		$(MAKE) --no-print-directory refresh.delivery.readiness.scoreboard >/dev/null; \
 		python3 -c "import json, pathlib; p=pathlib.Path('artifacts/backend/delivery_readiness_ci_summary.json'); d=json.loads(p.read_text(encoding='utf-8')) if p.is_file() else {}; o=d.get('overall') if isinstance(d.get('overall'), dict) else {}; print(f\"[verify.product.delivery.mainline] overall_ok={o.get('ok')} policy={o.get('policy')}\")"; \
 	if [ "$$FRONTEND_STATUS" = "PASS" ] && [ "$$SCENE_STATUS" = "PASS" ] && [ "$$ACTION_STATUS" = "PASS" ] && [ "$$MODULE9_STATUS" = "PASS" ] && [ "$$CONTRACT_CLOSURE_STATUS" = "PASS" ] && [ "$$GOVERNANCE_STATUS" = "PASS" ]; then \
@@ -4295,6 +4296,11 @@ verify.product.delivery.mainline: guard.prod.forbid
 	  echo "[FAIL] verify.product.delivery.mainline"; \
 	  exit 1; \
 	fi
+
+.PHONY: verify.product.delivery.mainline.summary.schema.guard
+verify.product.delivery.mainline.summary.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/delivery_mainline_run_summary_schema_guard.py
+	@python3 scripts/verify/delivery_mainline_run_summary_schema_guard.py
 
 .PHONY: export.product.delivery.package
 export.product.delivery.package: guard.prod.forbid

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -10,6 +10,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | System capability baseline | `make verify.system.capability_baseline.report` | PASS | `artifacts/backend/system_capability_baseline_report.json` |
 | Backend contract closure | `make verify.backend.contract.closure.mainline` | PASS | `artifacts/backend/backend_contract_closure_mainline_summary.json` |
 | Restricted product mainline | `make verify.restricted` | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
+| Restricted product mainline schema | `make verify.product.delivery.mainline.summary.schema.guard` | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
 | Diff hygiene | `git diff --check` | PASS | terminal output |
 
 ## Required Before `v2.0.0-rc1`

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -150,6 +150,9 @@
   - Emits run summary artifacts:
     - `artifacts/backend/delivery_mainline_run_summary.json`
     - `artifacts/backend/delivery_mainline_run_summary.md`
+- `make verify.product.delivery.mainline.summary.schema.guard`
+  - Verifies delivery mainline JSON/MD summary shape.
+  - Enforces branch/commit/profile metadata, required step statuses, and `ok` consistency with all required steps.
 - `make verify.product.delivery.action_closure.smoke`
   - Verifies action/search/workflow/validation closure signals for delivery high-frequency scenes.
   - Current focus scenes:

--- a/scripts/verify/delivery_mainline_run_summary_schema_guard.py
+++ b/scripts/verify/delivery_mainline_run_summary_schema_guard.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / "artifacts" / "backend" / "delivery_mainline_run_summary.json"
+REPORT_MD = ROOT / "artifacts" / "backend" / "delivery_mainline_run_summary.md"
+ALLOWED_STATUS = {"PASS", "FAIL", "SKIP"}
+REQUIRED_STEPS = (
+    "frontend_gate",
+    "scene_delivery_readiness",
+    "action_closure_smoke",
+    "module_capability_smoke",
+    "module9_smoke",
+    "governance_truth",
+)
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main() -> int:
+    payload = _load_json(REPORT_JSON)
+    errors: list[str] = []
+
+    if not payload:
+        errors.append(f"missing or invalid json: {REPORT_JSON.relative_to(ROOT).as_posix()}")
+    else:
+        for key in ("generated_at_utc", "branch", "commit_ref", "profile"):
+            if not isinstance(payload.get(key), str) or not payload.get(key):
+                errors.append(f"{key} must be non-empty string")
+        if not isinstance(payload.get("ok"), bool):
+            errors.append("ok must be bool")
+
+        steps = payload.get("steps")
+        if not isinstance(steps, dict):
+            errors.append("steps must be object")
+        else:
+            for key in REQUIRED_STEPS:
+                if steps.get(key) not in ALLOWED_STATUS:
+                    errors.append(f"steps.{key} must be PASS|FAIL|SKIP")
+            if steps.get("module9_smoke") != steps.get("module_capability_smoke"):
+                errors.append("steps.module9_smoke must mirror steps.module_capability_smoke")
+            expected_ok = all(steps.get(key) == "PASS" for key in REQUIRED_STEPS)
+            if isinstance(payload.get("ok"), bool) and payload["ok"] != expected_ok:
+                errors.append("ok must match all required steps PASS")
+
+    if not REPORT_MD.is_file():
+        errors.append(f"missing markdown report: {REPORT_MD.relative_to(ROOT).as_posix()}")
+    else:
+        md_text = REPORT_MD.read_text(encoding="utf-8")
+        for token in (
+            "# Delivery Mainline Run Summary",
+            "- generated_at_utc:",
+            "- branch:",
+            "- commit_ref:",
+            "| step | status |",
+            "| governance_truth |",
+        ):
+            if token not in md_text:
+                errors.append(f"markdown report missing token: {token}")
+
+    if errors:
+        print("[delivery_mainline_run_summary_schema_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+
+    print("[delivery_mainline_run_summary_schema_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add a schema guard for `delivery_mainline_run_summary` JSON/MD artifacts
- run the schema guard immediately after writing the mainline summary
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `make verify.product.delivery.mainline.summary.schema.guard`
- `python3 scripts/verify/delivery_mainline_run_summary.py --profile restricted --frontend PASS --scene PASS --action-closure PASS --module-capability PASS --governance PASS`
- `python3 scripts/verify/delivery_mainline_run_summary_schema_guard.py`
- `git diff --check`
