### PR TITLE
Guard v2 verify catalog scope

### DIFF
--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -10,6 +10,7 @@
 - Versioning reviewed: `docs/ops/versioning.md`.
 - Release indexes reviewed: `docs/ops/releases/README.md` and
   `docs/ops/releases/README.zh.md`.
+- Verify catalog reviewed: `docs/ops/verify/README.md`.
 - No production command is executed from a dirty worktree.
 
 ## Version And Tag Checks

--- a/docs/ops/releases/v2.0.0/README.md
+++ b/docs/ops/releases/v2.0.0/README.md
@@ -13,7 +13,7 @@
 ## Layer Target / Module / Reason
 
 - Layer Target: Ops / Release Governance
-- Module: versioning, release index, release checklist, release notes, release evidence manifest
+- Module: versioning, release index, release checklist, release notes, release evidence manifest, verify catalog
 - Reason: establish the active formal release line before RC and production
   deployment work begins, avoiding reuse of the existing remote `v1.0.0` tag.
 
@@ -55,6 +55,7 @@ make verify.release.v2_0_0.product_hardening
 - Versioning: `docs/ops/versioning.md`
 - Release index: `docs/ops/releases/README.md`
 - Release index (zh): `docs/ops/releases/README.zh.md`
+- Verify catalog: `docs/ops/verify/README.md`
 - Release notes: `docs/ops/release_notes_v2.0.0.md`
 - Release checklist: `docs/ops/release_checklist_v2.0.0.md`
 - Evidence manifest: `docs/ops/releases/v2.0.0/evidence_manifest.md`
@@ -86,6 +87,7 @@ Release governance rollback is file-level:
 - restore `docs/ops/versioning.md` edits
 - restore `docs/ops/releases/README.md` edits
 - restore `docs/ops/releases/README.zh.md` edits
+- restore `docs/ops/verify/README.md` edits
 
 Runtime rollback is outside this governance batch and must follow the production
 runbook if production deployment has started.

--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -50,7 +50,7 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 | Release checklist signoff | manual review | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Release checklist guard | `make verify.release.v2_0_0.checklist.guard` | PASS | `docs/ops/release_checklist_v2.0.0.md` |
 | Evidence manifest guard | `make verify.release.v2_0_0.evidence_manifest.guard` | PASS | `docs/ops/releases/v2.0.0/evidence_manifest.md` |
-| Release control docs guard | `make verify.release.v2_0_0.control_docs.guard` | PASS | `docs/ops/releases/v2.0.0/README.md`, `docs/ops/release_notes_v2.0.0.md`, `docs/ops/versioning.md`, `docs/ops/releases/README.md`, and `docs/ops/releases/README.zh.md` |
+| Release control docs guard | `make verify.release.v2_0_0.control_docs.guard` | PASS | `docs/ops/releases/v2.0.0/README.md`, `docs/ops/release_notes_v2.0.0.md`, `docs/ops/versioning.md`, `docs/ops/releases/README.md`, `docs/ops/releases/README.zh.md`, and `docs/ops/verify/README.md` |
 | Release governance guard | `make verify.release.v2_0_0.governance.guard` | PASS | release-control docs, evidence manifest, and checklist guard terminal output |
 | Formal evidence schema guard | `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard` | PASS | governance, hardening, dev acceptance, and prod-sim acceptance evidence shape guard terminal output |
 

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -194,12 +194,12 @@
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
-  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, production safety, post-release, and stop-condition sections.
-  - Enforces required release tag names and prod/prod-sim evidence separation language.
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections.
+  - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
-  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, evidence rules, and explicit prod-sim evidence directory validation.
+  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence tables, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
-  - Verifies the v2.0.0 release-control README, release notes, and versioning guide keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, and verification catalog keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -29,6 +29,7 @@ REQUIRED_TOKENS = (
     "Versioning reviewed: `docs/ops/versioning.md`.",
     "Release indexes reviewed: `docs/ops/releases/README.md` and",
     "`docs/ops/releases/README.zh.md`.",
+    "Verify catalog reviewed: `docs/ops/verify/README.md`.",
     "make release.dev.acceptance.publish",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard",
     "artifacts/backend/dev_acceptance_release_probe.json",

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -12,6 +12,7 @@ RELEASE_NOTES = ROOT / "docs" / "ops" / "release_notes_v2.0.0.md"
 VERSIONING = ROOT / "docs" / "ops" / "versioning.md"
 RELEASE_INDEX_EN = ROOT / "docs" / "ops" / "releases" / "README.md"
 RELEASE_INDEX_ZH = ROOT / "docs" / "ops" / "releases" / "README.zh.md"
+VERIFY_README = ROOT / "docs" / "ops" / "verify" / "README.md"
 
 README_TOKENS = (
     "# v2.0.0 Release Control",
@@ -19,10 +20,11 @@ README_TOKENS = (
     "- Planned gate tag: `gate-release-v2.0`",
     "- Planned RC tag: `v2.0.0-rc1`",
     "- Planned final tag: `v2.0.0`",
-    "- Module: versioning, release index, release checklist, release notes, release evidence manifest",
+    "- Module: versioning, release index, release checklist, release notes, release evidence manifest, verify catalog",
     "- Versioning: `docs/ops/versioning.md`",
     "- Release index: `docs/ops/releases/README.md`",
     "- Release index (zh): `docs/ops/releases/README.zh.md`",
+    "- Verify catalog: `docs/ops/verify/README.md`",
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
     "make verify.release.v2_0_0.governance.guard",
@@ -36,6 +38,7 @@ README_TOKENS = (
     "restore `docs/ops/versioning.md` edits",
     "restore `docs/ops/releases/README.md` edits",
     "restore `docs/ops/releases/README.zh.md` edits",
+    "restore `docs/ops/verify/README.md` edits",
     "Runtime rollback is outside this governance batch",
 )
 
@@ -95,6 +98,17 @@ RELEASE_INDEX_ZH_TOKENS = (
     "GitHub Release：正式 tag 后必须发布",
 )
 
+VERIFY_README_TOKENS = (
+    "`make verify.release.v2_0_0.checklist.guard`",
+    "controlled-doc review",
+    "versioning/release-index review",
+    "`make verify.release.v2_0_0.evidence_manifest.guard`",
+    "controlled-doc artifact coverage",
+    "`make verify.release.v2_0_0.control_docs.guard`",
+    "release indexes, and verification catalog",
+    "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
+)
+
 FORBIDDEN_TOKENS = (
     "Product delivery baseline: 9 modules",
     "reuse `v1.0.0`",
@@ -124,6 +138,7 @@ def main() -> int:
     _contains_all(VERSIONING, VERSIONING_TOKENS, errors)
     _contains_all(RELEASE_INDEX_EN, RELEASE_INDEX_EN_TOKENS, errors)
     _contains_all(RELEASE_INDEX_ZH, RELEASE_INDEX_ZH_TOKENS, errors)
+    _contains_all(VERIFY_README, VERIFY_README_TOKENS, errors)
     if errors:
         print("[release_v2_0_0_control_docs_guard] FAIL")
         for error in errors:

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -33,6 +33,7 @@ REQUIRED_TOKENS = (
     "`docs/ops/versioning.md`",
     "`docs/ops/releases/README.md`",
     "`docs/ops/releases/README.zh.md`",
+    "`docs/ops/verify/README.md`",
     "`make verify.release.v2_0_0.governance.guard`",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",


### PR DESCRIPTION
## Summary

- bring the v2 verify catalog description up to date with controlled-doc review scope
- include docs/ops/verify/README.md in release-control docs coverage, rollback, checklist review, and evidence manifest artifacts
- guard the verify catalog wording from the v2 control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `make verify.release.v2_0_0.checklist.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
