### PR TITLE
Guard v2 release notes sample evidence boundary

### DIFF
--- a/docs/ops/release_notes_v2.0.0.md
+++ b/docs/ops/release_notes_v2.0.0.md
@@ -67,5 +67,7 @@ follow `docs/ops/production_deployment_runbook_v1.md` and
   final tag.
 - Strict live checks may require a live-enabled runner; local restricted evidence
   is not a substitute for production deployment acceptance.
+- Recorded sample artifact directories may validate evidence schema shape, but
+  are not release signoff evidence.
 - RC tags are immutable once published. Any blocker fix requires a new commit and
   a new RC tag.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -56,6 +56,8 @@ NOTES_TOKENS = (
     "ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo",
     "Release governance docs: release-control README, release notes, versioning,",
     "release indexes, evidence manifest, checklist, and verify catalog.",
+    "Recorded sample artifact directories may validate evidence schema shape",
+    "are not release signoff evidence.",
     "Production deployment is not part of this release-note batch.",
     "RC tags are immutable once published.",
 )


### PR DESCRIPTION
## Summary

- add the sample-artifact evidence boundary to v2 release notes
- guard the release notes wording from the v2 control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
