### PR TITLE
Guard v2 release control docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4475,6 +4475,11 @@ verify.release.v2_0_0.evidence_manifest.guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py
 	@python3 scripts/verify/release_v2_0_0_evidence_manifest_guard.py
 
+.PHONY: verify.release.v2_0_0.control_docs.guard
+verify.release.v2_0_0.control_docs.guard: guard.prod.forbid
+	@python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py
+	@python3 scripts/verify/release_v2_0_0_control_docs_guard.py
+
 verify.platform.distribution.report: guard.prod.forbid
 	@python3 scripts/verify/platform_distribution_ready_report.py
 

--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -37,6 +37,7 @@ Required before formal `v2.0.0`:
 
 ```bash
 make verify.release.v2_0_0.product_hardening
+make verify.release.v2_0_0.control_docs.guard
 make verify.release.v2_0_0.evidence_manifest.guard
 ```
 

--- a/docs/ops/release_notes_v2.0.0.md
+++ b/docs/ops/release_notes_v2.0.0.md
@@ -12,7 +12,7 @@ track to `v2.0.0`.
 
 ## Scope
 
-- Product delivery baseline: 9 modules and 22 scoped scenes.
+- Product delivery baseline: 10 modules and 22 scoped scenes.
 - Startup contract: `login -> system.init -> ui.contract`.
 - Role authority: `role_surface.role_code`.
 - Route authority: backend-provided `default_route`.

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -50,6 +50,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Release checklist signoff | manual review | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Release checklist guard | `make verify.release.v2_0_0.checklist.guard` | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Evidence manifest guard | `make verify.release.v2_0_0.evidence_manifest.guard` | PASS | `docs/ops/releases/v2.0.0/evidence_manifest.md` |
+| Release control docs guard | `make verify.release.v2_0_0.control_docs.guard` | PASS | `docs/ops/releases/v2.0.0/README.md` and `docs/ops/release_notes_v2.0.0.md` |
 
 ## Evidence Rules
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -198,6 +198,8 @@
   - Enforces required release tag names and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, evidence rules, and explicit prod-sim evidence directory validation.
+- `make verify.release.v2_0_0.control_docs.guard`
+  - Verifies the v2.0.0 release-control README and release notes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`
   - Verifies explicit prod-sim acceptance evidence under the recorded run directory.
   - Requires strict SCBS release acceptance JSON/MD and no-legacy replay acceptance JSON to target `sc_prod_sim`; no default run directory is inferred.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -22,6 +22,7 @@ REQUIRED_TOKENS = (
     "## Stop Conditions",
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
+    "make verify.release.v2_0_0.control_docs.guard",
     "make verify.release.v2_0_0.evidence_manifest.guard",
     "make release.dev.acceptance.publish",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard",

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+CONTROL_README = ROOT / "docs" / "ops" / "releases" / "v2.0.0" / "README.md"
+RELEASE_NOTES = ROOT / "docs" / "ops" / "release_notes_v2.0.0.md"
+
+README_TOKENS = (
+    "# v2.0.0 Release Control",
+    "- Version: `v2.0.0`",
+    "- Planned gate tag: `gate-release-v2.0`",
+    "- Planned RC tag: `v2.0.0-rc1`",
+    "- Planned final tag: `v2.0.0`",
+    "make verify.release.v2_0_0.preflight",
+    "make verify.release.v2_0_0.product_hardening",
+    "Run prod-sim acceptance.",
+    "Create `v2.0.0` after formal release signoff.",
+    "Runtime rollback is outside this governance batch",
+)
+
+NOTES_TOKENS = (
+    "# Release Notes - v2.0.0",
+    "`v2.0.0` is the active formal release line",
+    "Product delivery baseline: 10 modules and 22 scoped scenes.",
+    "Startup contract: `login -> system.init -> ui.contract`.",
+    "Role authority: `role_surface.role_code`.",
+    "Route authority: backend-provided `default_route`.",
+    "make verify.release.v2_0_0.preflight",
+    "make verify.release.v2_0_0.product_hardening",
+    "ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo",
+    "Production deployment is not part of this release-note batch.",
+    "RC tags are immutable once published.",
+)
+
+FORBIDDEN_TOKENS = (
+    "Product delivery baseline: 9 modules",
+    "reuse `v1.0.0`",
+    "git tag -f",
+    "git push --force",
+    "Production deployment is part of this release-note batch.",
+)
+
+
+def _contains_all(path: Path, tokens: tuple[str, ...], errors: list[str]) -> None:
+    if not path.is_file():
+        errors.append(f"missing doc: {path.relative_to(ROOT).as_posix()}")
+        return
+    text = path.read_text(encoding="utf-8")
+    for token in tokens:
+        if token not in text:
+            errors.append(f"{path.relative_to(ROOT).as_posix()} missing token: {token}")
+    for token in FORBIDDEN_TOKENS:
+        if token in text:
+            errors.append(f"{path.relative_to(ROOT).as_posix()} contains forbidden token: {token}")
+
+
+def main() -> int:
+    errors: list[str] = []
+    _contains_all(CONTROL_README, README_TOKENS, errors)
+    _contains_all(RELEASE_NOTES, NOTES_TOKENS, errors)
+    if errors:
+        print("[release_v2_0_0_control_docs_guard] FAIL")
+        for error in errors:
+            print(error)
+        return 2
+    print("[release_v2_0_0_control_docs_guard] PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -28,6 +28,8 @@ REQUIRED_TOKENS = (
     "`make verify.dev.acceptance.release.schema.guard`",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`",
     "`make verify.release.v2_0_0.checklist.guard`",
+    "`make verify.release.v2_0_0.evidence_manifest.guard`",
+    "`make verify.release.v2_0_0.control_docs.guard`",
     "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",
     "Production deployment evidence is recorded separately after supervised",
     "Failed evidence is not overwritten without preserving the failure reason",


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
