### PR TITLE
Harden v2 control docs forbidden tokens

### DIFF
--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -374,6 +374,11 @@ FORBIDDEN_TOKENS = (
     "reuse `v1.0.0`",
     "git tag -f",
     "git push --force",
+    "git reset --hard",
+    "ENV=prod make",
+    "TODO",
+    "TBD",
+    "FIXME",
     "Production deployment is part of this release-note batch.",
 )
 


### PR DESCRIPTION
## Summary

- forbid destructive reset and prod make command snippets in v2 controlled docs
- forbid unresolved TODO/TBD/FIXME placeholders in the v2 control docs guard coverage

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
