### PR TITLE
Guard v2 release notes governance scope

### DIFF
--- a/docs/ops/release_notes_v2.0.0.md
+++ b/docs/ops/release_notes_v2.0.0.md
@@ -20,6 +20,8 @@ track to `v2.0.0`.
 - Dev acceptance path: uploaded backup validation, static rebuild, API lock, and
   optional real-user `system.init` probe.
 - Release gate: one-command preflight through `make verify.release.v2_0_0.preflight`.
+- Release governance docs: release-control README, release notes, versioning,
+  release indexes, evidence manifest, checklist, and verify catalog.
 
 ## Tag Plan
 

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -54,6 +54,8 @@ NOTES_TOKENS = (
     "make verify.release.v2_0_0.governance.guard",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo",
+    "Release governance docs: release-control README, release notes, versioning,",
+    "release indexes, evidence manifest, checklist, and verify catalog.",
     "Production deployment is not part of this release-note batch.",
     "RC tags are immutable once published.",
 )


### PR DESCRIPTION
## Summary

- document the expanded v2 governance document scope in release notes
- guard the release notes governance scope wording from the control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
