### PR TITLE
Guard v2 checklist hardening prose

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -194,7 +194,7 @@
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
-  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety, evidence, and preflight expansion lists locked by section.
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety, evidence, preflight expansion lists, and hardening expansion prose locked by section.
   - Enforces RC, formal-release, and dev-acceptance command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -203,6 +203,34 @@ REQUIRED_SECTION_LISTS = (
     ),
 )
 
+REQUIRED_TEXT_SNIPPETS = (
+    (
+        "This target expands to `make verify.product.release.ready` and must be green\n"
+        "before the final tag."
+    ),
+    (
+        "The readiness chain includes `make verify.docs.product_boundary`, so new addon\n"
+        "modules and product-boundary edits must keep the formal product boundary\n"
+        "catalog complete before release."
+    ),
+    (
+        "The readiness chain also includes `make verify.product.menu.release.ready`, so\n"
+        "formal product menu changes, system configuration entries, and runtime user\n"
+        "menu configuration boundaries must pass the menu release gate before release."
+    ),
+    (
+        "The readiness chain also includes\n"
+        "`make verify.frontend.widget_richness.post_ga.guard`, so x2many inline editing,\n"
+        "backend subviews, kanban/view-type semantics, and v2 chatter/attachments\n"
+        "projection remain part of formal hardening."
+    ),
+    (
+        "The platform performance sub-gate must measure the Web boot path with\n"
+        "`scene_ready_mode=registry`; full scene hydration remains a deep-link/runtime\n"
+        "path and is not the baseline startup payload."
+    ),
+)
+
 
 def _heading_order(text: str) -> tuple[str, ...]:
     return tuple(line.strip() for line in text.splitlines() if line.startswith("## "))
@@ -274,6 +302,12 @@ def _contains_required_section_lists(text: str, errors: list[str]) -> None:
             )
 
 
+def _contains_required_text_snippets(text: str, errors: list[str]) -> None:
+    for snippet in REQUIRED_TEXT_SNIPPETS:
+        if snippet not in text:
+            errors.append(f"checklist missing required text snippet: {snippet}")
+
+
 def main() -> int:
     errors: list[str] = []
     if not CHECKLIST.is_file():
@@ -289,6 +323,7 @@ def main() -> int:
         _contains_required_section_order(text, errors)
         _contains_required_command_blocks(text, errors)
         _contains_required_section_lists(text, errors)
+        _contains_required_text_snippets(text, errors)
 
     if errors:
         print("[release_v2_0_0_checklist_guard] FAIL")

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -115,7 +115,7 @@ VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "controlled-doc review",
     "sections in the expected order",
-    "key safety, evidence, and preflight expansion lists locked by section",
+    "key safety, evidence, preflight expansion lists, and hardening expansion prose locked by section",
     "Enforces RC, formal-release, and dev-acceptance command blocks exactly.",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",


### PR DESCRIPTION
## Summary

- enforce key product hardening expansion prose in the v2 release checklist guard
- cover product release readiness, product boundary, menu release, widget richness, and registry-mode performance language
- update verify catalog wording and guard that phrase from the control docs guard

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
