### PR TITLE
Harden v2 release guard forbidden tokens

### DIFF
--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -49,6 +49,9 @@ FORBIDDEN_TOKENS = (
     "git push --force",
     "git reset --hard",
     "ENV=prod make",
+    "TODO",
+    "TBD",
+    "FIXME",
 )
 
 REQUIRED_SECTION_ORDER = (

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -51,6 +51,13 @@ FORBIDDEN_TOKENS = (
     "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
     "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
     "sc_prod evidence",
+    "git tag -f",
+    "git push --force",
+    "git reset --hard",
+    "ENV=prod make",
+    "TODO",
+    "TBD",
+    "FIXME",
 )
 
 REQUIRED_TABLE_ROWS = {


### PR DESCRIPTION
## Summary

- forbid unresolved TODO/TBD/FIXME placeholders in v2 checklist and evidence manifest guards
- align evidence manifest guard forbidden tokens with destructive git/prod command snippets already blocked elsewhere

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_evidence_manifest_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
