### PR TITLE
Guard v2 evidence sample boundary

### DIFF
--- a/docs/ops/releases/v2.0.0/evidence_manifest.md
+++ b/docs/ops/releases/v2.0.0/evidence_manifest.md
@@ -91,5 +91,11 @@ This manifest supersedes the planned `v1.0.0` release line because the remote
 - Evidence shape guards:
   - `make verify.bundle.installation.ready.schema.guard`
   - `make verify.platform.performance.smoke.schema.guard`
+- Schema-only guard runs may use recorded artifact directories to verify evidence
+  shape, but recorded sample artifacts are not release signoff evidence.
 - Note: before creating `gate-release-v2.0` or `v2.0.0-rc1`, rerun required
   gates on a clean reviewed release database and attach the fresh artifacts.
+- Note: before creating final `v2.0.0`, rerun
+  `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
+  against the recorded prod-sim acceptance run directory for that release
+  candidate.

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -40,6 +40,10 @@ REQUIRED_TOKENS = (
     "Production deployment evidence is recorded separately after supervised",
     "Failed evidence is not overwritten without preserving the failure reason",
     "prod-sim acceptance artifact path to be recorded",
+    "Schema-only guard runs may use recorded artifact directories to verify evidence",
+    "recorded sample artifacts are not release signoff evidence",
+    "before creating final `v2.0.0`, rerun",
+    "against the recorded prod-sim acceptance run directory for that release",
 )
 
 FORBIDDEN_TOKENS = (


### PR DESCRIPTION
## Summary

- clarify that schema-only checks may use recorded artifact directories only for evidence shape validation
- state that sample artifacts are not release signoff evidence
- require final v2.0.0 schema verification against the recorded prod-sim acceptance run directory

## Validation

- `make verify.release.v2_0_0.evidence_manifest.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
