### PR TITLE
refactor: add contract form runtime state reducer

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -4,7 +4,7 @@ Generated from repository source files. This report is informational during the 
 
 ## Summary
 
-- Scanned files: `3849`
+- Scanned files: `3850`
 - Files requiring split plan: `42`
 - Files above warning threshold: `64`
 

--- a/frontend/apps/web/src/pages/contractForm/runtimeStateReducer.ts
+++ b/frontend/apps/web/src/pages/contractForm/runtimeStateReducer.ts
@@ -1,0 +1,61 @@
+import type {
+  FormRuntimeBusyKind,
+  FormRuntimeStateEvent,
+  FormRuntimeStatus,
+  FormSubmissionFeedback,
+} from './runtimeStateProtocol';
+
+export type FormRuntimeStateSnapshot = {
+  status: FormRuntimeStatus;
+  busyKind: FormRuntimeBusyKind;
+  errorMessage: string;
+  validationErrors: string[];
+  showOne2manyErrors: boolean;
+  submissionFeedback: FormSubmissionFeedback;
+};
+
+export const INITIAL_FORM_RUNTIME_STATE: FormRuntimeStateSnapshot = {
+  status: 'loading',
+  busyKind: null,
+  errorMessage: '',
+  validationErrors: [],
+  showOne2manyErrors: false,
+  submissionFeedback: null,
+};
+
+export function reduceFormRuntimeState(
+  state: FormRuntimeStateSnapshot,
+  event: FormRuntimeStateEvent,
+): FormRuntimeStateSnapshot {
+  if (event.kind === 'begin') {
+    return { ...state, busyKind: event.busyKind };
+  }
+  if (event.kind === 'end') {
+    return { ...state, busyKind: null };
+  }
+  if (event.kind === 'status') {
+    return {
+      ...state,
+      status: event.status,
+      errorMessage: event.errorMessage ?? (event.status === 'error' ? state.errorMessage : ''),
+    };
+  }
+  if (event.kind === 'validation') {
+    return {
+      ...state,
+      validationErrors: event.errors.slice(),
+      showOne2manyErrors: Boolean(event.showOne2manyErrors),
+    };
+  }
+  if (event.kind === 'feedback') {
+    return { ...state, submissionFeedback: event.feedback };
+  }
+  return state;
+}
+
+export function reduceFormRuntimeStateEvents(
+  initialState: FormRuntimeStateSnapshot,
+  events: FormRuntimeStateEvent[],
+): FormRuntimeStateSnapshot {
+  return events.reduce((state, event) => reduceFormRuntimeState(state, event), initialState);
+}

--- a/frontend/apps/web/src/pages/contractForm/types.ts
+++ b/frontend/apps/web/src/pages/contractForm/types.ts
@@ -8,6 +8,7 @@ export type {
   FormRuntimeTransactionName,
   FormSubmissionFeedback as SubmissionFeedback,
 } from './runtimeStateProtocol';
+export type { FormRuntimeStateSnapshot } from './runtimeStateReducer';
 
 export const MANY2ONE_CREATE_OPTION = '__create__';
 export const MANY2ONE_SEARCH_MORE_OPTION = '__search_more__';

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 PROTOCOL = ROOT / "frontend/apps/web/src/pages/contractForm/runtimeStateProtocol.ts"
+REDUCER = ROOT / "frontend/apps/web/src/pages/contractForm/runtimeStateReducer.ts"
 TYPES = ROOT / "frontend/apps/web/src/pages/contractForm/types.ts"
 PAGE = ROOT / "frontend/apps/web/src/pages/ContractFormPage.vue"
 SAVE_HELPER = ROOT / "frontend/apps/web/src/pages/contractForm/saveRecordHelpers.ts"
@@ -20,6 +21,7 @@ def _read(path: Path) -> str:
 def main() -> int:
     errors: list[str] = []
     protocol = _read(PROTOCOL)
+    reducer = _read(REDUCER)
     types = _read(TYPES)
     page = _read(PAGE)
     save_helper = _read(SAVE_HELPER)
@@ -29,6 +31,8 @@ def main() -> int:
 
     if not protocol:
         errors.append(f"missing protocol: {PROTOCOL.relative_to(ROOT)}")
+    if not reducer:
+        errors.append(f"missing reducer: {REDUCER.relative_to(ROOT)}")
 
     required_protocol_tokens = [
         "export type FormRuntimeStatus = 'loading' | 'ok' | 'error';",
@@ -64,12 +68,46 @@ def main() -> int:
         if token in protocol:
             errors.append(f"runtimeStateProtocol.ts must stay interface-only; forbidden token: {token}")
 
+    required_reducer_tokens = [
+        "export type FormRuntimeStateSnapshot",
+        "export const INITIAL_FORM_RUNTIME_STATE",
+        "export function reduceFormRuntimeState",
+        "export function reduceFormRuntimeStateEvents",
+        "event.kind === 'begin'",
+        "event.kind === 'end'",
+        "event.kind === 'status'",
+        "event.kind === 'validation'",
+        "event.kind === 'feedback'",
+    ]
+    for token in required_reducer_tokens:
+        if token not in reducer:
+            errors.append(f"runtimeStateReducer.ts missing token: {token}")
+
+    forbidden_reducer_tokens = [
+        "await ",
+        "async ",
+        "intentRequest",
+        "triggerOnchange",
+        "executeButton",
+        "router.",
+        "window.",
+        "createContractFormRecord",
+        "writeContractFormRecord",
+        "queryRelationOptions",
+        "reload(",
+        ".value =",
+    ]
+    for token in forbidden_reducer_tokens:
+        if token in reducer:
+            errors.append(f"runtimeStateReducer.ts must stay pure; forbidden token: {token}")
+
     required_type_exports = [
         "FormRuntimeBusyKind as BusyKind",
         "FormRuntimeStatus as UiStatus",
         "FormSubmissionFeedback as SubmissionFeedback",
         "FormRuntimeStateRefs",
         "FormRuntimeStateEvent",
+        "FormRuntimeStateSnapshot",
     ]
     for token in required_type_exports:
         if token not in types:


### PR DESCRIPTION
## Summary

Add a pure reducer baseline for contract-form runtime state events.

This builds on the runtime state protocol without moving the current side-effect flows. `saveRecord`, `runAction`, and `runOnchangeRoundtrip` still own their existing Vue ref writes and transaction boundaries.

## Scope

- Add `runtimeStateReducer.ts` with `FormRuntimeStateSnapshot`, initial state, single-event reducer, and event-list reducer.
- Re-export the snapshot type through `contractForm/types.ts`.
- Extend `contract_form_runtime_state_protocol_guard.py` to require the reducer and keep it free of API/router/window/Vue ref side effects.
- Refresh complexity evidence for the added frontend source file.

## Out of scope

- No migration of `saveRecord`, `runAction`, or `runOnchangeRoundtrip`.
- No centralized Vue ref mutation helper yet.
- No user-facing behavior change intended.

## Validation

- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `make ci.local.quick`
- `make ci`
