### PR TITLE
Guard v2 evidence rules structure

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -198,7 +198,7 @@
   - Enforces RC and formal-release command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
-  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules, and explicit prod-sim evidence directory validation.
+  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -122,6 +122,7 @@ VERIFY_README_TOKENS = (
     "evidence table row content/order",
     "current local verification status structure",
     "controlled-doc artifact coverage",
+    "evidence rules structure",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target dependencies and guard recipes",
     "Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape",

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -111,6 +111,13 @@ REQUIRED_LOCAL_STATUS_ITEMS = (
     "Note: before creating final `v2.0.0`, rerun",
 )
 
+REQUIRED_EVIDENCE_RULES = (
+    "Evidence from `sc_prod_sim` must not be presented as `sc_prod` evidence.",
+    "Production deployment evidence is recorded separately after supervised",
+    "Snapshot changes must include the command that produced them.",
+    "Failed evidence is not overwritten without preserving the failure reason in an",
+)
+
 
 def _table_rows_for_section(text: str, heading: str) -> tuple[tuple[str, str, str, str], ...] | None:
     lines = text.splitlines()
@@ -182,6 +189,18 @@ def _contains_required_local_status_items(text: str, errors: list[str]) -> None:
         )
 
 
+def _contains_required_evidence_rules(text: str, errors: list[str]) -> None:
+    actual_items = _top_level_bullets_after_heading(text, "## Evidence Rules")
+    if actual_items is None:
+        errors.append("manifest missing section: ## Evidence Rules")
+        return
+    if actual_items != REQUIRED_EVIDENCE_RULES:
+        errors.append(
+            "manifest evidence rules mismatch: "
+            f"expected={REQUIRED_EVIDENCE_RULES!r} actual={actual_items!r}"
+        )
+
+
 def main() -> int:
     errors: list[str] = []
     if not MANIFEST.is_file():
@@ -197,6 +216,7 @@ def main() -> int:
         if text.count("| Evidence | Command | Required Result | Artifact |") != 4:
             errors.append("manifest must contain four evidence tables")
         _contains_required_table_rows(text, errors)
+        _contains_required_evidence_rules(text, errors)
         _contains_required_local_status_items(text, errors)
 
     if errors:


### PR DESCRIPTION
## Summary

- enforce the v2 evidence manifest Evidence Rules bullets in order
- document evidence rules structure coverage in the verify catalog
- guard the updated verify catalog phrase from the control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
