### PR TITLE
Guard v2 Makefile phony target order

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -201,6 +201,7 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate section order, evidence table row content/order, current local verification status and nested artifact/shape-guard structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the v2.0.0 Makefile release targets appear in expected phony order.
   - Verifies the v2.0.0 release guard entries appear in expected order in this catalog.
   - Enforces release-control section order, status, scope, boundary and gate command blocks, release document list, rollback list, release-index section order and planned entries, release-notes section order, intent, scope, tag plan, production boundary, known limits, acceptance command blocks, versioning section order, tag type, no-history-rewrite, tag pre-check, formal release line, and promotion order shape for the v2.0.0 control README and versioning guide.
 - `make verify.release.v2_0_0.governance.guard`

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -125,6 +125,7 @@ VERIFY_README_TOKENS = (
     "evidence rules structure",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes",
+    "v2.0.0 Makefile release targets appear in expected phony order",
     "release guard entries appear in expected order",
     "Enforces release-control section order, status, scope, boundary and gate command blocks, release document list, rollback list, release-index section order and planned entries, release-notes section order, intent, scope, tag plan, production boundary, known limits, acceptance command blocks, versioning section order, tag type, no-history-rewrite, tag pre-check, formal release line, and promotion order shape",
     "`PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard`",
@@ -1004,6 +1005,14 @@ def _contains_makefile_targets(errors: list[str]) -> None:
     for target in MAKEFILE_PHONY_TARGETS:
         if target not in phony_targets:
             errors.append(f"Makefile missing .PHONY target: {target}")
+    actual_v2_phony_targets = tuple(
+        target for target in phony_targets if target.startswith("verify.release.v2_0_0.")
+    )
+    if actual_v2_phony_targets != MAKEFILE_PHONY_TARGETS:
+        errors.append(
+            "Makefile v2 release .PHONY target order mismatch: "
+            f"expected={MAKEFILE_PHONY_TARGETS!r} actual={actual_v2_phony_targets!r}"
+        )
     for target, expected_prereqs in MAKEFILE_TARGET_PREREQS:
         actual_prereqs = _makefile_prereqs(text, target)
         if actual_prereqs is None:


### PR DESCRIPTION
## Summary

- Add exact ordering validation for v2 release Makefile .PHONY targets.
- Update verification catalog wording and control-doc token coverage for this Makefile order check.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
