### PR TITLE
Document v2 control docs shape guard

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -201,6 +201,7 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table rows/order, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Enforces release document list and promotion order shape for the v2.0.0 control README and versioning guide.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -122,6 +122,7 @@ VERIFY_README_TOKENS = (
     "controlled-doc artifact coverage",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target dependencies",
+    "Enforces release document list and promotion order shape",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Recorded sample artifact directories may validate schema shape only",
     "final release signoff requires the recorded prod-sim acceptance run directory",


### PR DESCRIPTION
## Summary

- document that the v2 control docs guard enforces release document list and promotion order shape
- guard the verify catalog wording from the control docs guard

## Validation

- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
