### PR TITLE
Guard v2 Makefile phony targets

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -200,7 +200,7 @@
 - `make verify.release.v2_0_0.evidence_manifest.guard`
   - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
-  - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target dependencies and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.
 - `make verify.release.v2_0_0.governance.guard`
   - Runs the v2.0.0 release-control docs, evidence manifest, and checklist guards as one governance closure target.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -124,7 +124,7 @@ VERIFY_README_TOKENS = (
     "controlled-doc artifact coverage",
     "evidence rules structure",
     "`make verify.release.v2_0_0.control_docs.guard`",
-    "release indexes, verification catalog, and Makefile target dependencies and guard recipes",
+    "release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes",
     "Enforces release-control status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes scope, tag plan, known limits, acceptance command blocks, versioning formal release line, and promotion order shape",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
     "Recorded sample artifact directories may validate schema shape only",
@@ -295,6 +295,16 @@ RELEASE_INDEX_ZH_PLANNED_ITEMS = (
     "GitHub Release：正式 tag 后必须发布",
 )
 
+MAKEFILE_PHONY_TARGETS = (
+    "verify.release.v2_0_0.preflight",
+    "verify.release.v2_0_0.product_hardening",
+    "verify.release.v2_0_0.checklist.guard",
+    "verify.release.v2_0_0.evidence_manifest.guard",
+    "verify.release.v2_0_0.control_docs.guard",
+    "verify.release.v2_0_0.governance.guard",
+    "verify.release.v2_0_0.formal_evidence.schema.guard",
+)
+
 MAKEFILE_TARGET_PREREQS = (
     (
         "verify.release.v2_0_0.preflight",
@@ -398,6 +408,14 @@ def _makefile_prereqs(text: str, target: str) -> tuple[str, ...] | None:
         prereq_text = " ".join(chunk for chunk in chunks if chunk)
         return tuple(prereq_text.split())
     return None
+
+
+def _makefile_phony_targets(text: str) -> tuple[str, ...]:
+    targets: list[str] = []
+    for line in text.splitlines():
+        if line.startswith(".PHONY:"):
+            targets.extend(line[len(".PHONY:") :].strip().split())
+    return tuple(targets)
 
 
 def _makefile_recipe(text: str, target: str) -> tuple[str, ...] | None:
@@ -711,6 +729,10 @@ def _contains_makefile_targets(errors: list[str]) -> None:
         errors.append(f"missing Makefile: {MAKEFILE.relative_to(ROOT).as_posix()}")
         return
     text = MAKEFILE.read_text(encoding="utf-8")
+    phony_targets = _makefile_phony_targets(text)
+    for target in MAKEFILE_PHONY_TARGETS:
+        if target not in phony_targets:
+            errors.append(f"Makefile missing .PHONY target: {target}")
     for target, expected_prereqs in MAKEFILE_TARGET_PREREQS:
         actual_prereqs = _makefile_prereqs(text, target)
         if actual_prereqs is None:


### PR DESCRIPTION
## Summary

- enforce .PHONY declarations for v2 release governance Makefile targets
- keep the control docs guard covering phony declarations alongside dependencies and recipes
- document the expanded Makefile coverage in the verify catalog

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
