### PR TITLE
Guard v2 checklist dev acceptance command

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -195,7 +195,7 @@
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
   - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety and evidence lists locked by section.
-  - Enforces RC and formal-release command blocks exactly.
+  - Enforces RC, formal-release, and dev-acceptance command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -82,6 +82,15 @@ REQUIRED_COMMAND_BLOCKS = (
             "make verify.release.v2_0_0.evidence_manifest.guard",
         ),
     ),
+    (
+        "For `sc_demo` acceptance:",
+        (
+            "ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo \\",
+            "ACCEPTANCE_BACKUP_DIR=<uploaded_backup_dir> \\",
+            "ACCEPTANCE_BASE_URL=http://127.0.0.1:18081 \\",
+            "make release.dev.acceptance.publish",
+        ),
+    ),
 )
 
 REQUIRED_SECTION_LISTS = (

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -116,7 +116,7 @@ VERIFY_README_TOKENS = (
     "controlled-doc review",
     "sections in the expected order",
     "key safety and evidence lists locked by section",
-    "Enforces RC and formal-release command blocks exactly.",
+    "Enforces RC, formal-release, and dev-acceptance command blocks exactly.",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",
     "evidence table row content/order",


### PR DESCRIPTION
## Summary

- enforce the v2 release checklist dev-acceptance command block exactly
- document dev-acceptance command block coverage in the verify catalog
- guard the updated verify catalog phrase from the control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
