### PR TITLE
[codex] Guard README preflight supporting gates

### DIFF
--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -206,6 +206,7 @@
   - Verifies the v2.0.0 release-control README, release notes, versioning guide, release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes keep planned tag names, release boundaries, required gates, immutable RC guidance, and the current 10-module product delivery baseline.
   - Cross-checks product release readiness Makefile dependencies against the release checklist hardening expansion.
   - Cross-checks release notes minimum verification subgates against the v2.0.0 preflight Makefile dependencies.
+  - Cross-checks release-control README supporting gates against the v2.0.0 preflight Makefile dependencies.
   - Verifies the release-control README supporting gates match the v2.0.0 preflight dependency set, including platform release policy runtime.
   - Verifies the v2.0.0 Makefile release targets appear in expected phony order.
   - Verifies the v2.0.0 Makefile release target definitions appear in expected order.

--- a/scripts/verify/release_v2_0_0_control_docs_guard.py
+++ b/scripts/verify/release_v2_0_0_control_docs_guard.py
@@ -130,6 +130,7 @@ VERIFY_README_TOKENS = (
     "release indexes, verification catalog, and Makefile target phony declarations, dependencies, and guard recipes",
     "Cross-checks product release readiness Makefile dependencies against the release checklist hardening expansion.",
     "Cross-checks release notes minimum verification subgates against the v2.0.0 preflight Makefile dependencies.",
+    "Cross-checks release-control README supporting gates against the v2.0.0 preflight Makefile dependencies.",
     "supporting gates match the v2.0.0 preflight dependency set",
     "including platform release policy runtime",
     "v2.0.0 Makefile release targets appear in expected phony order",
@@ -1160,6 +1161,35 @@ def _contains_notes_preflight_dependency_alignment(errors: list[str]) -> None:
         )
 
 
+def _contains_readme_preflight_dependency_alignment(errors: list[str]) -> None:
+    if not MAKEFILE.is_file():
+        errors.append(f"missing Makefile: {MAKEFILE.relative_to(ROOT).as_posix()}")
+        return
+    if not CONTROL_README.is_file():
+        errors.append(f"missing release-control README: {CONTROL_README.relative_to(ROOT).as_posix()}")
+        return
+    makefile_text = MAKEFILE.read_text(encoding="utf-8")
+    readme_text = CONTROL_README.read_text(encoding="utf-8")
+    prereqs = _makefile_prereqs(makefile_text, "verify.release.v2_0_0.preflight")
+    if prereqs is None:
+        errors.append("Makefile missing target: verify.release.v2_0_0.preflight")
+        return
+    actual_commands = _command_block_after_marker(readme_text, "Supporting gates:")
+    if actual_commands is None:
+        errors.append("release-control README missing supporting gates command block")
+        return
+    expected_commands = tuple(
+        f"make {target}"
+        for target in prereqs
+        if target != "guard.prod.forbid"
+    )
+    if actual_commands != expected_commands:
+        errors.append(
+            "release-control README preflight dependency expansion mismatch: "
+            f"expected={expected_commands!r} actual={actual_commands!r}"
+        )
+
+
 def main() -> int:
     errors: list[str] = []
     _contains_all(CONTROL_README, README_TOKENS, errors)
@@ -1207,6 +1237,7 @@ def main() -> int:
     _contains_makefile_targets(errors)
     _contains_product_readiness_checklist_alignment(errors)
     _contains_notes_preflight_dependency_alignment(errors)
+    _contains_readme_preflight_dependency_alignment(errors)
     if errors:
         print("[release_v2_0_0_control_docs_guard] FAIL")
         for error in errors:


### PR DESCRIPTION
## Summary

- Add a release-control guard cross-check that compares the release-control README `Supporting gates` command block with the Makefile `verify.release.v2_0_0.preflight` dependency list.
- Document the new cross-check in the verify catalog.

## Verification

- `make verify.release.v2_0_0.governance.guard`
- `PROD_SIM_ACCEPTANCE_ARTIFACT_DIR=artifacts/migration/prod_sim_fresh_replay_20260506T000602 make verify.release.v2_0_0.formal_evidence.schema.guard`