### PR TITLE
Guard v2 Makefile guard recipes

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -200,7 +200,7 @@
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
-  - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -123,7 +123,7 @@ VERIFY_README_TOKENS = (
     "current local verification status structure",
     "controlled-doc artifact coverage",
     "`make verify.release.v2_0_0.control_docs.guard`",
-    "release indexes, verification catalog, and Makefile target dependencies",
+    "release indexes, verification catalog, and Makefile target dependencies and guard recipes",
     "Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Recorded sample artifact directories may validate schema shape only",
@@ -334,6 +334,30 @@ MAKEFILE_TARGET_PREREQS = (
     ),
 )
 
+MAKEFILE_TARGET_RECIPES = (
+    (
+        "verify.release.v2_0_0.checklist.guard",
+        (
+            "@python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py",
+            "@python3 scripts/verify/release_v2_0_0_checklist_guard.py",
+        ),
+    ),
+    (
+        "verify.release.v2_0_0.evidence_manifest.guard",
+        (
+            "@python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py",
+            "@python3 scripts/verify/release_v2_0_0_evidence_manifest_guard.py",
+        ),
+    ),
+    (
+        "verify.release.v2_0_0.control_docs.guard",
+        (
+            "@python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py",
+            "@python3 scripts/verify/release_v2_0_0_control_docs_guard.py",
+        ),
+    ),
+)
+
 FORBIDDEN_TOKENS = (
     "Product delivery baseline: 9 modules",
     "reuse `v1.0.0`",
@@ -372,6 +396,21 @@ def _makefile_prereqs(text: str, target: str) -> tuple[str, ...] | None:
             chunks.append(lines[cursor].strip())
         prereq_text = " ".join(chunk for chunk in chunks if chunk)
         return tuple(prereq_text.split())
+    return None
+
+
+def _makefile_recipe(text: str, target: str) -> tuple[str, ...] | None:
+    prefix = f"{target}:"
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith(prefix):
+            continue
+        recipe: list[str] = []
+        for recipe_line in lines[index + 1 :]:
+            if not recipe_line.startswith("\t"):
+                break
+            recipe.append(recipe_line.strip())
+        return tuple(recipe)
     return None
 
 
@@ -680,6 +719,16 @@ def _contains_makefile_targets(errors: list[str]) -> None:
             errors.append(
                 "Makefile target prereqs mismatch: "
                 f"{target} expected={expected_prereqs!r} actual={actual_prereqs!r}"
+            )
+    for target, expected_recipe in MAKEFILE_TARGET_RECIPES:
+        actual_recipe = _makefile_recipe(text, target)
+        if actual_recipe is None:
+            errors.append(f"Makefile missing target: {target}")
+            continue
+        if actual_recipe != expected_recipe:
+            errors.append(
+                "Makefile target recipe mismatch: "
+                f"{target} expected={expected_recipe!r} actual={actual_recipe!r}"
             )
 
 


### PR DESCRIPTION
## Summary

- enforce Makefile recipes for the v2 checklist, evidence manifest, and control docs guards
- keep each guard target compiling and running its expected script
- document Makefile guard recipe coverage in the verify catalog and guard that wording

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
