### PR TITLE
Guard v2 control README header lists

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -201,7 +201,7 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
-  - Enforces release document list, release-control boundary and gate command blocks, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.
+  - Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.
 - `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -124,10 +124,26 @@ VERIFY_README_TOKENS = (
     "controlled-doc artifact coverage",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target dependencies",
-    "Enforces release document list, release-control boundary and gate command blocks, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape",
+    "Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Recorded sample artifact directories may validate schema shape only",
     "final release signoff requires the recorded prod-sim acceptance run directory",
+)
+
+README_STATUS_ITEMS = (
+    "Version: `v2.0.0`",
+    "Status: planned",
+    "Release type: formal release",
+    "Planned gate tag: `gate-release-v2.0`",
+    "Planned RC tag: `v2.0.0-rc1`",
+    "Planned final tag: `v2.0.0`",
+    "Governance date: 2026-05-12",
+)
+
+README_LAYER_TARGET_ITEMS = (
+    "Layer Target: Ops / Release Governance",
+    "Module: versioning, release index, release checklist, release notes, release evidence manifest, verify catalog",
+    "Reason: establish the active formal release line before RC and production",
 )
 
 README_RELEASE_DOCUMENTS = (
@@ -443,6 +459,26 @@ def _contains_readme_release_documents(errors: list[str]) -> None:
         )
 
 
+def _contains_readme_section_list(
+    heading: str,
+    expected_items: tuple[str, ...],
+    errors: list[str],
+) -> None:
+    if not CONTROL_README.is_file():
+        errors.append(f"missing release-control README: {CONTROL_README.relative_to(ROOT).as_posix()}")
+        return
+    text = CONTROL_README.read_text(encoding="utf-8")
+    actual_items = _list_items_after_heading(text, heading)
+    if actual_items is None:
+        errors.append(f"release-control README missing section: {heading}")
+        return
+    if actual_items != expected_items:
+        errors.append(
+            "release-control README section items mismatch: "
+            f"{heading} expected={expected_items!r} actual={actual_items!r}"
+        )
+
+
 def _contains_readme_boundaries(errors: list[str]) -> None:
     if not CONTROL_README.is_file():
         errors.append(f"missing release-control README: {CONTROL_README.relative_to(ROOT).as_posix()}")
@@ -655,6 +691,8 @@ def main() -> int:
     _contains_all(RELEASE_INDEX_EN, RELEASE_INDEX_EN_TOKENS, errors)
     _contains_all(RELEASE_INDEX_ZH, RELEASE_INDEX_ZH_TOKENS, errors)
     _contains_all(VERIFY_README, VERIFY_README_TOKENS, errors)
+    _contains_readme_section_list("## Status", README_STATUS_ITEMS, errors)
+    _contains_readme_section_list("## Layer Target / Module / Reason", README_LAYER_TARGET_ITEMS, errors)
     _contains_readme_release_documents(errors)
     _contains_readme_boundaries(errors)
     _contains_readme_gate_commands(errors)


### PR DESCRIPTION
## Summary

- enforce v2 release-control README Status bullets exactly
- enforce Layer Target / Module / Reason bullets exactly
- update the verify catalog wording for the expanded control README structure coverage

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
