### PR TITLE
Refresh delivery scoreboard mainline evidence

### DIFF
--- a/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
+++ b/docs/product/delivery/v1/delivery_readiness_scoreboard_v1.md
@@ -2,9 +2,9 @@
 
 ## Snapshot
 
-- generated_at_utc: 2026-07-05T02:32:08Z
+- generated_at_utc: 2026-07-05T02:42:18Z
 - branch: `main`
-- commit_ref: `5d065f65a`
+- commit_ref: `5b90db9a7`
 - primary_gate: `make verify.scene.delivery.readiness.role_company_matrix`
 - gate_result: `PASS`
 - final_closeout_date: `2026-07-05`
@@ -23,7 +23,7 @@
 | Company access preflight | PASS (strict) | `artifacts/backend/scene_company_access_preflight_report.json` |
 | Multi-company evidence accumulation | PASS (strict) | `artifacts/backend/scene_multi_company_evidence_report.json` |
 | No-action regression guard | PASS | `make verify.scene.no_action_scene.guard` |
-| CI restricted profile readiness | PASS (2026-07-05T02:32:07Z) | `CI_SCENE_DELIVERY_PROFILE=restricted make ci.scene.delivery.readiness` |
+| CI restricted profile readiness | PASS (2026-07-05T02:42:18Z) | `CI_SCENE_DELIVERY_PROFILE=restricted make ci.scene.delivery.readiness` |
 | CI strict profile readiness | PASS (2026-06-30T07:05:38Z) | `CI_SCENE_DELIVERY_PROFILE=strict make ci.scene.delivery.readiness` |
 | Mainline one-command summary | PASS | `artifacts/backend/delivery_mainline_run_summary.json` |
 | Product delivery action closure smoke | PASS | `artifacts/backend/product_delivery_action_closure_report.json` |
@@ -73,7 +73,7 @@
 5. Payment approval field consumer audit is green: `verify.portal.payment_request_approval_field_consumer_audit` with `unexpected_deprecated_refs=0`.
 6. Open backlog is Post-GA only: `gap.role_journey_longtail_coverage`; it is retained to keep governance truthful and is not a release blocker.
 7. CI profile posture: strict=PASS (2026-06-30T07:05:38Z), restricted=PASS (2026-07-04T18:13:42Z); release execution should use strict in live-enabled runners and restricted only for network-restricted evidence runs.
-3. CI profile posture: strict=PASS (2026-06-30T07:05:38Z), restricted=PASS (2026-07-05T02:32:07Z); release execution should use strict in live-enabled runners and restricted only for network-restricted evidence runs.
+3. CI profile posture: strict=PASS (2026-06-30T07:05:38Z), restricted=PASS (2026-07-05T02:42:18Z); release execution should use strict in live-enabled runners and restricted only for network-restricted evidence runs.
 
 ## Repro Command Set (Default)
 


### PR DESCRIPTION
## Summary
- Refresh delivery readiness scoreboard snapshot to the current mainline commit after the product hardening/demo cleanup merge.
- Record the latest restricted CI profile readiness timestamp from the release preflight run.

## Verification
- `ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo ACCEPTANCE_BASE_URL=http://127.0.0.1:18081 ACCEPTANCE_LOGIN=wutao ACCEPTANCE_PASSWORD=123456 make release.dev.acceptance.publish`
- `ENV=dev ENV_FILE=.env.dev DB_NAME=sc_demo make verify.dev.acceptance.release.schema.guard`
- `make verify.release.v2_0_0.preflight`