### PR TITLE
Guard v2 checklist section order

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -194,7 +194,7 @@
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
-  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections.
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table rows/order, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -51,6 +51,32 @@ FORBIDDEN_TOKENS = (
     "ENV=prod make",
 )
 
+REQUIRED_SECTION_ORDER = (
+    "## Preconditions",
+    "## Version And Tag Checks",
+    "## Local / CI Gate",
+    "## Contract And Startup Gate",
+    "## Product Hardening Gate",
+    "## Dev Acceptance Gate",
+    "## Prod-Sim Gate",
+    "## Production Safety",
+    "## Post-Release",
+    "## Stop Conditions",
+)
+
+
+def _heading_order(text: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in text.splitlines() if line.startswith("## "))
+
+
+def _contains_required_section_order(text: str, errors: list[str]) -> None:
+    actual_order = _heading_order(text)
+    if actual_order != REQUIRED_SECTION_ORDER:
+        errors.append(
+            "checklist section order mismatch: "
+            f"expected={REQUIRED_SECTION_ORDER!r} actual={actual_order!r}"
+        )
+
 
 def main() -> int:
     errors: list[str] = []
@@ -64,6 +90,7 @@ def main() -> int:
         for token in FORBIDDEN_TOKENS:
             if token in text:
                 errors.append(f"checklist contains forbidden token: {token}")
+        _contains_required_section_order(text, errors)
 
     if errors:
         print("[release_v2_0_0_checklist_guard] FAIL")

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -114,6 +114,7 @@ RELEASE_INDEX_ZH_TOKENS = (
 VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "controlled-doc review",
+    "sections in the expected order",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "evidence table rows/order",


### PR DESCRIPTION
## Summary

- enforce the v2 release checklist section order from the checklist guard
- document the ordered-section coverage in the verify catalog
- guard the verify catalog wording from the v2 control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
