### PR TITLE
Guard dev acceptance release probe schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -537,6 +537,12 @@ ACCEPTANCE_PASSWORD ?=
 
 verify.dev.acceptance.release: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) ACCEPTANCE_BACKUP_DIR="$(ACCEPTANCE_BACKUP_DIR)" ACCEPTANCE_BASE_URL="$(ACCEPTANCE_BASE_URL)" ACCEPTANCE_LOGIN="$(ACCEPTANCE_LOGIN)" ACCEPTANCE_PASSWORD="$(ACCEPTANCE_PASSWORD)" ACCEPTANCE_PROBE_OUTPUT="$(ACCEPTANCE_PROBE_OUTPUT)" python3 scripts/ops/dev_acceptance_release_probe.py
+	@ACCEPTANCE_PROBE_OUTPUT="$(ACCEPTANCE_PROBE_OUTPUT)" python3 scripts/verify/dev_acceptance_release_probe_schema_guard.py
+
+.PHONY: verify.dev.acceptance.release.schema.guard
+verify.dev.acceptance.release.schema.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/dev_acceptance_release_probe_schema_guard.py
+	@ACCEPTANCE_PROBE_OUTPUT="$(ACCEPTANCE_PROBE_OUTPUT)" python3 scripts/verify/dev_acceptance_release_probe_schema_guard.py
 
 release.dev.acceptance.publish: guard.prod.forbid check-compose-project check-compose-env verify.frontend.build verify.user_confirmed.formal_surface.locked verify.dev.acceptance.release
 	@echo "[release.dev.acceptance.publish] PASS base_url=$(ACCEPTANCE_BASE_URL) db=$(DB_NAME) artifact=$(ACCEPTANCE_PROBE_OUTPUT)"

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -44,6 +44,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Evidence | Command | Required Result | Artifact |
 |---|---|---|---|
 | Dev acceptance publish | `make release.dev.acceptance.publish` with dev env vars | PASS | `artifacts/backend/dev_acceptance_release_probe.json` |
+| Dev acceptance schema | `make verify.dev.acceptance.release.schema.guard` | PASS | `artifacts/backend/dev_acceptance_release_probe.json` |
 | Prod-sim acceptance | governed prod-sim Makefile flow | PASS | prod-sim acceptance artifact path to be recorded |
 | Release checklist signoff | manual review | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -190,6 +190,9 @@
 - `make verify.platform.performance.smoke.schema.guard`
   - Verifies the platform performance smoke JSON/MD report shape.
   - Enforces expected intent coverage, row/summary iteration consistency, threshold field shape, and error/warning count consistency.
+- `make verify.dev.acceptance.release.schema.guard`
+  - Verifies the dev acceptance release probe JSON shape.
+  - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.scene.product_delivery.readiness.guard`
   - Enforces final product delivery readiness thresholds from `scripts/verify/baselines/scene_product_delivery_readiness_guard.json`.
   - Writes reports: `artifacts/backend/scene_product_delivery_readiness_report.json` and `artifacts/backend/scene_product_delivery_readiness_report.md`.

--- a/scripts/verify/dev_acceptance_release_probe_schema_guard.py
+++ b/scripts/verify/dev_acceptance_release_probe_schema_guard.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+REPORT_JSON = ROOT / os.getenv(
+    "ACCEPTANCE_PROBE_OUTPUT",
+    "artifacts/backend/dev_acceptance_release_probe.json",
+)
+
+
+def _load_json(path: Path) -> dict:
+    if not path.is_file():
+        return {}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _string_list(value: object) -> bool:
+    return isinstance(value, list) and all(isinstance(item, str) for item in value)
+
+
+def _check_status_block(prefix: str, value: object, errors: list[str]) -> dict:
+    if not isinstance(value, dict):
+        errors.append(f"{prefix} must be object")
+        return {}
+    status = value.get("status")
+    enabled = value.get("enabled")
+    if enabled is not False and status not in {"PASS", "FAIL"}:
+        errors.append(f"{prefix}.status must be PASS or FAIL when enabled")
+    block_errors = value.get("errors")
+    if block_errors is not None and not _string_list(block_errors):
+        errors.append(f"{prefix}.errors must be string list")
+        block_errors = []
+    if status == "PASS" and block_errors:
+        errors.append(f"{prefix}.status=PASS must not contain errors")
+    if status == "FAIL" and not block_errors:
+        errors.append(f"{prefix}.status=FAIL must contain errors")
+    return value
+
+
+def _check_backup(value: object, errors: list[str]) -> str:
+    backup = _check_status_block("backup", value, errors)
+    if not backup:
+        return "FAIL"
+    enabled = backup.get("enabled")
+    if not isinstance(enabled, bool):
+        errors.append("backup.enabled must be bool")
+    if enabled is False:
+        return "PASS"
+    if not isinstance(backup.get("dir"), str) or not backup.get("dir"):
+        errors.append("backup.dir must be non-empty string when enabled")
+    if not isinstance(backup.get("checks"), dict):
+        errors.append("backup.checks must be object when enabled")
+    return str(backup.get("status") or "FAIL")
+
+
+def _check_frontend(value: object, errors: list[str]) -> str:
+    frontend = _check_status_block("frontend", value, errors)
+    if not frontend:
+        return "FAIL"
+    if not isinstance(frontend.get("base_url"), str) or not frontend.get("base_url"):
+        errors.append("frontend.base_url must be non-empty string")
+    checks = frontend.get("checks")
+    if not isinstance(checks, dict):
+        errors.append("frontend.checks must be object")
+        return str(frontend.get("status") or "FAIL")
+    for key in ("root_status", "asset_status", "intent_options_status", "intent_get_status"):
+        if key in checks and not isinstance(checks.get(key), int):
+            errors.append(f"frontend.checks.{key} must be int")
+    for key in (
+        "asset_has_db",
+        "asset_has_app_env",
+        "asset_has_forbidden_db_token",
+        "asset_forbidden_db_is_default",
+    ):
+        if key in checks and not isinstance(checks.get(key), bool):
+            errors.append(f"frontend.checks.{key} must be bool")
+    asset_path = checks.get("asset_path")
+    if frontend.get("status") == "PASS" and (not isinstance(asset_path, str) or not asset_path):
+        errors.append("frontend.checks.asset_path must be non-empty string when frontend passes")
+    if frontend.get("status") == "PASS":
+        expected = {
+            "root_status": 200,
+            "asset_status": 200,
+            "intent_options_status": 204,
+            "intent_get_status": 405,
+        }
+        for key, expected_value in expected.items():
+            if checks.get(key) != expected_value:
+                errors.append(f"frontend.checks.{key} must be {expected_value} when frontend passes")
+    return str(frontend.get("status") or "FAIL")
+
+
+def _check_login(value: object, errors: list[str]) -> str:
+    login = _check_status_block("login", value, errors)
+    if not login:
+        return "FAIL"
+    enabled = login.get("enabled")
+    if not isinstance(enabled, bool):
+        errors.append("login.enabled must be bool")
+    if enabled is False:
+        return "PASS"
+    if not isinstance(login.get("login"), str) or not login.get("login"):
+        errors.append("login.login must be non-empty string when enabled")
+    checks = login.get("checks")
+    if not isinstance(checks, dict):
+        errors.append("login.checks must be object when enabled")
+        return str(login.get("status") or "FAIL")
+    for key in ("auth_status", "system_init_status"):
+        if not isinstance(checks.get(key), int):
+            errors.append(f"login.checks.{key} must be int")
+    if not isinstance(checks.get("system_init_ok"), bool):
+        errors.append("login.checks.system_init_ok must be bool")
+    if checks.get("auth_uid") is not None and not isinstance(checks.get("auth_uid"), int):
+        errors.append("login.checks.auth_uid must be int when present")
+    if checks.get("nav_count") is not None and not isinstance(checks.get("nav_count"), int):
+        errors.append("login.checks.nav_count must be int when present")
+    if login.get("status") == "PASS":
+        if checks.get("auth_status") != 200:
+            errors.append("login.checks.auth_status must be 200 when login passes")
+        if checks.get("system_init_status") != 200:
+            errors.append("login.checks.system_init_status must be 200 when login passes")
+        if checks.get("system_init_ok") is not True:
+            errors.append("login.checks.system_init_ok must be true when login passes")
+    return str(login.get("status") or "FAIL")
+
+
+def main() -> int:
+    payload = _load_json(REPORT_JSON)
+    errors: list[str] = []
+    if not payload:
+        errors.append(f"missing or invalid json: {REPORT_JSON.relative_to(ROOT).as_posix()}")
+    else:
+        if payload.get("mode") != "dev_acceptance_release_probe":
+            errors.append("mode must be dev_acceptance_release_probe")
+        if payload.get("status") not in {"PASS", "FAIL"}:
+            errors.append("status must be PASS or FAIL")
+        for key in ("db_name", "base_url", "app_env"):
+            if not isinstance(payload.get(key), str) or not payload.get(key):
+                errors.append(f"{key} must be non-empty string")
+        statuses = [
+            _check_backup(payload.get("backup"), errors),
+            _check_frontend(payload.get("frontend"), errors),
+            _check_login(payload.get("login"), errors),
+        ]
+        expected_status = "PASS" if all(status == "PASS" for status in statuses) else "FAIL"
+        if payload.get("status") in {"PASS", "FAIL"} and payload.get("status") != expected_status:
+            errors.append("status must match backup/frontend/login aggregate status")
+
+    if errors:
+        print("[dev_acceptance_release_probe_schema_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+    print("[dev_acceptance_release_probe_schema_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
