### PR TITLE
Guard v2 checklist sample evidence boundary

### DIFF
--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -109,6 +109,8 @@ Before formal release:
 - `sc_prod_sim` upgrade or replay path is executed only through Makefile targets.
 - Prod-sim acceptance evidence is validated with
   `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`.
+- Recorded sample artifact directories may validate schema shape only; they are
+  not release signoff evidence.
 - Frontend static assets are rebuilt for the intended target DB/env.
 - Real-user acceptance uses named business users, not only service smoke users.
 - Prod-sim evidence is kept separate from production evidence.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -32,6 +32,8 @@ REQUIRED_TOKENS = (
     "Verify catalog reviewed: `docs/ops/verify/README.md`.",
     "make release.dev.acceptance.publish",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard",
+    "Recorded sample artifact directories may validate schema shape only",
+    "not release signoff evidence.",
     "artifacts/backend/dev_acceptance_release_probe.json",
     "gate-release-v2.0",
     "v2.0.0-rc1",


### PR DESCRIPTION
## Summary

- state in the v2 checklist that recorded sample artifact directories only validate schema shape
- guard the checklist wording so sample artifacts cannot be mistaken for release signoff evidence

## Validation

- `make verify.release.v2_0_0.checklist.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
