### PR TITLE
Forbid v2 prod-sim sample paths in release docs

### DIFF
--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -45,6 +45,8 @@ REQUIRED_TOKENS = (
 )
 
 FORBIDDEN_TOKENS = (
+    "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
+    "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
     "git tag -f",
     "git push --force",
     "git reset --hard",

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -495,6 +495,8 @@ MAKEFILE_TARGET_RECIPES = (
 FORBIDDEN_TOKENS = (
     "Product delivery baseline: 9 modules",
     "reuse `v1.0.0`",
+    "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
+    "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
     "git tag -f",
     "git push --force",
     "git reset --hard",


### PR DESCRIPTION
## Summary

- Forbid concrete historical prod-sim sample artifact paths in v2 control docs.
- Apply the same sample-path boundary to the v2 release checklist guard.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py scripts/verify/release_v2_0_0_checklist_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
