### PR TITLE
Guard v2 evidence manifest table shape

### DIFF
--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -53,6 +53,88 @@ FORBIDDEN_TOKENS = (
     "sc_prod evidence",
 )
 
+REQUIRED_TABLE_EVIDENCE = {
+    "## Required Before `gate-release-v2.0`": (
+        "System capability baseline",
+        "System capability baseline schema",
+        "Platform release policy runtime",
+        "Platform release policy runtime schema",
+        "Backend contract closure",
+        "Backend contract closure snapshot schema",
+        "Restricted product mainline",
+        "Restricted product mainline schema",
+        "Diff hygiene",
+    ),
+    "## Required Before `v2.0.0-rc1`": (
+        "Release preflight",
+        "Action closure smoke",
+        "Action closure schema",
+        "Module capability smoke",
+        "Module capability schema",
+        "Intent alias snapshot",
+        "Intent alias snapshot schema",
+    ),
+    "## Required Product Hardening Before Formal `v2.0.0`": (
+        "Product release readiness",
+        "Bundle installation schema",
+        "View richness hardening",
+        "Platform performance smoke",
+        "Platform performance schema",
+    ),
+    "## Required Before Formal `v2.0.0`": (
+        "Dev acceptance publish",
+        "Dev acceptance schema",
+        "Prod-sim acceptance",
+        "Prod-sim acceptance schema",
+        "Release checklist signoff",
+        "Release checklist guard",
+        "Evidence manifest guard",
+        "Release control docs guard",
+        "Release governance guard",
+        "Formal evidence schema guard",
+    ),
+}
+
+
+def _table_evidence_for_section(text: str, heading: str) -> tuple[str, ...] | None:
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError:
+        return None
+
+    table_rows: list[str] = []
+    in_table = False
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        if line.startswith("|"):
+            in_table = True
+            table_rows.append(line)
+        elif in_table and line.strip():
+            break
+
+    evidence: list[str] = []
+    for row in table_rows:
+        cells = [cell.strip() for cell in row.strip().strip("|").split("|")]
+        if not cells or cells[0] in {"Evidence", "---"}:
+            continue
+        evidence.append(cells[0])
+    return tuple(evidence)
+
+
+def _contains_required_table_evidence(text: str, errors: list[str]) -> None:
+    for heading, expected_evidence in REQUIRED_TABLE_EVIDENCE.items():
+        actual_evidence = _table_evidence_for_section(text, heading)
+        if actual_evidence is None:
+            errors.append(f"manifest missing section table: {heading}")
+            continue
+        if actual_evidence != expected_evidence:
+            errors.append(
+                "manifest evidence table mismatch: "
+                f"{heading} expected={expected_evidence!r} actual={actual_evidence!r}"
+            )
+
 
 def main() -> int:
     errors: list[str] = []
@@ -68,6 +150,7 @@ def main() -> int:
                 errors.append(f"manifest contains forbidden token: {token}")
         if text.count("| Evidence | Command | Required Result | Artifact |") != 4:
             errors.append("manifest must contain four evidence tables")
+        _contains_required_table_evidence(text, errors)
 
     if errors:
         print("[release_v2_0_0_evidence_manifest_guard] FAIL")


### PR DESCRIPTION
## Summary

- parse the v2 evidence manifest tables by section
- enforce the expected evidence rows and order for gate, RC, product hardening, and formal release sections

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
