### PR TITLE
Guard v2 control README sample evidence boundary

### DIFF
--- a/docs/ops/releases/v2.0.0/README.md
+++ b/docs/ops/releases/v2.0.0/README.md
@@ -73,6 +73,10 @@ make verify.release.v2_0_0.product_hardening
 9. Create `v2.0.0-rc1` after RC evidence passes.
 10. Create `v2.0.0` after formal release signoff.
 
+Recorded sample artifact directories may validate schema shape only; final
+release signoff requires the recorded prod-sim acceptance run directory for that
+release candidate.
+
 ## Rollback
 
 Release governance rollback is file-level:

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -31,6 +31,8 @@ README_TOKENS = (
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "Run prod-sim acceptance.",
     "Create `v2.0.0` after formal release signoff.",
+    "Recorded sample artifact directories may validate schema shape only",
+    "release signoff requires the recorded prod-sim acceptance run directory",
     "remove `verify.release.v2_0_0.preflight` from `Makefile`",
     "remove `verify.release.v2_0_0.product_hardening` from `Makefile`",
     "remove `verify.release.v2_0_0.governance.guard` from `Makefile`",


### PR DESCRIPTION
## Summary

- add the sample-artifact evidence boundary to the v2 release-control README promotion order
- guard the control README wording from the v2 control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
