### PR TITLE
Align v2 notes and checklist preflight gates

### DIFF
--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -34,6 +34,7 @@ git diff --check
 The preflight target expands to:
 
 - `make verify.system.capability_baseline.report`
+- `make verify.platform.release_policy.runtime`
 - `make verify.backend.contract.closure.mainline`
 - `make verify.restricted`
 

--- a/docs/ops/release_notes_v2.0.0.md
+++ b/docs/ops/release_notes_v2.0.0.md
@@ -42,6 +42,7 @@ make verify.release.v2_0_0.product_hardening
 make verify.release.v2_0_0.governance.guard
 PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard
 make verify.system.capability_baseline.report
+make verify.platform.release_policy.runtime
 make verify.restricted
 make verify.backend.contract.closure.mainline
 ```

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -129,6 +129,7 @@ REQUIRED_SECTION_LISTS = (
         "The preflight target expands to:",
         (
             "`make verify.system.capability_baseline.report`",
+            "`make verify.platform.release_policy.runtime`",
             "`make verify.backend.contract.closure.mainline`",
             "`make verify.restricted`",
         ),

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -285,6 +285,7 @@ NOTES_MINIMUM_VERIFICATION_COMMANDS = (
     "make verify.release.v2_0_0.governance.guard",
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "make verify.system.capability_baseline.report",
+    "make verify.platform.release_policy.runtime",
     "make verify.restricted",
     "make verify.backend.contract.closure.mainline",
 )


### PR DESCRIPTION
## Summary

- Add `make verify.platform.release_policy.runtime` to the v2 release notes minimum verification block.
- Add the same platform release-policy gate to the v2 checklist preflight expansion.
- Update control/checklist guards so these docs stay aligned with the Makefile preflight dependency set.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py scripts/verify/release_v2_0_0_checklist_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
