### PR TITLE
Guard backend contract closure snapshot schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4223,11 +4223,18 @@ verify.product.delivery.module9.smoke: verify.product.delivery.module_capability
 verify.backend.contract.closure.guard: guard.prod.forbid
 	@python3 scripts/verify/backend_contract_closure_guard.py
 	@python3 scripts/verify/backend_contract_closure_snapshot_guard.py
+	@python3 scripts/verify/backend_contract_closure_snapshot_schema_guard.py
 	@python3 scripts/verify/intent_canonical_alias_snapshot_guard.py
 
 .PHONY: verify.backend.contract.closure.snapshot.guard
 verify.backend.contract.closure.snapshot.guard: guard.prod.forbid
 	@python3 scripts/verify/backend_contract_closure_snapshot_guard.py
+	@python3 scripts/verify/backend_contract_closure_snapshot_schema_guard.py
+
+.PHONY: verify.backend.contract.closure.snapshot.schema.guard
+verify.backend.contract.closure.snapshot.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_schema_guard.py
+	@python3 scripts/verify/backend_contract_closure_snapshot_schema_guard.py
 
 .PHONY: verify.intent.canonical_alias.snapshot.guard
 verify.intent.canonical_alias.snapshot.guard: guard.prod.forbid
@@ -4246,6 +4253,7 @@ verify.backend.contract.closure.mainline: guard.prod.forbid
 	if ! python3 scripts/verify/backend_contract_closure_guard.py; then STRUCTURE=FAIL; fi; \
 	echo "[verify.backend.contract.closure.mainline] step=closure_snapshot_guard"; \
 	if ! python3 scripts/verify/backend_contract_closure_snapshot_guard.py; then SNAPSHOT=FAIL; fi; \
+	if ! python3 scripts/verify/backend_contract_closure_snapshot_schema_guard.py; then SNAPSHOT=FAIL; fi; \
 	echo "[verify.backend.contract.closure.mainline] step=intent_alias_snapshot_guard"; \
 	if ! python3 scripts/verify/intent_canonical_alias_snapshot_guard.py; then ALIAS=FAIL; fi; \
 	python3 scripts/verify/backend_contract_closure_mainline_summary.py --structure $$STRUCTURE --snapshot $$SNAPSHOT --alias $$ALIAS; \

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -12,6 +12,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Platform release policy runtime | `make verify.platform.release_policy.runtime` | PASS | `artifacts/backend/platform_release_policy_runtime_probe.json` |
 | Platform release policy runtime schema | `make verify.platform.release_policy.runtime.schema.guard` | PASS | `artifacts/backend/platform_release_policy_runtime_probe.json` |
 | Backend contract closure | `make verify.backend.contract.closure.mainline` | PASS | `artifacts/backend/backend_contract_closure_mainline_summary.json` |
+| Backend contract closure snapshot schema | `make verify.backend.contract.closure.snapshot.schema.guard` | PASS | `artifacts/backend/backend_contract_closure_snapshot.json` |
 | Restricted product mainline | `make verify.restricted` | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
 | Restricted product mainline schema | `make verify.product.delivery.mainline.summary.schema.guard` | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
 | Diff hygiene | `git diff --check` | PASS | terminal output |

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -178,6 +178,9 @@
 - `make verify.system.capability_baseline.report.schema.guard`
   - Verifies the system capability baseline JSON/MD report shape.
   - Enforces baseline metadata, summary/check count consistency, sorted checks, and required Markdown sections.
+- `make verify.backend.contract.closure.snapshot.schema.guard`
+  - Verifies the backend contract closure snapshot artifact shape.
+  - Enforces meta intent and scene governance payload key lists are non-empty, sorted, and duplicate-free.
 - `make verify.platform.release_policy.runtime.schema.guard`
   - Verifies the platform release-policy runtime probe JSON/MD shape.
   - Enforces product coverage, policy/catalog counts, user/no-native/subset/admin delivery summaries, and failure consistency.

--- a/scripts/verify/backend_contract_closure_snapshot_schema_guard.py
+++ b/scripts/verify/backend_contract_closure_snapshot_schema_guard.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ARTIFACT = ROOT / "artifacts" / "backend" / "backend_contract_closure_snapshot.json"
+REQUIRED_SECTIONS = ("meta_intent_catalog", "scene_governance_v1")
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def main() -> int:
+    payload = _load_json(ARTIFACT)
+    errors: list[str] = []
+
+    if not payload:
+        errors.append(f"missing or invalid artifact: {ARTIFACT.relative_to(ROOT).as_posix()}")
+    else:
+        for section in REQUIRED_SECTIONS:
+            value = payload.get(section)
+            if not isinstance(value, dict):
+                errors.append(f"{section} must be object")
+                continue
+            keys = value.get("payload_keys")
+            if not isinstance(keys, list) or not all(isinstance(item, str) for item in keys):
+                errors.append(f"{section}.payload_keys must be string list")
+                continue
+            if not keys:
+                errors.append(f"{section}.payload_keys must be non-empty")
+            if keys != sorted(keys):
+                errors.append(f"{section}.payload_keys must be sorted")
+            if len(keys) != len(set(keys)):
+                errors.append(f"{section}.payload_keys must not contain duplicates")
+
+    if errors:
+        print("[backend_contract_closure_snapshot_schema_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+
+    print("[backend_contract_closure_snapshot_schema_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
