### PR TITLE
Add v2 formal evidence schema guard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4487,6 +4487,15 @@ verify.release.v2_0_0.governance.guard: guard.prod.forbid \
 	verify.release.v2_0_0.checklist.guard
 	@echo "[OK] verify.release.v2_0_0.governance.guard done"
 
+.PHONY: verify.release.v2_0_0.formal_evidence.schema.guard
+verify.release.v2_0_0.formal_evidence.schema.guard: guard.prod.forbid \
+	verify.release.v2_0_0.governance.guard \
+	verify.bundle.installation.ready.schema.guard \
+	verify.platform.performance.smoke.schema.guard \
+	verify.dev.acceptance.release.schema.guard \
+	verify.prod.sim.acceptance.evidence.schema.guard
+	@echo "[OK] verify.release.v2_0_0.formal_evidence.schema.guard done"
+
 verify.platform.distribution.report: guard.prod.forbid
 	@python3 scripts/verify/platform_distribution_ready_report.py
 

--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -38,6 +38,7 @@ Required before formal `v2.0.0`:
 ```bash
 make verify.release.v2_0_0.product_hardening
 make verify.release.v2_0_0.governance.guard
+PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard
 make verify.release.v2_0_0.control_docs.guard
 make verify.release.v2_0_0.evidence_manifest.guard
 ```

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -52,6 +52,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Evidence manifest guard | `make verify.release.v2_0_0.evidence_manifest.guard` | PASS | `docs/ops/releases/v2.0.0/evidence_manifest.md` |
 | Release control docs guard | `make verify.release.v2_0_0.control_docs.guard` | PASS | `docs/ops/releases/v2.0.0/README.md` and `docs/ops/release_notes_v2.0.0.md` |
 | Release governance guard | `make verify.release.v2_0_0.governance.guard` | PASS | release-control docs, evidence manifest, and checklist guard terminal output |
+| Formal evidence schema guard | `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard` | PASS | governance, hardening, dev acceptance, and prod-sim acceptance evidence shape guard terminal output |
 
 ## Evidence Rules
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -202,6 +202,8 @@
   - Verifies the v2.0.0 release-control README and release notes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
+- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
+  - Runs the v2.0.0 governance, product hardening schema, dev acceptance schema, and prod-sim acceptance evidence schema guards as the formal evidence shape closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`
   - Verifies explicit prod-sim acceptance evidence under the recorded run directory.
   - Requires strict SCBS release acceptance JSON/MD and no-legacy replay acceptance JSON to target `sc_prod_sim`; no default run directory is inferred.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -23,6 +23,7 @@ REQUIRED_TOKENS = (
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
     "make verify.release.v2_0_0.governance.guard",
+    "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "make verify.release.v2_0_0.control_docs.guard",
     "make verify.release.v2_0_0.evidence_manifest.guard",
     "make release.dev.acceptance.publish",

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -31,6 +31,7 @@ REQUIRED_TOKENS = (
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "`make verify.release.v2_0_0.governance.guard`",
+    "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",
     "Production deployment evidence is recorded separately after supervised",
     "Failed evidence is not overwritten without preserving the failure reason",


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
