### PR TITLE
Guard v2 versioning release order

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -199,7 +199,7 @@
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
-  - Verifies the v2.0.0 release-control README and release notes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the v2.0.0 release-control README, release notes, and versioning guide keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`

--- a/docs/ops/versioning.md
+++ b/docs/ops/versioning.md
@@ -94,8 +94,9 @@ Promotion order:
 2. Run `make verify.release.v2_0_0.preflight` on the reviewed release commit.
 3. Create `gate-release-v2.0` only after gate evidence passes.
 4. Run `make verify.release.v2_0_0.product_hardening` and close any blocker.
-5. Create `v2.0.0-rc1` only after RC evidence passes.
-6. Create `v2.0.0` only after prod-sim acceptance and release checklist signoff.
+5. Run `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard` after prod-sim acceptance evidence is recorded.
+6. Create `v2.0.0-rc1` only after RC evidence passes.
+7. Create `v2.0.0` only after prod-sim acceptance and release checklist signoff.
 
 Production deployment is not implied by creating `v2.0.0`; deployment remains a
 separate supervised operation under `docs/ops/production_deployment_runbook_v1.md`.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -9,6 +9,7 @@ import sys
 ROOT = Path(__file__).resolve().parents[2]
 CONTROL_README = ROOT / "docs" / "ops" / "releases" / "v2.0.0" / "README.md"
 RELEASE_NOTES = ROOT / "docs" / "ops" / "release_notes_v2.0.0.md"
+VERSIONING = ROOT / "docs" / "ops" / "versioning.md"
 
 README_TOKENS = (
     "# v2.0.0 Release Control",
@@ -37,6 +38,20 @@ NOTES_TOKENS = (
     "RC tags are immutable once published.",
 )
 
+VERSIONING_TOKENS = (
+    "# Tag & Release Naming Convention v1.0",
+    "Never reuse a tag name.",
+    "## 8) v2.0.0 Formal Release Line",
+    "`v1.0.0` tag name already exists remotely and must not be reused",
+    "gate baseline: `gate-release-v2.0`",
+    "release candidates: `v2.0.0-rc1`, `v2.0.0-rc2` only when blocker fixes require a new candidate",
+    "formal release: `v2.0.0`",
+    "make verify.release.v2_0_0.preflight",
+    "make verify.release.v2_0_0.product_hardening",
+    "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
+    "Production deployment is not implied by creating `v2.0.0`",
+)
+
 FORBIDDEN_TOKENS = (
     "Product delivery baseline: 9 modules",
     "reuse `v1.0.0`",
@@ -63,6 +78,7 @@ def main() -> int:
     errors: list[str] = []
     _contains_all(CONTROL_README, README_TOKENS, errors)
     _contains_all(RELEASE_NOTES, NOTES_TOKENS, errors)
+    _contains_all(VERSIONING, VERSIONING_TOKENS, errors)
     if errors:
         print("[release_v2_0_0_control_docs_guard] FAIL")
         for error in errors:


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
