### PR TITLE
Guard v2 evidence manifest structure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4470,6 +4470,11 @@ verify.release.v2_0_0.checklist.guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py
 	@python3 scripts/verify/release_v2_0_0_checklist_guard.py
 
+.PHONY: verify.release.v2_0_0.evidence_manifest.guard
+verify.release.v2_0_0.evidence_manifest.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+	@python3 scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+
 verify.platform.distribution.report: guard.prod.forbid
 	@python3 scripts/verify/platform_distribution_ready_report.py
 

--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -37,6 +37,7 @@ Required before formal `v2.0.0`:
 
 ```bash
 make verify.release.v2_0_0.product_hardening
+make verify.release.v2_0_0.evidence_manifest.guard
 ```
 
 This target expands to `make verify.product.release.ready` and must be green

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -49,6 +49,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Prod-sim acceptance schema | `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard` | PASS | `scbs_release_acceptance_strict_result_v1.json`, `scbs_release_acceptance_strict_v1.md`, and `scbs_no_legacy_replay_acceptance_result_v1.json` under the recorded run dir |
 | Release checklist signoff | manual review | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Release checklist guard | `make verify.release.v2_0_0.checklist.guard` | PASS | `docs/ops/release_checklist_v2.0.0.md` |
+| Evidence manifest guard | `make verify.release.v2_0_0.evidence_manifest.guard` | PASS | `docs/ops/releases/v2.0.0/evidence_manifest.md` |
 
 ## Evidence Rules
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -196,6 +196,8 @@
 - `make verify.release.v2_0_0.checklist.guard`
   - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, production safety, post-release, and stop-condition sections.
   - Enforces required release tag names and prod/prod-sim evidence separation language.
+- `make verify.release.v2_0_0.evidence_manifest.guard`
+  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, evidence rules, and explicit prod-sim evidence directory validation.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`
   - Verifies explicit prod-sim acceptance evidence under the recorded run directory.
   - Requires strict SCBS release acceptance JSON/MD and no-legacy replay acceptance JSON to target `sc_prod_sim`; no default run directory is inferred.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -22,6 +22,7 @@ REQUIRED_TOKENS = (
     "## Stop Conditions",
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
+    "make verify.release.v2_0_0.evidence_manifest.guard",
     "make release.dev.acceptance.publish",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard",
     "artifacts/backend/dev_acceptance_release_probe.json",

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MANIFEST = ROOT / "docs" / "ops" / "releases" / "v2.0.0" / "evidence_manifest.md"
+
+REQUIRED_TOKENS = (
+    "# v2.0.0 Evidence Manifest",
+    "## Required Before `gate-release-v2.0`",
+    "## Required Before `v2.0.0-rc1`",
+    "## Required Product Hardening Before Formal `v2.0.0`",
+    "## Required Before Formal `v2.0.0`",
+    "## Evidence Rules",
+    "## Current Local Verification Status",
+    "`make verify.system.capability_baseline.report.schema.guard`",
+    "`make verify.platform.release_policy.runtime.schema.guard`",
+    "`make verify.product.delivery.mainline.summary.schema.guard`",
+    "`make verify.product.delivery.action_closure.schema.guard`",
+    "`make verify.product.delivery.module_capability.schema.guard`",
+    "`make verify.intent.canonical_alias.snapshot.schema.guard`",
+    "`make verify.bundle.installation.ready.schema.guard`",
+    "`make verify.platform.performance.smoke.schema.guard`",
+    "`make verify.dev.acceptance.release.schema.guard`",
+    "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`",
+    "`make verify.release.v2_0_0.checklist.guard`",
+    "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",
+    "Production deployment evidence is recorded separately after supervised",
+    "Failed evidence is not overwritten without preserving the failure reason",
+    "prod-sim acceptance artifact path to be recorded",
+)
+
+FORBIDDEN_TOKENS = (
+    "v1.0.0` |",
+    "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
+    "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
+    "sc_prod evidence",
+)
+
+
+def main() -> int:
+    errors: list[str] = []
+    if not MANIFEST.is_file():
+        errors.append(f"missing manifest: {MANIFEST.relative_to(ROOT).as_posix()}")
+    else:
+        text = MANIFEST.read_text(encoding="utf-8")
+        for token in REQUIRED_TOKENS:
+            if token not in text:
+                errors.append(f"manifest missing token: {token}")
+        for token in FORBIDDEN_TOKENS:
+            if token in text:
+                errors.append(f"manifest contains forbidden token: {token}")
+        if text.count("| Evidence | Command | Required Result | Artifact |") != 4:
+            errors.append("manifest must contain four evidence tables")
+
+    if errors:
+        print("[release_v2_0_0_evidence_manifest_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+    print("[release_v2_0_0_evidence_manifest_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
