### PR TITLE
Guard v2 rollback target coverage

### DIFF
--- a/docs/ops/releases/v2.0.0/README.md
+++ b/docs/ops/releases/v2.0.0/README.md
@@ -77,6 +77,9 @@ Release governance rollback is file-level:
 - remove `docs/ops/release_notes_v2.0.0.md`
 - remove `docs/ops/release_checklist_v2.0.0.md`
 - remove `verify.release.v2_0_0.preflight` from `Makefile`
+- remove `verify.release.v2_0_0.product_hardening` from `Makefile`
+- remove `verify.release.v2_0_0.governance.guard` from `Makefile`
+- remove `verify.release.v2_0_0.formal_evidence.schema.guard` from `Makefile`
 - restore release index and versioning edits
 
 Runtime rollback is outside this governance batch and must follow the production

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -25,6 +25,10 @@ README_TOKENS = (
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "Run prod-sim acceptance.",
     "Create `v2.0.0` after formal release signoff.",
+    "remove `verify.release.v2_0_0.preflight` from `Makefile`",
+    "remove `verify.release.v2_0_0.product_hardening` from `Makefile`",
+    "remove `verify.release.v2_0_0.governance.guard` from `Makefile`",
+    "remove `verify.release.v2_0_0.formal_evidence.schema.guard` from `Makefile`",
     "Runtime rollback is outside this governance batch",
 )
 


### PR DESCRIPTION
## Summary

- add schema validation for `backend_contract_closure_snapshot.json`
- run the schema guard from snapshot and mainline backend contract closure targets
- document the schema guard in verify docs and the v2.0.0 evidence manifest

## Verification

- `python3 -m py_compile scripts/verify/backend_contract_closure_snapshot_guard.py scripts/verify/backend_contract_closure_snapshot_schema_guard.py`
- `make verify.backend.contract.closure.snapshot.guard`
- `make verify.backend.contract.closure.snapshot.schema.guard`
- `make verify.backend.contract.closure.mainline`
- `git diff --check`
