### PR TITLE
Align v2 release notes preflight order

### DIFF
--- a/docs/ops/release_notes_v2.0.0.md
+++ b/docs/ops/release_notes_v2.0.0.md
@@ -43,8 +43,8 @@ make verify.release.v2_0_0.governance.guard
 PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard
 make verify.system.capability_baseline.report
 make verify.platform.release_policy.runtime
-make verify.restricted
 make verify.backend.contract.closure.mainline
+make verify.restricted
 ```
 
 Environment-specific acceptance:

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -287,8 +287,8 @@ NOTES_MINIMUM_VERIFICATION_COMMANDS = (
     "PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=<run_dir> make verify.release.v2_0_0.formal_evidence.schema.guard",
     "make verify.system.capability_baseline.report",
     "make verify.platform.release_policy.runtime",
-    "make verify.restricted",
     "make verify.backend.contract.closure.mainline",
+    "make verify.restricted",
 )
 
 NOTES_ENV_ACCEPTANCE_COMMANDS = (


### PR DESCRIPTION
## Summary

- Align the v2 release notes minimum verification sub-gate order with the Makefile preflight dependency order.
- Update the control-doc guard expected command block to keep that order locked.

## Validation

- `python3 -m py_compile scripts/verify/release_v2_0_0_control_docs_guard.py`
- `make verify.release.v2_0_0.control_docs.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`
- `git diff --check`
