### PR TITLE
Guard v2 evidence manifest section order

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -198,7 +198,7 @@
   - Enforces RC, formal-release, and dev-acceptance command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`
-  - Verifies the v2.0.0 evidence manifest keeps required gate sections, evidence table row content/order, current local verification status and nested artifact/shape-guard structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
+  - Verifies the v2.0.0 evidence manifest keeps required gate section order, evidence table row content/order, current local verification status and nested artifact/shape-guard structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Enforces release-control section order, status, scope, boundary and gate command blocks, release document list, rollback list, release-index planned entries, release-notes section order, intent, scope, tag plan, production boundary, known limits, acceptance command blocks, versioning section order, tag type, no-history-rewrite, tag pre-check, formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.

--- a/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
+++ b/scripts/verify/release_v2_0_0_evidence_manifest_guard.py
@@ -60,6 +60,15 @@ FORBIDDEN_TOKENS = (
     "FIXME",
 )
 
+REQUIRED_SECTION_ORDER = (
+    "## Required Before `gate-release-v2.0`",
+    "## Required Before `v2.0.0-rc1`",
+    "## Required Product Hardening Before Formal `v2.0.0`",
+    "## Required Before Formal `v2.0.0`",
+    "## Evidence Rules",
+    "## Current Local Verification Status",
+)
+
 REQUIRED_TABLE_ROWS = {
     "## Required Before `gate-release-v2.0`": (
         ("System capability baseline", "`make verify.system.capability_baseline.report`", "PASS", "`artifacts/backend/system_capability_baseline_report.json`"),
@@ -188,6 +197,10 @@ def _top_level_bullets_after_heading(text: str, heading: str) -> tuple[str, ...]
     return tuple(items)
 
 
+def _heading_order(text: str) -> tuple[str, ...]:
+    return tuple(line.strip() for line in text.splitlines() if line.startswith("## "))
+
+
 def _nested_bullets_after_top_level_item(
     text: str,
     heading: str,
@@ -230,6 +243,15 @@ def _contains_required_table_rows(text: str, errors: list[str]) -> None:
                 "manifest evidence table rows mismatch: "
                 f"{heading} expected={expected_rows!r} actual={actual_rows!r}"
             )
+
+
+def _contains_required_section_order(text: str, errors: list[str]) -> None:
+    actual_order = _heading_order(text)
+    if actual_order != REQUIRED_SECTION_ORDER:
+        errors.append(
+            "manifest section order mismatch: "
+            f"expected={REQUIRED_SECTION_ORDER!r} actual={actual_order!r}"
+        )
 
 
 def _contains_required_local_status_items(text: str, errors: list[str]) -> None:
@@ -284,6 +306,7 @@ def main() -> int:
                 errors.append(f"manifest contains forbidden token: {token}")
         if text.count("| Evidence | Command | Required Result | Artifact |") != 4:
             errors.append("manifest must contain four evidence tables")
+        _contains_required_section_order(text, errors)
         _contains_required_table_rows(text, errors)
         _contains_required_evidence_rules(text, errors)
         _contains_required_local_status_items(text, errors)


### PR DESCRIPTION
## Summary

- Add exact heading-order validation for the v2.0.0 evidence manifest.
- Update verification catalog wording for evidence manifest section-order coverage.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_evidence_manifest_guard.py`
- `make verify.release.v2_0_0.evidence_manifest.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
