### PR TITLE
Guard v2 product readiness Makefile deps

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -201,6 +201,7 @@
   - Verifies the v2.0.0 evidence manifest keeps required gate section order, evidence table row content/order, current local verification status and nested artifact/shape-guard structure, schema guard rows, controlled-doc artifact coverage, evidence rules structure, and explicit prod-sim evidence directory validation.
 - `make verify.release.v2_0_0.control_docs.guard`
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
+  - Verifies product release readiness target dependencies stay aligned with the release checklist hardening expansion.
   - Verifies the release-control README supporting gates match the v2.0.0 preflight dependency set, including platform release policy runtime.
   - Verifies the v2.0.0 Makefile release targets appear in expected phony order.
   - Verifies the v2.0.0 Makefile release target definitions appear in expected order.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -125,6 +125,7 @@ VERIFY_README_TOKENS = (
     "evidence rules structure",
     "`make verify.release.v2_0_0.control_docs.guard`",
     "release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes",
+    "product release readiness target dependencies",
     "supporting gates match the v2.0.0 preflight dependency set",
     "including platform release policy runtime",
     "v2.0.0 Makefile release targets appear in expected phony order",
@@ -424,6 +425,24 @@ MAKEFILE_TARGET_PREREQS = (
         (
             "guard.prod.forbid",
             "verify.product.release.ready",
+        ),
+    ),
+    (
+        "verify.product.release.ready",
+        (
+            "guard.prod.forbid",
+            "verify.docs.product_boundary",
+            "verify.user_module.product_boundary",
+            "verify.product.surface.clean",
+            "verify.product.menu.release.ready",
+            "verify.product.complexity.bound",
+            "verify.product.bundle.isolation",
+            "verify.product.tier.enforcement",
+            "verify.product.delivery.productization.readiness.strict",
+            "verify.frontend.widget_richness.post_ga.guard",
+            "verify.ui.product.stability",
+            "verify.delivery.reproducible",
+            "verify.product.sla.baseline",
         ),
     ),
     (


### PR DESCRIPTION
## Summary

- Add exact Makefile dependency validation for `verify.product.release.ready`.
- Update verification catalog wording and control-doc token coverage for product readiness dependency alignment.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
