### PR TITLE
Align v2 README supporting gates with preflight

### DIFF
--- a/docs/ops/releases/v2.0.0/README.md
+++ b/docs/ops/releases/v2.0.0/README.md
@@ -40,6 +40,7 @@ Supporting gates:
 
 ```bash
 make verify.system.capability_baseline.report
+make verify.platform.release_policy.runtime
 make verify.backend.contract.closure.mainline
 make verify.restricted
 ```

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -201,6 +201,7 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate section order, evidence table row content/order, current local verification status and nested artifact/shape-guard structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies the release-control README supporting gates match the v2.0.0 preflight dependency set, including platform release policy runtime.
   - Verifies the v2.0.0 Makefile release targets appear in expected phony order.
   - Verifies the v2.0.0 Makefile release target definitions appear in expected order.
   - Verifies the v2.0.0 release guard entries appear in expected order in this catalog.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -125,6 +125,8 @@ VERIFY_README_TOKENS = (
     "evidence rules structure",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes",
+    "supporting gates match the v2.0.0 preflight dependency set",
+    "including platform release policy runtime",
     "v2.0.0 Makefile release targets appear in expected phony order",
     "v2.0.0 Makefile release target definitions appear in expected order",
     "release guard entries appear in expected order",
@@ -199,6 +201,7 @@ README_REQUIRED_GATES_COMMANDS = (
 
 README_SUPPORTING_GATES_COMMANDS = (
     "make verify.system.capability_baseline.report",
+    "make verify.platform.release_policy.runtime",
     "make verify.backend.contract.closure.mainline",
     "make verify.restricted",
 )


### PR DESCRIPTION
## Summary

- Add `make verify.platform.release_policy.runtime` to the v2 release-control README supporting gates.
- Lock the README supporting gate list to match the v2 preflight dependency set.
- Update the verification catalog wording and control-doc token coverage for this alignment.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
