### PR TITLE
Guard v2 versioning sample evidence boundary

### DIFF
--- a/docs/ops/versioning.md
+++ b/docs/ops/versioning.md
@@ -98,5 +98,9 @@ Promotion order:
 6. Create `v2.0.0-rc1` only after RC evidence passes.
 7. Create `v2.0.0` only after prod-sim acceptance and release checklist signoff.
 
+Recorded sample artifact directories may validate schema shape only; final
+release signoff requires the recorded prod-sim acceptance run directory for that
+release candidate.
+
 Production deployment is not implied by creating `v2.0.0`; deployment remains a
 separate supervised operation under `docs/ops/production_deployment_runbook_v1.md`.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -75,6 +75,8 @@ VERSIONING_TOKENS = (
     "make verify.release.v2_0_0.preflight",
     "make verify.release.v2_0_0.product_hardening",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
+    "Recorded sample artifact directories may validate schema shape only",
+    "release signoff requires the recorded prod-sim acceptance run directory",
     "Production deployment is not implied by creating `v2.0.0`",
 )
 


### PR DESCRIPTION
## Summary

- add the sample-artifact evidence boundary to the v2 versioning promotion order
- guard the versioning wording from the v2 control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
