### PR TITLE
Guard v2 checklist command blocks

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -195,6 +195,7 @@
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
   - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order.
+  - Enforces RC and formal-release command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table rows/order, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -64,6 +64,26 @@ REQUIRED_SECTION_ORDER = (
     "## Stop Conditions",
 )
 
+REQUIRED_COMMAND_BLOCKS = (
+    (
+        "Required before RC:",
+        (
+            "make verify.release.v2_0_0.preflight",
+            "git diff --check",
+        ),
+    ),
+    (
+        "Required before formal `v2.0.0`:",
+        (
+            "make verify.release.v2_0_0.product_hardening",
+            "make verify.release.v2_0_0.governance.guard",
+            "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
+            "make verify.release.v2_0_0.control_docs.guard",
+            "make verify.release.v2_0_0.evidence_manifest.guard",
+        ),
+    ),
+)
+
 
 def _heading_order(text: str) -> tuple[str, ...]:
     return tuple(line.strip() for line in text.splitlines() if line.startswith("## "))
@@ -76,6 +96,35 @@ def _contains_required_section_order(text: str, errors: list[str]) -> None:
             "checklist section order mismatch: "
             f"expected={REQUIRED_SECTION_ORDER!r} actual={actual_order!r}"
         )
+
+
+def _command_block_after(text: str, marker: str) -> tuple[str, ...] | None:
+    marker_index = text.find(marker)
+    if marker_index < 0:
+        return None
+    after_marker = text[marker_index + len(marker) :]
+    fence_start = after_marker.find("```bash")
+    if fence_start < 0:
+        return None
+    after_fence = after_marker[fence_start + len("```bash") :]
+    fence_end = after_fence.find("```")
+    if fence_end < 0:
+        return None
+    block = after_fence[:fence_end]
+    return tuple(line.strip() for line in block.splitlines() if line.strip())
+
+
+def _contains_required_command_blocks(text: str, errors: list[str]) -> None:
+    for marker, expected_commands in REQUIRED_COMMAND_BLOCKS:
+        actual_commands = _command_block_after(text, marker)
+        if actual_commands is None:
+            errors.append(f"checklist missing command block after marker: {marker}")
+            continue
+        if actual_commands != expected_commands:
+            errors.append(
+                "checklist command block mismatch: "
+                f"{marker} expected={expected_commands!r} actual={actual_commands!r}"
+            )
 
 
 def main() -> int:
@@ -91,6 +140,7 @@ def main() -> int:
             if token in text:
                 errors.append(f"checklist contains forbidden token: {token}")
         _contains_required_section_order(text, errors)
+        _contains_required_command_blocks(text, errors)
 
     if errors:
         print("[release_v2_0_0_checklist_guard] FAIL")

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -115,6 +115,7 @@ VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "controlled-doc review",
     "sections in the expected order",
+    "Enforces RC and formal-release command blocks exactly.",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "evidence table rows/order",


### PR DESCRIPTION
## Summary

- parse v2 checklist RC and formal-release command blocks exactly
- document the command-block coverage in the verify catalog
- guard the verify catalog wording from the v2 control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
