### PR TITLE
Guard v2 evidence local status structure

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -198,7 +198,7 @@
   - Enforces RC and formal-release command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
-  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table rows/order, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
+  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table rows/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Enforces release document list, release-control boundary and gate command blocks, rollback list, release-index planned entries, release-notes tag plan and minimum verification commands, and promotion order shape for the v2.0.0 control README and versioning guide.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -119,6 +119,7 @@ VERIFY_README_TOKENS = (
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "evidence table rows/order",
+    "current local verification status structure",
     "controlled-doc artifact coverage",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target dependencies",

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -95,6 +95,22 @@ REQUIRED_TABLE_EVIDENCE = {
     ),
 }
 
+REQUIRED_LOCAL_STATUS_ITEMS = (
+    "Command: `make verify.release.v2_0_0.product_hardening`",
+    "Status: blocked in the current local `sc_demo` dev verification environment",
+    "Current blocker evidence:",
+    "Evidence shape guard:",
+    "Current blocker facts on `sc_demo`:",
+    "Latest passing sub-gate in this batch:",
+    "Closed sub-gates: `verify.bundle.installation.ready` and",
+    "Release hardening also includes",
+    "Artifacts:",
+    "Evidence shape guards:",
+    "Schema-only guard runs may use recorded artifact directories to verify evidence",
+    "Note: before creating `gate-release-v2.0` or `v2.0.0-rc1`, rerun required",
+    "Note: before creating final `v2.0.0`, rerun",
+)
+
 
 def _table_evidence_for_section(text: str, heading: str) -> tuple[str, ...] | None:
     lines = text.splitlines()
@@ -123,6 +139,22 @@ def _table_evidence_for_section(text: str, heading: str) -> tuple[str, ...] | No
     return tuple(evidence)
 
 
+def _top_level_bullets_after_heading(text: str, heading: str) -> tuple[str, ...] | None:
+    lines = text.splitlines()
+    try:
+        start = lines.index(heading)
+    except ValueError:
+        return None
+
+    items: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("## "):
+            break
+        if line.startswith("- "):
+            items.append(line[2:].strip())
+    return tuple(items)
+
+
 def _contains_required_table_evidence(text: str, errors: list[str]) -> None:
     for heading, expected_evidence in REQUIRED_TABLE_EVIDENCE.items():
         actual_evidence = _table_evidence_for_section(text, heading)
@@ -134,6 +166,18 @@ def _contains_required_table_evidence(text: str, errors: list[str]) -> None:
                 "manifest evidence table mismatch: "
                 f"{heading} expected={expected_evidence!r} actual={actual_evidence!r}"
             )
+
+
+def _contains_required_local_status_items(text: str, errors: list[str]) -> None:
+    actual_items = _top_level_bullets_after_heading(text, "## Current Local Verification Status")
+    if actual_items is None:
+        errors.append("manifest missing section: ## Current Local Verification Status")
+        return
+    if actual_items != REQUIRED_LOCAL_STATUS_ITEMS:
+        errors.append(
+            "manifest local verification status items mismatch: "
+            f"expected={REQUIRED_LOCAL_STATUS_ITEMS!r} actual={actual_items!r}"
+        )
 
 
 def main() -> int:
@@ -151,6 +195,7 @@ def main() -> int:
         if text.count("| Evidence | Command | Required Result | Artifact |") != 4:
             errors.append("manifest must contain four evidence tables")
         _contains_required_table_evidence(text, errors)
+        _contains_required_local_status_items(text, errors)
 
     if errors:
         print("[release_v2_0_0_evidence_manifest_guard] FAIL")


### PR DESCRIPTION
## Summary

- enforce the ordered Current Local Verification Status bullets in the v2 evidence manifest guard
- document current local status structure coverage in the verify catalog
- add the new verify catalog phrase to the control docs guard token set

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
