### PR TITLE
Add v2 release governance guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4480,6 +4480,13 @@ verify.release.v2_0_0.control_docs.guard: guard.prod.forbid
 	@python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py
 	@python3 scripts/verify/release_v2_0_0_control_docs_guard.py
 
+.PHONY: verify.release.v2_0_0.governance.guard
+verify.release.v2_0_0.governance.guard: guard.prod.forbid \
+	verify.release.v2_0_0.control_docs.guard \
+	verify.release.v2_0_0.evidence_manifest.guard \
+	verify.release.v2_0_0.checklist.guard
+	@echo "[OK] verify.release.v2_0_0.governance.guard done"
+
 verify.platform.distribution.report: guard.prod.forbid
 	@python3 scripts/verify/platform_distribution_ready_report.py
 

--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -37,6 +37,7 @@ Required before formal `v2.0.0`:
 
 ```bash
 make verify.release.v2_0_0.product_hardening
+make verify.release.v2_0_0.governance.guard
 make verify.release.v2_0_0.control_docs.guard
 make verify.release.v2_0_0.evidence_manifest.guard
 ```

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -51,6 +51,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Release checklist guard | `make verify.release.v2_0_0.checklist.guard` | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Evidence manifest guard | `make verify.release.v2_0_0.evidence_manifest.guard` | PASS | `docs/ops/releases/v2.0.0/evidence_manifest.md` |
 | Release control docs guard | `make verify.release.v2_0_0.control_docs.guard` | PASS | `docs/ops/releases/v2.0.0/README.md` and `docs/ops/release_notes_v2.0.0.md` |
+| Release governance guard | `make verify.release.v2_0_0.governance.guard` | PASS | release-control docs, evidence manifest, and checklist guard terminal output |
 
 ## Evidence Rules
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -200,6 +200,8 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README and release notes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+- `make verify.release.v2_0_0.governance.guard`
+  - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`
   - Verifies explicit prod-sim acceptance evidence under the recorded run directory.
   - Requires strict SCBS release acceptance JSON/MD and no-legacy replay acceptance JSON to target `sc_prod_sim`; no default run directory is inferred.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -22,6 +22,7 @@ REQUIRED_TOKENS = (
     "## Stop Conditions",
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
+    "make verify.release.v2_0_0.governance.guard",
     "make verify.release.v2_0_0.control_docs.guard",
     "make verify.release.v2_0_0.evidence_manifest.guard",
     "make release.dev.acceptance.publish",

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -30,6 +30,7 @@ REQUIRED_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "`make verify.release.v2_0_0.control_docs.guard`",
+    "`make verify.release.v2_0_0.governance.guard`",
     "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",
     "Production deployment evidence is recorded separately after supervised",
     "Failed evidence is not overwritten without preserving the failure reason",


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
