### PR TITLE
[codex] Guard production readonly release validation wiring

### DIFF
--- a/docs/ops/production_release_flow_standard_v1.md
+++ b/docs/ops/production_release_flow_standard_v1.md
@@ -191,6 +191,14 @@ SC_LOGIN_ENV_EXPECTED=prod ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_DANG
 BASE_URL=http://127.0.0.1:8072 ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_DANGER=1 make smoke.business_full
 BASE_URL=http://127.0.0.1:8072 ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_DANGER=1 make smoke.role_matrix
 ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod make verify.non_demo_data_contamination
+ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_READONLY_VERIFY=1 make verify.business_system.usability_readiness.prod
+```
+
+如果本次发布范围包含历史附件镜像或补齐任务，还必须执行对应的生产只读附件验收：
+
+```bash
+ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_READONLY_VERIFY=1 make verify.legacy_attachment.mirror.completeness.audit.prod
+ENV=prod ENV_FILE=.env.prod DB_NAME=sc_prod PROD_READONLY_VERIFY=1 make verify.legacy_online_attachment.mirror.job.audit.prod
 ```
 
 必须额外确认：

--- a/docs/ops/verify/README.md
+++ b/docs/ops/verify/README.md
@@ -226,6 +226,8 @@
 - `make verify.production_release.flow.guard`
   - Verifies the production release-flow control plane is wired together across the flow standard, deployment record template, Makefile target, verify catalog, release checklist, release indexes, deployment runbook, and deployment record guard script.
   - Enforces the release-flow document keeps environment responsibilities, alignment definitions, hard rules, package verification, production validation matrix, difference registration, and closure criteria in order.
+  - Enforces the production read-only business readiness gate is wired through Makefile, production command policy, deployment runbook, and release-flow validation matrix: `make verify.business_system.usability_readiness.prod`.
+  - Enforces the production read-only attachment validation targets remain registered for attachment-scope releases.
 - `make verify.scene.product_delivery.readiness.guard`
   - Enforces final product delivery readiness thresholds from `scripts/verify/baselines/scene_product_delivery_readiness_guard.json`.
   - Writes reports: `artifacts/backend/scene_product_delivery_readiness_report.json` and `artifacts/backend/scene_product_delivery_readiness_report.md`.

--- a/scripts/verify/production_release_flow_guard.py
+++ b/scripts/verify/production_release_flow_guard.py
@@ -12,6 +12,7 @@ FILES = {
     "flow": ROOT / "docs/ops/production_release_flow_standard_v1.md",
     "ops_readme": ROOT / "docs/ops/README.md",
     "deploy_runbook": ROOT / "docs/ops/production_deployment_runbook_v1.md",
+    "prod_policy": ROOT / "docs/ops/prod_command_policy.md",
     "verify_readme": ROOT / "docs/ops/verify/README.md",
     "release_checklist": ROOT / "docs/ops/release_checklist_v2.0.0.md",
     "release_index_en": ROOT / "docs/ops/releases/README.md",
@@ -30,6 +31,9 @@ FLOW_TOKENS = (
     "生产不得直接用日常开发目录整包覆盖",
     "docs/ops/releases/templates/production_deployment_record_TEMPLATE.zh.md",
     "make verify.production_deployment.record.guard",
+    "make verify.business_system.usability_readiness.prod",
+    "make verify.legacy_attachment.mirror.completeness.audit.prod",
+    "make verify.legacy_online_attachment.mirror.job.audit.prod",
     "生产与日常开发服务器完全一致",
     "发布结论区分了“发布包对齐”和“全量对齐”",
 )
@@ -48,14 +52,34 @@ TEMPLATE_TOKENS = (
 
 MAKEFILE_TOKENS = (
     ".PHONY: verify.production_deployment.record.guard",
+    ".PHONY: verify.business_capability.productization_p1 verify.business_system.usability_readiness verify.business_system.usability_readiness.prod",
+    "verify.business_system.usability_readiness.prod: guard.prod.readonly check-compose-project check-compose-env",
+    "BUSINESS_SYSTEM_READINESS_PROD_READONLY=1 BUSINESS_SYSTEM_READINESS_INCLUDE_P1=0",
+    "verify.legacy_attachment.mirror.completeness.audit.prod: guard.prod.readonly check-compose-project check-compose-env",
+    "verify.legacy_online_attachment.mirror.job.audit.prod: guard.prod.readonly check-compose-project check-compose-env",
     "python3 -m py_compile scripts/verify/production_deployment_record_guard.py",
     "python3 scripts/verify/production_deployment_record_guard.py",
 )
 
 VERIFY_README_TOKENS = (
     "`make verify.production_deployment.record.guard`",
+    "`make verify.business_system.usability_readiness.prod`",
     "Verifies concrete production deployment records",
     "explicit non-full-alignment wording",
+    "production read-only business readiness gate",
+)
+
+DEPLOY_RUNBOOK_TOKENS = (
+    "make verify.business_system.usability_readiness.prod",
+    "PROD_READONLY_VERIFY=1",
+    "只运行历史业务可用性 probe 与 formal backfill audit",
+)
+
+PROD_POLICY_TOKENS = (
+    "make verify.business_system.usability_readiness.prod",
+    "make verify.legacy_attachment.mirror.completeness.audit.prod",
+    "make verify.legacy_online_attachment.mirror.job.audit.prod",
+    "PROD_READONLY_VERIFY=1",
 )
 
 CHECKLIST_TOKENS = (
@@ -125,6 +149,8 @@ def main() -> int:
     _require_tokens("template", contents["template"], TEMPLATE_TOKENS, errors)
     _require_tokens("makefile", contents["makefile"], MAKEFILE_TOKENS, errors)
     _require_tokens("verify_readme", contents["verify_readme"], VERIFY_README_TOKENS, errors)
+    _require_tokens("deploy_runbook", contents["deploy_runbook"], DEPLOY_RUNBOOK_TOKENS, errors)
+    _require_tokens("prod_policy", contents["prod_policy"], PROD_POLICY_TOKENS, errors)
     _require_tokens("release_checklist", contents["release_checklist"], CHECKLIST_TOKENS, errors)
     _require_tokens("release_index_en", contents["release_index_en"], INDEX_TOKENS, errors)
     _require_tokens("release_index_zh", contents["release_index_zh"], INDEX_TOKENS, errors)


### PR DESCRIPTION
## Summary

Wires the new production read-only business readiness command into the production release-flow control guard.

## Changes

- Adds `make verify.business_system.usability_readiness.prod` to the production release validation matrix.
- Documents attachment-scope production read-only validation commands in the release-flow standard.
- Extends `production_release_flow_guard.py` to verify the production read-only business readiness target is present in Makefile, prod command policy, deployment runbook, verify catalog, and release-flow standard.
- Extends the guard to verify production read-only attachment validation targets remain registered.
- Updates the verification catalog description for `make verify.production_release.flow.guard`.

## Validation

- `python3 -m py_compile scripts/verify/production_release_flow_guard.py`
- `make verify.production_release.flow.guard`
- `git diff --check`