### PR TITLE
[codex] Add production readonly business readiness gate

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -906,7 +906,7 @@ verify.finance_interfund.position.bundle_summary: guard.prod.forbid check-compos
 verify.finance_interfund.position.all: verify.finance_interfund.projection.static_guard verify.interfund_user_data.full_coverage.audit verify.interfund_borrow.classification_gap.audit verify.finance_business_fact.scope.audit verify.finance_business_fact.projection.audit verify.finance_business_project.summary.audit verify.interfund_movement.fact.audit verify.interfund_movement_project.summary.audit verify.interfund_treasury_ledger.backfill_readiness.audit verify.company_contractor.responsibility_fact.audit verify.company_contractor.responsibility_summary.audit verify.company_contractor.responsibility_http.smoke verify.finance_project_capital.position.audit verify.finance_project_counterparty.position.audit verify.finance_counterparty.position_summary.audit verify.finance_counterparty.identity_quality.audit verify.finance_position.drilldown_usability.audit verify.finance_interfund.position.menu_runtime.audit verify.finance_interfund.position.bundle_summary
 	@echo "FINANCE_INTERFUND_POSITION_AUDIT_ALL_PASS db=$(DB_NAME)"
 
-.PHONY: verify.business_capability.productization_p1 verify.business_system.usability_readiness verify.formal_business.release_gate formal_entry_metadata.non_business_creator.write
+.PHONY: verify.business_capability.productization_p1 verify.business_system.usability_readiness verify.business_system.usability_readiness.prod verify.formal_business.release_gate formal_entry_metadata.non_business_creator.write
 verify.formal_business.release_gate: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" bash scripts/ops/validate_formal_business_release_gate.sh
 
@@ -915,6 +915,9 @@ verify.business_capability.productization_p1: guard.prod.forbid check-compose-pr
 
 verify.business_system.usability_readiness: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" BUSINESS_SYSTEM_READINESS_INCLUDE_P1="$(BUSINESS_SYSTEM_READINESS_INCLUDE_P1)" BUSINESS_SYSTEM_READINESS_ARTIFACT_DIR="$(BUSINESS_SYSTEM_READINESS_ARTIFACT_DIR)" bash scripts/ops/validate_business_system_usability_readiness.sh
+
+verify.business_system.usability_readiness.prod: guard.prod.readonly check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" BUSINESS_SYSTEM_READINESS_PROD_READONLY=1 BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0 BUSINESS_SYSTEM_READINESS_ARTIFACT_DIR="$(BUSINESS_SYSTEM_READINESS_ARTIFACT_DIR)" bash scripts/ops/validate_business_system_usability_readiness.sh
 
 formal_entry_metadata.surface.write: guard.prod.forbid check-compose-project check-compose-env
 	@$(RUN_ENV) DB_NAME=$(DB_NAME) FORMAL_ENTRY_METADATA_DB_ALLOWLIST="$(DB_NAME)" MIGRATION_ARTIFACT_ROOT="$(MIGRATION_ARTIFACT_ROOT)" bash scripts/ops/odoo_shell_exec.sh < scripts/ops/formal_entry_metadata_surface_write.py

--- a/docs/ops/prod_command_policy.md
+++ b/docs/ops/prod_command_policy.md
@@ -12,6 +12,9 @@ Makefile guards and script-level guards.
 
 - `make up/down/logs/ps`
 - `make diag.project`
+- `make verify.business_system.usability_readiness.prod` (requires `PROD_READONLY_VERIFY=1`)
+- `make verify.legacy_attachment.mirror.completeness.audit.prod` (requires `PROD_READONLY_VERIFY=1`)
+- `make verify.legacy_online_attachment.mirror.job.audit.prod` (requires `PROD_READONLY_VERIFY=1`)
 - `make verify.baseline` (requires PROD_DANGER=1)
 - `make verify.p0` (requires PROD_DANGER=1)
 - `make verify.p0.flow` (requires PROD_DANGER=1)
@@ -59,6 +62,13 @@ Fresh production history initialization:
 ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_DANGER=1 \
   RUN_ID=prod_history_init_YYYYMMDDTHHMMSS \
   make history.production.fresh_init
+```
+
+Read-only production business readiness verification:
+
+```bash
+ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_READONLY_VERIFY=1 \
+  make verify.business_system.usability_readiness.prod
 ```
 
 Resume a production history initialization from a replay step:

--- a/docs/ops/production_deployment_runbook_v1.md
+++ b/docs/ops/production_deployment_runbook_v1.md
@@ -310,6 +310,15 @@ ENV=test ENV_FILE=.env.prod.sim DB_NAME=sc_prod_sim \
 9. 业务 smoke：验证新业务动作不被历史缺口全局阻断。
 10. 证据归档：归档 replay 输出、日志、probe 结果和验收记录。
 
+生产部署后的业务可用性验收必须使用只读入口：
+
+```bash
+ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_READONLY_VERIFY=1 \
+  make verify.business_system.usability_readiness.prod
+```
+
+该入口只运行历史业务可用性 probe 与 formal backfill audit，不执行 P1 聚合或任何写入型修复。
+
 ### 6.4 断点续跑
 
 如果重建中断，禁止重新发明服务器脚本。保留同一个 `RUN_ID`，用失败 step 续跑：

--- a/scripts/ops/validate_business_system_usability_readiness.sh
+++ b/scripts/ops/validate_business_system_usability_readiness.sh
@@ -7,6 +7,7 @@ export ROOT_DIR
 DB_NAME="${DB_NAME:-${DB:-sc_demo}}"
 ARTIFACT_DIR="${BUSINESS_SYSTEM_READINESS_ARTIFACT_DIR:-$ROOT_DIR/artifacts/backend}"
 INCLUDE_P1="${BUSINESS_SYSTEM_READINESS_INCLUDE_P1:-1}"
+PROD_READONLY="${BUSINESS_SYSTEM_READINESS_PROD_READONLY:-0}"
 MIGRATION_ARTIFACT_ROOT="${MIGRATION_ARTIFACT_ROOT:-/tmp/history_continuity/$DB_NAME/adhoc}"
 export MIGRATION_ARTIFACT_ROOT
 
@@ -15,7 +16,22 @@ source "$ROOT_DIR/scripts/common/env.sh"
 # shellcheck source=../common/guard_prod.sh
 source "$ROOT_DIR/scripts/common/guard_prod.sh"
 
-guard_prod_forbid
+truthy() {
+  [[ "${1:-}" =~ ^(1|true|True|yes|YES)$ ]]
+}
+
+if truthy "$PROD_READONLY"; then
+  if [[ "${PROD_READONLY_VERIFY:-}" != "1" ]]; then
+    echo "❌ prod readonly guard: set PROD_READONLY_VERIFY=1 to run this read-only production verifier" >&2
+    exit 2
+  fi
+  if truthy "$INCLUDE_P1"; then
+    echo "❌ prod readonly readiness cannot include P1; set BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0" >&2
+    exit 2
+  fi
+else
+  guard_prod_forbid
+fi
 
 : "${DB_NAME:?DB_NAME is required}"
 
@@ -47,7 +63,25 @@ run_check() {
   echo "BUSINESS_SYSTEM_READINESS_CHECK_PASS: ${name}"
 }
 
-echo "BUSINESS_SYSTEM_READINESS_START: db=${DB_NAME} started_at=${STARTED_AT} include_p1=${INCLUDE_P1}"
+run_history_business_usable_probe() {
+  if truthy "$PROD_READONLY"; then
+    DB_NAME="$DB_NAME" MIGRATION_ARTIFACT_ROOT="$MIGRATION_ARTIFACT_ROOT" \
+      bash scripts/ops/odoo_shell_exec.sh < scripts/migration/history_business_usable_probe.py
+    return
+  fi
+  make history.business.usable.probe DB_NAME="$DB_NAME"
+}
+
+run_formal_business_backfill_audit() {
+  if truthy "$PROD_READONLY"; then
+    DB_NAME="$DB_NAME" MIGRATION_ARTIFACT_ROOT="$MIGRATION_ARTIFACT_ROOT" \
+      bash scripts/ops/odoo_shell_exec.sh < scripts/verify/formal_business_backfill_audit_probe.py
+    return
+  fi
+  make verify.formal_business_backfill.audit DB_NAME="$DB_NAME"
+}
+
+echo "BUSINESS_SYSTEM_READINESS_START: db=${DB_NAME} started_at=${STARTED_AT} include_p1=${INCLUDE_P1} prod_readonly=${PROD_READONLY}"
 
 run_check "python_compile_readiness_inputs" \
   python3 -m py_compile \
@@ -63,14 +97,14 @@ else
 fi
 
 run_check "history_business_usable_probe" \
-  make history.business.usable.probe DB_NAME="$DB_NAME"
+  run_history_business_usable_probe
 
 run_check "formal_business_backfill_audit" \
-  make verify.formal_business_backfill.audit DB_NAME="$DB_NAME"
+  run_formal_business_backfill_audit
 
 FINISHED_AT="$(date -Iseconds)"
 
-python3 - "$RUN_LOG" "$SUMMARY_JSON" "$SUMMARY_MD" "$DB_NAME" "$STARTED_AT" "$FINISHED_AT" "$P1_STATUS" "$CHECK_FAILURES" <<'PY'
+python3 - "$RUN_LOG" "$SUMMARY_JSON" "$SUMMARY_MD" "$DB_NAME" "$STARTED_AT" "$FINISHED_AT" "$P1_STATUS" "$CHECK_FAILURES" "$PROD_READONLY" <<'PY'
 import json
 import sys
 from pathlib import Path
@@ -82,6 +116,7 @@ db_name = sys.argv[4]
 started_at = sys.argv[5]
 finished_at = sys.argv[6]
 p1_status = sys.argv[7]
+prod_readonly = sys.argv[9]
 
 text = log_path.read_text(encoding="utf-8", errors="replace")
 
@@ -109,6 +144,7 @@ decision = "ready_for_business_system_use" if ok else "not_ready_for_business_sy
 payload = {
     "scope": "business_system_usability_readiness",
     "database": db_name,
+    "prod_readonly": prod_readonly in {"1", "true", "True", "yes", "YES"},
     "started_at": started_at,
     "finished_at": finished_at,
     "status": "PASS" if ok else "FAIL",
@@ -126,6 +162,7 @@ lines = [
     "# Business System Usability Readiness",
     "",
     f"- database: `{db_name}`",
+    f"- prod_readonly: `{payload['prod_readonly']}`",
     f"- status: `{payload['status']}`",
     f"- decision: `{decision}`",
     f"- started_at: `{started_at}`",


### PR DESCRIPTION
## Summary

Adds a production-safe read-only entrypoint for business system usability readiness verification after deployment.

## Changes

- Added `make verify.business_system.usability_readiness.prod` guarded by `guard.prod.readonly` and `PROD_READONLY_VERIFY=1`.
- Extended `scripts/ops/validate_business_system_usability_readiness.sh` with `BUSINESS_SYSTEM_READINESS_PROD_READONLY=1` mode.
- Production read-only mode runs only `history_business_usable_probe.py` and `formal_business_backfill_audit_probe.py`, skips P1, and fails if P1 is requested.
- Readiness summaries now include `prod_readonly` for audit clarity.
- Documented the allowed production read-only command in `prod_command_policy.md` and the production deployment runbook.

## Validation

- `bash -n scripts/ops/validate_business_system_usability_readiness.sh`
- `python3 -m py_compile scripts/migration/history_business_usable_probe.py scripts/verify/formal_business_backfill_audit_probe.py`
- `git diff --check`
- `make verify.business_system.usability_readiness.prod ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod` fails without `PROD_READONLY_VERIFY=1` as expected.
- `BUSINESS_SYSTEM_READINESS_PROD_READONLY=1 BUSINESS_SYSTEM_READINESS_INCLUDE_P1=1 PROD_READONLY_VERIFY=1 DB_NAME=sc_prod bash scripts/ops/validate_business_system_usability_readiness.sh` fails as expected.
- `PROD_READONLY_VERIFY=1 make -n verify.business_system.usability_readiness.prod ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod` expands with `BUSINESS_SYSTEM_READINESS_PROD_READONLY=1` and `BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0`.
- `BUSINESS_SYSTEM_READINESS_PROD_READONLY=1 BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0 PROD_READONLY_VERIFY=1 DB_NAME=sc_demo bash scripts/ops/validate_business_system_usability_readiness.sh` passes.
- `BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0 DB_NAME=sc_demo make verify.business_system.usability_readiness` passes.