### PR TITLE
Guard v2 release checklist structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4460,6 +4460,11 @@ verify.release.v2_0_0.preflight: guard.prod.forbid \
 verify.release.v2_0_0.product_hardening: guard.prod.forbid verify.product.release.ready
 	@echo "[OK] verify.release.v2_0_0.product_hardening done"
 
+.PHONY: verify.release.v2_0_0.checklist.guard
+verify.release.v2_0_0.checklist.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py
+	@python3 scripts/verify/release_v2_0_0_checklist_guard.py
+
 verify.platform.distribution.report: guard.prod.forbid
 	@python3 scripts/verify/platform_distribution_ready_report.py
 

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -47,6 +47,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Dev acceptance schema | `make verify.dev.acceptance.release.schema.guard` | PASS | `artifacts/backend/dev_acceptance_release_probe.json` |
 | Prod-sim acceptance | governed prod-sim Makefile flow | PASS | prod-sim acceptance artifact path to be recorded |
 | Release checklist signoff | manual review | PASS | `docs/ops/release_checklist_v2.0.0.md` |
+| Release checklist guard | `make verify.release.v2_0_0.checklist.guard` | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 
 ## Evidence Rules
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -193,6 +193,9 @@
 - `make verify.dev.acceptance.release.schema.guard`
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
+- `make verify.release.v2_0_0.checklist.guard`
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, production safety, post-release, and stop-condition sections.
+  - Enforces required release tag names and prod/prod-sim evidence separation language.
 - `make verify.scene.product_delivery.readiness.guard`
   - Enforces final product delivery readiness thresholds from `scripts/verify/baselines/scene_product_delivery_readiness_guard.json`.
   - Writes reports: `artifacts/backend/scene_product_delivery_readiness_report.json` and `artifacts/backend/scene_product_delivery_readiness_report.md`.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CHECKLIST = ROOT / "docs" / "ops" / "release_checklist_v2.0.0.md"
+
+REQUIRED_TOKENS = (
+    "# Release Checklist - v2.0.0",
+    "## Preconditions",
+    "## Version And Tag Checks",
+    "## Local / CI Gate",
+    "## Product Hardening Gate",
+    "## Dev Acceptance Gate",
+    "## Prod-Sim Gate",
+    "## Production Safety",
+    "## Post-Release",
+    "## Stop Conditions",
+    "make verify.release.v2_0_0.preflight",
+    "make verify.release.v2_0_0.product_hardening",
+    "make release.dev.acceptance.publish",
+    "artifacts/backend/dev_acceptance_release_probe.json",
+    "gate-release-v2.0",
+    "v2.0.0-rc1",
+    "v2.0.0",
+    "sc_prod_sim",
+    "sc_prod",
+    "Production destructive reset is forbidden.",
+    "Prod and prod-sim evidence are mixed.",
+)
+
+FORBIDDEN_TOKENS = (
+    "git tag -f",
+    "git push --force",
+    "git reset --hard",
+    "ENV=prod make",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not CHECKLIST.is_file():
+        errors.append(f"missing checklist: {CHECKLIST.relative_to(ROOT).as_posix()}")
+    else:
+        text = CHECKLIST.read_text(encoding="utf-8")
+        for token in REQUIRED_TOKENS:
+            if token not in text:
+                errors.append(f"checklist missing token: {token}")
+        for token in FORBIDDEN_TOKENS:
+            if token in text:
+                errors.append(f"checklist contains forbidden token: {token}")
+
+    if errors:
+        print("[release_v2_0_0_checklist_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+    print("[release_v2_0_0_checklist_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
