### PR TITLE
Guard v2 release index evidence boundary

### DIFF
--- a/docs/ops/releases/README.md
+++ b/docs/ops/releases/README.md
@@ -27,6 +27,7 @@ Other release notes under `docs/release/` or GitHub Releases are supporting copi
   - Verify: `make verify.release.v2_0_0.preflight`
   - Governance Verify: `make verify.release.v2_0_0.governance.guard`
   - Formal Evidence Verify: `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
+  - Evidence Boundary: recorded sample artifacts are not release signoff evidence
   - GitHub Release: required after formal tag
 
 ## Release List (Newest First)

--- a/docs/ops/releases/README.zh.md
+++ b/docs/ops/releases/README.zh.md
@@ -22,6 +22,7 @@ status: active
   - Verify：`make verify.release.v2_0_0.preflight`
   - Governance Verify：`make verify.release.v2_0_0.governance.guard`
   - Formal Evidence Verify：`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
+  - Evidence Boundary：历史样本证据不可作为发布签发证据
   - GitHub Release：正式 tag 后必须发布
 
 ## 模板

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -91,6 +91,7 @@ RELEASE_INDEX_EN_TOKENS = (
     "Verify: `make verify.release.v2_0_0.preflight`",
     "Governance Verify: `make verify.release.v2_0_0.governance.guard`",
     "Formal Evidence Verify: `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
+    "Evidence Boundary: recorded sample artifacts are not release signoff evidence",
     "GitHub Release: required after formal tag",
 )
 
@@ -105,6 +106,7 @@ RELEASE_INDEX_ZH_TOKENS = (
     "Verify：`make verify.release.v2_0_0.preflight`",
     "Governance Verify：`make verify.release.v2_0_0.governance.guard`",
     "Formal Evidence Verify：`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
+    "Evidence Boundary：历史样本证据不可作为发布签发证据",
     "GitHub Release：正式 tag 后必须发布",
 )
 


### PR DESCRIPTION
## Summary

- add an evidence boundary line to the English and Chinese v2 release index entries
- guard the index wording so sample artifacts cannot be treated as release signoff evidence

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
