### PR TITLE
Forbid sc_prod evidence phrase in v2 docs

### DIFF
--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -47,6 +47,7 @@ REQUIRED_TOKENS = (
 FORBIDDEN_TOKENS = (
     "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
     "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
+    "sc_prod evidence",
     "git tag -f",
     "git push --force",
     "git reset --hard",

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -497,6 +497,7 @@ FORBIDDEN_TOKENS = (
     "reuse `v1.0.0`",
     "artifacts/migration/prod_sim_fresh_replay_20260506T000602",
     "artifacts/migration/prod_sim_fresh_replay_20260505T230223",
+    "sc_prod evidence",
     "git tag -f",
     "git push --force",
     "git reset --hard",


### PR DESCRIPTION
## Summary

- Forbid the `sc_prod evidence` phrase in v2 control docs.
- Apply the same prod/prod-sim evidence boundary to the v2 release checklist guard.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py scripts/verify/release_v2_0_0_checklist_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
