### PR TITLE
Record v2 iteration evidence boundary

### DIFF
--- a/docs/ops/iterations/release_v2_0_0_version_governance_batch_20260512.md
+++ b/docs/ops/iterations/release_v2_0_0_version_governance_batch_20260512.md
@@ -22,6 +22,10 @@ Current validation shape:
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`
 - `git diff --check`
 
+Recorded sample artifact directories may validate schema shape only; final
+release signoff requires the recorded prod-sim acceptance run directory for that
+release candidate.
+
 No tag creation, production deployment, production database operation, or
 prod-sim destructive runtime operation is implied by this follow-up closure.
 


### PR DESCRIPTION
## Summary

- record the sample-artifact evidence boundary in the v2 governance iteration follow-up
- keep the historical handoff note aligned with the current release governance docs

## Validation

- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
