### PR TITLE
Guard v2 checklist preflight expansion

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -194,7 +194,7 @@
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
-  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety and evidence lists locked by section.
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety, evidence, and preflight expansion lists locked by section.
   - Enforces RC, formal-release, and dev-acceptance command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -120,6 +120,14 @@ REQUIRED_SECTION_LISTS = (
         ),
     ),
     (
+        "The preflight target expands to:",
+        (
+            "`make verify.system.capability_baseline.report`",
+            "`make verify.backend.contract.closure.mainline`",
+            "`make verify.restricted`",
+        ),
+    ),
+    (
         "## Contract And Startup Gate",
         (
             "`login -> system.init -> ui.contract` must remain unchanged.",

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -115,7 +115,7 @@ VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "controlled-doc review",
     "sections in the expected order",
-    "key safety and evidence lists locked by section",
+    "key safety, evidence, and preflight expansion lists locked by section",
     "Enforces RC, formal-release, and dev-acceptance command blocks exactly.",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",


### PR DESCRIPTION
## Summary

- enforce the v2 release checklist preflight expansion list
- keep verify catalog wording aligned with checklist guard coverage
- guard the updated verify catalog phrase from the control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
