### PR TITLE
Guard v2 release document scope

### DIFF
--- a/docs/ops/releases/v2.0.0/README.md
+++ b/docs/ops/releases/v2.0.0/README.md
@@ -13,7 +13,7 @@
 ## Layer Target / Module / Reason
 
 - Layer Target: Ops / Release Governance
-- Module: versioning, release checklist, release notes, release evidence manifest
+- Module: versioning, release index, release checklist, release notes, release evidence manifest
 - Reason: establish the active formal release line before RC and production
   deployment work begins, avoiding reuse of the existing remote `v1.0.0` tag.
 
@@ -52,6 +52,9 @@ make verify.release.v2_0_0.product_hardening
 
 ## Release Documents
 
+- Versioning: `docs/ops/versioning.md`
+- Release index: `docs/ops/releases/README.md`
+- Release index (zh): `docs/ops/releases/README.zh.md`
 - Release notes: `docs/ops/release_notes_v2.0.0.md`
 - Release checklist: `docs/ops/release_checklist_v2.0.0.md`
 - Evidence manifest: `docs/ops/releases/v2.0.0/evidence_manifest.md`
@@ -80,7 +83,9 @@ Release governance rollback is file-level:
 - remove `verify.release.v2_0_0.product_hardening` from `Makefile`
 - remove `verify.release.v2_0_0.governance.guard` from `Makefile`
 - remove `verify.release.v2_0_0.formal_evidence.schema.guard` from `Makefile`
-- restore release index and versioning edits
+- restore `docs/ops/versioning.md` edits
+- restore `docs/ops/releases/README.md` edits
+- restore `docs/ops/releases/README.zh.md` edits
 
 Runtime rollback is outside this governance batch and must follow the production
 runbook if production deployment has started.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -19,6 +19,10 @@ README_TOKENS = (
     "- Planned gate tag: `gate-release-v2.0`",
     "- Planned RC tag: `v2.0.0-rc1`",
     "- Planned final tag: `v2.0.0`",
+    "- Module: versioning, release index, release checklist, release notes, release evidence manifest",
+    "- Versioning: `docs/ops/versioning.md`",
+    "- Release index: `docs/ops/releases/README.md`",
+    "- Release index (zh): `docs/ops/releases/README.zh.md`",
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
     "make verify.release.v2_0_0.governance.guard",
@@ -29,6 +33,9 @@ README_TOKENS = (
     "remove `verify.release.v2_0_0.product_hardening` from `Makefile`",
     "remove `verify.release.v2_0_0.governance.guard` from `Makefile`",
     "remove `verify.release.v2_0_0.formal_evidence.schema.guard` from `Makefile`",
+    "restore `docs/ops/versioning.md` edits",
+    "restore `docs/ops/releases/README.md` edits",
+    "restore `docs/ops/releases/README.zh.md` edits",
     "Runtime rollback is outside this governance batch",
 )
 


### PR DESCRIPTION
## Summary

- list versioning and release index docs as v2 controlled release documents
- make rollback targets explicit for versioning and both release indexes
- guard the expanded control README document scope

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`