### PR TITLE
Guard v2 checklist product readiness deps

### DIFF
--- a/docs/ops/release_checklist_v2.0.0.md
+++ b/docs/ops/release_checklist_v2.0.0.md
@@ -65,6 +65,21 @@ The platform performance sub-gate must measure the Web boot path with
 `scene_ready_mode=registry`; full scene hydration remains a deep-link/runtime
 path and is not the baseline startup payload.
 
+The product readiness target expands to:
+
+  - `verify.docs.product_boundary`
+  - `verify.user_module.product_boundary`
+  - `verify.product.surface.clean`
+  - `verify.product.menu.release.ready`
+  - `verify.product.complexity.bound`
+  - `verify.product.bundle.isolation`
+  - `verify.product.tier.enforcement`
+  - `verify.product.delivery.productization.readiness.strict`
+  - `verify.frontend.widget_richness.post_ga.guard`
+  - `verify.ui.product.stability`
+  - `verify.delivery.reproducible`
+  - `verify.product.sla.baseline`
+
 ## Contract And Startup Gate
 
 - `login -> system.init -> ui.contract` must remain unchanged.

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -194,7 +194,7 @@
   - Verifies the dev acceptance release probe JSON shape.
   - Enforces mode/status metadata, backup/frontend/login block status consistency, and key frontend/login check field types.
 - `make verify.release.v2_0_0.checklist.guard`
-  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety, evidence, preflight expansion lists, and hardening expansion prose locked by section.
+  - Verifies the v2.0.0 release checklist keeps required preflight, product hardening, dev acceptance, prod-sim, controlled-doc review, production safety, post-release, and stop-condition sections in the expected order, with key safety, evidence, preflight expansion lists, product readiness dependency lists, and hardening expansion prose locked by section.
   - Enforces RC, formal-release, and dev-acceptance command blocks exactly.
   - Enforces required release tag names, versioning/release-index review, and prod/prod-sim evidence separation language.
 - `make verify.release.v2_0_0.evidence_manifest.guard`

--- a/scripts/verify/release_v2_0_0_checklist_guard.py
+++ b/scripts/verify/release_v2_0_0_checklist_guard.py
@@ -155,6 +155,23 @@ REQUIRED_SECTION_LISTS = (
         ),
     ),
     (
+        "The product readiness target expands to:",
+        (
+            "`verify.docs.product_boundary`",
+            "`verify.user_module.product_boundary`",
+            "`verify.product.surface.clean`",
+            "`verify.product.menu.release.ready`",
+            "`verify.product.complexity.bound`",
+            "`verify.product.bundle.isolation`",
+            "`verify.product.tier.enforcement`",
+            "`verify.product.delivery.productization.readiness.strict`",
+            "`verify.frontend.widget_richness.post_ga.guard`",
+            "`verify.ui.product.stability`",
+            "`verify.delivery.reproducible`",
+            "`verify.product.sla.baseline`",
+        ),
+    ),
+    (
         "Required evidence:",
         (
             "`artifacts/backend/dev_acceptance_release_probe.json`",
@@ -255,12 +272,19 @@ def _top_level_bullets_after_heading(text: str, heading: str) -> tuple[str, ...]
         start = lines.index(heading)
     except ValueError:
         return None
+    is_section = heading.startswith("## ")
     items: list[str] = []
     for line in lines[start + 1 :]:
         if line.startswith("## "):
             break
-        if line.startswith("- "):
+        if is_section and line.startswith("- "):
             items.append(line[2:].strip())
+        elif not is_section:
+            stripped = line.strip()
+            if stripped.startswith("- "):
+                items.append(stripped[2:].strip())
+            elif items:
+                break
     return tuple(items)
 
 

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -115,7 +115,7 @@ VERIFY_README_TOKENS = (
     "`make verify.release.v2_0_0.checklist.guard`",
     "controlled-doc review",
     "sections in the expected order",
-    "key safety, evidence, preflight expansion lists, and hardening expansion prose locked by section",
+    "key safety, evidence, preflight expansion lists, product readiness dependency lists, and hardening expansion prose locked by section",
     "Enforces RC, formal-release, and dev-acceptance command blocks exactly.",
     "versioning/release-index review",
     "`make verify.release.v2_0_0.evidence_manifest.guard`",


### PR DESCRIPTION
## Summary

- Add the full `verify.product.release.ready` dependency set to the v2 release checklist.
- Lock the product readiness dependency list in the checklist guard.
- Update the verification catalog wording and control-doc token coverage for this checklist structure.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_checklist_guard.py scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.checklist.guard`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
