### PR TITLE
Guard v2 verify catalog sample boundary

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -204,6 +204,7 @@
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
   - Runs the v2.0.0 governance, product hardening schema, dev acceptance schema, and prod-sim acceptance evidence schema guards as the formal evidence shape closure target.
+  - Recorded sample artifact directories may validate schema shape only; final release signoff requires the recorded prod-sim acceptance run directory for that release candidate.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.prod.sim.acceptance.evidence.schema.guard`
   - Verifies explicit prod-sim acceptance evidence under the recorded run directory.
   - Requires strict SCBS release acceptance JSON/MD and no-legacy replay acceptance JSON to target `sc_prod_sim`; no default run directory is inferred.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -113,6 +113,8 @@ VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, and verification catalog",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
+    "Recorded sample artifact directories may validate schema shape only",
+    "final release signoff requires the recorded prod-sim acceptance run directory",
 )
 
 FORBIDDEN_TOKENS = (


### PR DESCRIPTION
## Summary

- document the sample-artifact boundary in the v2 verify catalog formal evidence target
- guard the verify catalog wording from the v2 control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
