### PR TITLE
Guard product hardening evidence schemas

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3952,6 +3952,12 @@ verify.phasex.operating.summary: guard.prod.forbid
 
 verify.bundle.installation.ready: guard.prod.forbid
 	@python3 scripts/verify/bundle_installation_ready.py
+	@python3 scripts/verify/product_hardening_schema_guard.py --report bundle
+
+.PHONY: verify.bundle.installation.ready.schema.guard
+verify.bundle.installation.ready.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/product_hardening_schema_guard.py
+	@python3 scripts/verify/product_hardening_schema_guard.py --report bundle
 
 verify.product.tier.ready: guard.prod.forbid
 	@python3 scripts/verify/product_tier_ready.py
@@ -4464,6 +4470,12 @@ verify.contract.compat: guard.prod.forbid
 
 verify.platform.performance.smoke: guard.prod.forbid
 	@python3 scripts/verify/platform_performance_smoke.py
+	@python3 scripts/verify/product_hardening_schema_guard.py --report performance
+
+.PHONY: verify.platform.performance.smoke.schema.guard
+verify.platform.performance.smoke.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/product_hardening_schema_guard.py
+	@python3 scripts/verify/product_hardening_schema_guard.py --report performance
 
 verify.platform.maturity.ready: guard.prod.forbid \
 	verify.platform.distribution.ready \

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -34,8 +34,10 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Evidence | Command | Required Result | Artifact |
 |---|---|---|---|
 | Product release readiness | `make verify.release.v2_0_0.product_hardening` | PASS | `artifacts/backend/bundle_installation_report.json` and related product gate artifacts |
+| Bundle installation schema | `make verify.bundle.installation.ready.schema.guard` | PASS | `artifacts/backend/bundle_installation_report.json` |
 | View richness hardening | included in `make verify.release.v2_0_0.product_hardening` | PASS | `docs/product/view_richness_post_ga_report_v1.md` |
 | Platform performance smoke | included in `make verify.release.v2_0_0.product_hardening` | PASS | `artifacts/backend/platform_performance_smoke.json` |
+| Platform performance schema | `make verify.platform.performance.smoke.schema.guard` | PASS | `artifacts/backend/platform_performance_smoke.json` |
 
 ## Required Before Formal `v2.0.0`
 
@@ -79,5 +81,8 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 - Artifacts:
   - `artifacts/backend/bundle_installation_report.json`
   - `artifacts/backend/platform_performance_smoke.json`
+- Evidence shape guards:
+  - `make verify.bundle.installation.ready.schema.guard`
+  - `make verify.platform.performance.smoke.schema.guard`
 - Note: before creating `gate-release-v2.0` or `v2.0.0-rc1`, rerun required
   gates on a clean reviewed release database and attach the fresh artifacts.

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -184,6 +184,12 @@
 - `make verify.platform.release_policy.runtime.schema.guard`
   - Verifies the platform release-policy runtime probe JSON/MD shape.
   - Enforces product coverage, policy/catalog counts, user/no-native/subset/admin delivery summaries, and failure consistency.
+- `make verify.bundle.installation.ready.schema.guard`
+  - Verifies the bundle installation readiness JSON/MD report shape.
+  - Enforces construction/owner bundle coverage, positive scene/capability counts, reversible disabled payload shape, and error/warning count consistency.
+- `make verify.platform.performance.smoke.schema.guard`
+  - Verifies the platform performance smoke JSON/MD report shape.
+  - Enforces expected intent coverage, row/summary iteration consistency, threshold field shape, and error/warning count consistency.
 - `make verify.scene.product_delivery.readiness.guard`
   - Enforces final product delivery readiness thresholds from `scripts/verify/baselines/scene_product_delivery_readiness_guard.json`.
   - Writes reports: `artifacts/backend/scene_product_delivery_readiness_report.json` and `artifacts/backend/scene_product_delivery_readiness_report.md`.

--- a/scripts/verify/product_hardening_schema_guard.py
+++ b/scripts/verify/product_hardening_schema_guard.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+BUNDLE_JSON = ROOT / "artifacts" / "backend" / "bundle_installation_report.json"
+BUNDLE_MD = ROOT / "docs" / "ops" / "audit" / "bundle_installation_report.md"
+PERFORMANCE_JSON = ROOT / "artifacts" / "backend" / "platform_performance_smoke.json"
+PERFORMANCE_MD = ROOT / "docs" / "ops" / "audit" / "platform_performance_smoke.md"
+EXPECTED_BUNDLES = {"construction", "owner"}
+EXPECTED_INTENTS = {"system.init", "ui.contract", "execute_button"}
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _string_list(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _require_summary(summary: object, keys: tuple[str, ...], errors: list[str]) -> dict:
+    if not isinstance(summary, dict):
+        errors.append("summary must be object")
+        return {}
+    for key in keys:
+        if not isinstance(summary.get(key), int):
+            errors.append(f"summary.{key} must be int")
+    return summary
+
+
+def _check_bundle_rows(bundles: object, errors: list[str]) -> dict:
+    if not isinstance(bundles, dict):
+        errors.append("bundles must be object")
+        return {}
+    seen = set(bundles)
+    if seen != EXPECTED_BUNDLES:
+        errors.append(f"bundles must cover {sorted(EXPECTED_BUNDLES)}")
+    for name, row in bundles.items():
+        prefix = f"bundles.{name}"
+        if not isinstance(row, dict):
+            errors.append(f"{prefix} must be object")
+            continue
+        for key in ("scene_count", "capability_count"):
+            if not isinstance(row.get(key), int) or row.get(key) < 1:
+                errors.append(f"{prefix}.{key} must be positive int")
+        for key in (
+            "enabled_shape_keys",
+            "disabled_shape_keys",
+            "enabled_extra_keys",
+            "disabled_extra_keys",
+            "missing_after_disabled",
+        ):
+            if not _string_list(row.get(key)):
+                errors.append(f"{prefix}.{key} must be string list")
+        unsupported_enabled_keys = set(row.get("enabled_extra_keys") or []) - {"ext_facts"}
+        if unsupported_enabled_keys:
+            errors.append(f"{prefix}.enabled_extra_keys must only contain ext_facts")
+        if row.get("disabled_extra_keys"):
+            errors.append(f"{prefix}.disabled_extra_keys must be empty")
+        if row.get("missing_after_disabled"):
+            errors.append(f"{prefix}.missing_after_disabled must be empty")
+    return bundles
+
+
+def _check_bundle() -> list[str]:
+    payload = _load_json(BUNDLE_JSON)
+    errors: list[str] = []
+    if not payload:
+        return [f"missing or invalid json: {BUNDLE_JSON.relative_to(ROOT).as_posix()}"]
+    if not isinstance(payload.get("ok"), bool):
+        errors.append("ok must be bool")
+    summary = _require_summary(payload.get("summary"), ("baseline_shape_count", "error_count", "warning_count"), errors)
+    bundles = _check_bundle_rows(payload.get("bundles"), errors)
+    report_errors = payload.get("errors")
+    if not _string_list(report_errors):
+        errors.append("errors must be string list")
+        report_errors = []
+    warnings = payload.get("warnings")
+    if not _string_list(warnings):
+        errors.append("warnings must be string list")
+        warnings = []
+    if summary:
+        if summary.get("error_count") != len(report_errors):
+            errors.append("summary.error_count must match errors length")
+        if summary.get("warning_count") != len(warnings):
+            errors.append("summary.warning_count must match warnings length")
+        if len(bundles) == len(EXPECTED_BUNDLES) and summary.get("baseline_shape_count", 0) < 1:
+            errors.append("summary.baseline_shape_count must be positive when bundles are present")
+    if payload.get("ok") is True and report_errors:
+        errors.append("ok=true report must not contain errors")
+    if payload.get("ok") is False and not report_errors:
+        errors.append("ok=false report must contain errors")
+    if not BUNDLE_MD.is_file():
+        errors.append(f"missing markdown report: {BUNDLE_MD.relative_to(ROOT).as_posix()}")
+    else:
+        text = BUNDLE_MD.read_text(encoding="utf-8")
+        for token in ("# Bundle Installation Report", "- baseline_shape_count:", "## Bundles", "## Errors"):
+            if token not in text:
+                errors.append(f"markdown report missing token: {token}")
+    return errors
+
+
+def _check_performance_row(row: object, idx: int, errors: list[str]) -> None:
+    prefix = f"rows[{idx}]"
+    if not isinstance(row, dict):
+        errors.append(f"{prefix} must be object")
+        return
+    intent = str(row.get("intent") or "").strip()
+    if intent not in EXPECTED_INTENTS:
+        errors.append(f"{prefix}.intent must be one of {sorted(EXPECTED_INTENTS)}")
+    for key in ("iterations", "max_payload_bytes", "threshold_payload_bytes"):
+        if not isinstance(row.get(key), int) or row.get(key) < 1:
+            errors.append(f"{prefix}.{key} must be positive int")
+    for key in ("avg_ms", "p95_ms", "threshold_p95_ms"):
+        if not isinstance(row.get(key), (int, float)) or row.get(key) < 0:
+            errors.append(f"{prefix}.{key} must be non-negative number")
+    status_codes = row.get("status_codes")
+    if not isinstance(status_codes, list) or not status_codes or not all(isinstance(item, int) for item in status_codes):
+        errors.append(f"{prefix}.status_codes must be non-empty int list")
+
+
+def _check_performance() -> list[str]:
+    payload = _load_json(PERFORMANCE_JSON)
+    errors: list[str] = []
+    if not payload:
+        return [f"missing or invalid json: {PERFORMANCE_JSON.relative_to(ROOT).as_posix()}"]
+    if not isinstance(payload.get("ok"), bool):
+        errors.append("ok must be bool")
+    summary = _require_summary(payload.get("summary"), ("target_count", "iterations", "error_count", "warning_count"), errors)
+    rows = payload.get("rows")
+    if not isinstance(rows, list):
+        errors.append("rows must be list")
+        rows = []
+    seen_intents: set[str] = set()
+    for idx, row in enumerate(rows):
+        _check_performance_row(row, idx, errors)
+        if isinstance(row, dict):
+            seen_intents.add(str(row.get("intent") or "").strip())
+    if seen_intents != EXPECTED_INTENTS:
+        errors.append(f"rows must cover {sorted(EXPECTED_INTENTS)}")
+    report_errors = payload.get("errors")
+    if not _string_list(report_errors):
+        errors.append("errors must be string list")
+        report_errors = []
+    warnings = payload.get("warnings")
+    if not _string_list(warnings):
+        errors.append("warnings must be string list")
+        warnings = []
+    if summary:
+        if summary.get("target_count") != len(rows):
+            errors.append("summary.target_count must match rows length")
+        if summary.get("error_count") != len(report_errors):
+            errors.append("summary.error_count must match errors length")
+        if summary.get("warning_count") != len(warnings):
+            errors.append("summary.warning_count must match warnings length")
+        for idx, row in enumerate(rows):
+            if isinstance(row, dict) and row.get("iterations") != summary.get("iterations"):
+                errors.append(f"rows[{idx}].iterations must match summary.iterations")
+    if payload.get("ok") is True and report_errors:
+        errors.append("ok=true report must not contain errors")
+    if payload.get("ok") is False and not report_errors:
+        errors.append("ok=false report must contain errors")
+    if not PERFORMANCE_MD.is_file():
+        errors.append(f"missing markdown report: {PERFORMANCE_MD.relative_to(ROOT).as_posix()}")
+    else:
+        text = PERFORMANCE_MD.read_text(encoding="utf-8")
+        for token in ("# Platform Performance Smoke", "- target_count:", "| intent | avg_ms |", "## Errors"):
+            if token not in text:
+                errors.append(f"markdown report missing token: {token}")
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate product hardening report schemas")
+    parser.add_argument("--report", choices=("bundle", "performance", "all"), default="all")
+    args = parser.parse_args()
+
+    errors: list[str] = []
+    if args.report in {"bundle", "all"}:
+        errors.extend(f"bundle: {error}" for error in _check_bundle())
+    if args.report in {"performance", "all"}:
+        errors.extend(f"performance: {error}" for error in _check_performance())
+
+    if errors:
+        print("[product_hardening_schema_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+    print("[product_hardening_schema_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
