### PR TITLE
refactor: apply contract form runtime status events

### DIFF
--- a/.github/workflows/v1_1_quality_gate.yml
+++ b/.github/workflows/v1_1_quality_gate.yml
@@ -15,6 +15,9 @@ jobs:
     timeout-minutes: 30
     env:
       CI_CACHE_REPO: /opt/ci-cache/sce-backend-odoo.git
+      CI_REMOTE_URL: https://gitee.com/leegege/sce-backend-odoo.git
+      CI_GIT_USERNAME: ${{ secrets.CI_GIT_USERNAME }}
+      CI_GIT_PASSWORD: ${{ secrets.CI_GIT_PASSWORD }}
       HEAD_REF: ${{ github.event.pull_request.head.ref || github.ref_name }}
       HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
 
@@ -28,20 +31,22 @@ jobs:
         run: |
           set -euo pipefail
 
-          REMOTE_URL="${CI_REMOTE_URL:-https://github.com/Leedefend/sce-backend-odoo.git}"
-          FETCH_TIMEOUT_SECONDS="${CI_FETCH_TIMEOUT_SECONDS:-180}"
-          FETCH_ATTEMPTS="${CI_FETCH_ATTEMPTS:-4}"
-          FETCH_BACKOFF_BASE_SECONDS="${CI_FETCH_BACKOFF_BASE_SECONDS:-15}"
+          REMOTE_URL="${CI_REMOTE_URL:-https://gitee.com/leegege/sce-backend-odoo.git}"
+          FETCH_BRANCH_TIMEOUT_SECONDS="${CI_FETCH_BRANCH_TIMEOUT_SECONDS:-90}"
+          FETCH_SHA_TIMEOUT_SECONDS="${CI_FETCH_SHA_TIMEOUT_SECONDS:-60}"
+          FETCH_ATTEMPTS="${CI_FETCH_ATTEMPTS:-5}"
+          FETCH_BACKOFF_BASE_SECONDS="${CI_FETCH_BACKOFF_BASE_SECONDS:-10}"
 
           network_diag() {
+            remote_host="$(printf '%s' "${REMOTE_URL}" | sed -E 's#^[^/:]+://([^/@]+@)?([^/:]+).*#\2#; s#^[^@]+@([^:]+):.*#\1#')"
             echo "::group::CI checkout network diagnostics"
             date -Is || true
             echo "remote=${REMOTE_URL}"
+            echo "remote_host=${remote_host}"
             echo "head_ref=${HEAD_REF}"
             echo "head_sha=${HEAD_SHA}"
-            getent hosts github.com || true
-            getent hosts api.github.com || true
-            timeout 20 curl -I --connect-timeout 8 --max-time 20 https://github.com 2>&1 | sed -n '1,12p' || true
+            getent hosts "${remote_host}" || true
+            timeout 20 curl -I --connect-timeout 8 --max-time 20 "https://${remote_host}" 2>&1 | sed -n '1,12p' || true
             timeout 20 git --git-dir="${CI_CACHE_REPO}" ls-remote --heads origin "${HEAD_REF}" 2>&1 | sed -n '1,12p' || true
             echo "::endgroup::"
           }
@@ -50,7 +55,14 @@ jobs:
             git config --global protocol.version 2
             git config --global http.version HTTP/1.1
             git config --global http.lowSpeedLimit 1000
-            git config --global http.lowSpeedTime 60
+            git config --global http.lowSpeedTime 30
+          }
+
+          configure_git_credentials() {
+            if [ -n "${CI_GIT_USERNAME:-}" ] && [ -n "${CI_GIT_PASSWORD:-}" ]; then
+              git config --global credential.helper \
+                '!f() { test "$1" = get || exit 0; echo username=$CI_GIT_USERNAME; echo password=$CI_GIT_PASSWORD; }; f'
+            fi
           }
 
           ensure_cache_repo() {
@@ -71,10 +83,11 @@ jobs:
               return 0
             fi
 
+            network_diag
             for attempt in $(seq 1 "${FETCH_ATTEMPTS}"); do
               echo "Fetching ${HEAD_REF}/${HEAD_SHA} from origin (attempt ${attempt}/${FETCH_ATTEMPTS})"
               set +e
-              timeout "${FETCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags --prune origin \
+              timeout "${FETCH_BRANCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags --prune origin \
                 "+refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}"
               branch_status=$?
               if [ "${branch_status}" -eq 0 ] && git --git-dir="${CI_CACHE_REPO}" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
@@ -82,7 +95,7 @@ jobs:
                 return 0
               fi
 
-              timeout "${FETCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags origin "${HEAD_SHA}"
+              timeout "${FETCH_SHA_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags origin "${HEAD_SHA}"
               sha_status=$?
               if [ "${sha_status}" -eq 0 ] && git --git-dir="${CI_CACHE_REPO}" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
                 set -e
@@ -113,6 +126,7 @@ jobs:
           }
 
           configure_git_transport
+          configure_git_credentials
           ensure_cache_repo
           fetch_head_sha
           checkout_workspace

--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -4,7 +4,7 @@ Generated from repository source files. This report is informational during the 
 
 ## Summary
 
-- Scanned files: `3850`
+- Scanned files: `3852`
 - Files requiring split plan: `42`
 - Files above warning threshold: `64`
 

--- a/frontend/apps/web/src/pages/contractForm/runtimeStateApplier.ts
+++ b/frontend/apps/web/src/pages/contractForm/runtimeStateApplier.ts
@@ -1,0 +1,17 @@
+import type { FormRuntimeStateEvent, FormRuntimeStatusRefs } from './runtimeStateProtocol';
+import { INITIAL_FORM_RUNTIME_STATE, reduceFormRuntimeState } from './runtimeStateReducer';
+
+type FormRuntimeStatusEvent = Extract<FormRuntimeStateEvent, { kind: 'status' }>;
+
+export function applyFormRuntimeStatusEvent(
+  refs: FormRuntimeStatusRefs,
+  event: FormRuntimeStatusEvent,
+) {
+  const next = reduceFormRuntimeState({
+    ...INITIAL_FORM_RUNTIME_STATE,
+    status: refs.status.value,
+    errorMessage: refs.errorMessage.value,
+  }, event);
+  refs.status.value = next.status;
+  refs.errorMessage.value = next.errorMessage;
+}

--- a/frontend/apps/web/src/pages/contractForm/useFormActionRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useFormActionRuntime.ts
@@ -3,7 +3,8 @@ import type { Router, LocationQueryRaw } from 'vue-router';
 import { executeButton } from '../../api/executeButton';
 import { pickContractNavQuery } from '../../app/navigationContext';
 import { buildFormActionExecutionPlan } from './actionExecutionPlan';
-import type { BusyKind, ContractAction, SubmissionFeedback } from './types';
+import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';
 
 type SceneMutationInput = {
   mutation: NonNullable<ContractAction['mutation']>;
@@ -33,7 +34,7 @@ export function useFormActionRuntime(params: {
   routeMenuId: () => unknown;
   router: Router;
   saveRecord: (refreshPolicy?: ContractAction['refreshPolicy']) => Promise<boolean | number>;
-  status: Ref<string>;
+  status: Ref<UiStatus>;
   submissionFeedback: Ref<SubmissionFeedback>;
 }) {
   async function runAction(action: ContractAction) {
@@ -80,8 +81,12 @@ export function useFormActionRuntime(params: {
       return;
     }
     if (plan.kind === 'open_missing_target') {
-      params.errorMessage.value = '打开操作缺少目标页面';
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'runAction',
+        status: 'error',
+        errorMessage: '打开操作缺少目标页面',
+      });
       return;
     }
     if (plan.kind === 'scene_mutation') {
@@ -104,8 +109,12 @@ export function useFormActionRuntime(params: {
         await params.applyProjectionRefreshPolicy(plan.refreshPolicy);
         return;
       } catch (err) {
-        params.errorMessage.value = err instanceof Error ? err.message : '场景操作执行失败';
-        params.status.value = 'error';
+        applyFormRuntimeStatusEvent(params, {
+          kind: 'status',
+          transaction: 'runAction',
+          status: 'error',
+          errorMessage: err instanceof Error ? err.message : '场景操作执行失败',
+        });
         return;
       } finally {
         params.busyKind.value = null;
@@ -144,8 +153,12 @@ export function useFormActionRuntime(params: {
         }
         return;
       } catch (err) {
-        params.errorMessage.value = err instanceof Error ? err.message : '操作执行失败';
-        params.status.value = 'error';
+        applyFormRuntimeStatusEvent(params, {
+          kind: 'status',
+          transaction: 'runAction',
+          status: 'error',
+          errorMessage: err instanceof Error ? err.message : '操作执行失败',
+        });
       } finally {
         params.busyKind.value = null;
       }

--- a/scripts/ci/checkout_from_ci_mirror.sh
+++ b/scripts/ci/checkout_from_ci_mirror.sh
@@ -6,20 +6,22 @@ set -euo pipefail
 : "${HEAD_SHA:?HEAD_SHA is required}"
 : "${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
 
-REMOTE_URL="${CI_REMOTE_URL:-https://github.com/Leedefend/sce-backend-odoo.git}"
-FETCH_TIMEOUT_SECONDS="${CI_FETCH_TIMEOUT_SECONDS:-180}"
-FETCH_ATTEMPTS="${CI_FETCH_ATTEMPTS:-4}"
-FETCH_BACKOFF_BASE_SECONDS="${CI_FETCH_BACKOFF_BASE_SECONDS:-15}"
+REMOTE_URL="${CI_REMOTE_URL:-https://gitee.com/leegege/sce-backend-odoo.git}"
+FETCH_BRANCH_TIMEOUT_SECONDS="${CI_FETCH_BRANCH_TIMEOUT_SECONDS:-90}"
+FETCH_SHA_TIMEOUT_SECONDS="${CI_FETCH_SHA_TIMEOUT_SECONDS:-60}"
+FETCH_ATTEMPTS="${CI_FETCH_ATTEMPTS:-5}"
+FETCH_BACKOFF_BASE_SECONDS="${CI_FETCH_BACKOFF_BASE_SECONDS:-10}"
 
 network_diag() {
+  remote_host="$(printf '%s' "${REMOTE_URL}" | sed -E 's#^[^/:]+://([^/@]+@)?([^/:]+).*#\2#; s#^[^@]+@([^:]+):.*#\1#')"
   echo "::group::CI checkout network diagnostics"
   date -Is || true
   echo "remote=${REMOTE_URL}"
+  echo "remote_host=${remote_host}"
   echo "head_ref=${HEAD_REF}"
   echo "head_sha=${HEAD_SHA}"
-  getent hosts github.com || true
-  getent hosts api.github.com || true
-  timeout 20 curl -I --connect-timeout 8 --max-time 20 https://github.com 2>&1 | sed -n '1,12p' || true
+  getent hosts "${remote_host}" || true
+  timeout 20 curl -I --connect-timeout 8 --max-time 20 "https://${remote_host}" 2>&1 | sed -n '1,12p' || true
   timeout 20 git --git-dir="${CI_CACHE_REPO}" ls-remote --heads origin "${HEAD_REF}" 2>&1 | sed -n '1,12p' || true
   echo "::endgroup::"
 }
@@ -28,7 +30,14 @@ configure_git_transport() {
   git config --global protocol.version 2
   git config --global http.version HTTP/1.1
   git config --global http.lowSpeedLimit 1000
-  git config --global http.lowSpeedTime 60
+  git config --global http.lowSpeedTime 30
+}
+
+configure_git_credentials() {
+  if [ -n "${CI_GIT_USERNAME:-}" ] && [ -n "${CI_GIT_PASSWORD:-}" ]; then
+    git config --global credential.helper \
+      '!f() { test "$1" = get || exit 0; echo username=$CI_GIT_USERNAME; echo password=$CI_GIT_PASSWORD; }; f'
+  fi
 }
 
 ensure_cache_repo() {
@@ -49,10 +58,11 @@ fetch_head_sha() {
     return 0
   fi
 
+  network_diag
   for attempt in $(seq 1 "${FETCH_ATTEMPTS}"); do
     echo "Fetching ${HEAD_REF}/${HEAD_SHA} from origin (attempt ${attempt}/${FETCH_ATTEMPTS})"
     set +e
-    timeout "${FETCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags --prune origin \
+    timeout "${FETCH_BRANCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags --prune origin \
       "+refs/heads/${HEAD_REF}:refs/remotes/origin/${HEAD_REF}"
     branch_status=$?
     if [ "${branch_status}" -eq 0 ] && git --git-dir="${CI_CACHE_REPO}" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
@@ -60,7 +70,7 @@ fetch_head_sha() {
       return 0
     fi
 
-    timeout "${FETCH_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags origin "${HEAD_SHA}"
+    timeout "${FETCH_SHA_TIMEOUT_SECONDS}" git --git-dir="${CI_CACHE_REPO}" fetch --no-tags origin "${HEAD_SHA}"
     sha_status=$?
     if [ "${sha_status}" -eq 0 ] && git --git-dir="${CI_CACHE_REPO}" cat-file -e "${HEAD_SHA}^{commit}" 2>/dev/null; then
       set -e
@@ -91,6 +101,7 @@ checkout_workspace() {
 }
 
 configure_git_transport
+configure_git_credentials
 ensure_cache_repo
 fetch_head_sha
 checkout_workspace

--- a/scripts/ci/create_gitee_mirror_repo.sh
+++ b/scripts/ci/create_gitee_mirror_repo.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${GITEE_ACCESS_TOKEN:?GITEE_ACCESS_TOKEN is required}"
+
+REPO_NAME="${GITEE_REPO_NAME:-sce-backend-odoo}"
+REPO_PATH="${GITEE_REPO_PATH:-${REPO_NAME}}"
+REPO_DESCRIPTION="${GITEE_REPO_DESCRIPTION:-Domestic CI mirror for Leedefend/sce-backend-odoo}"
+REPO_PRIVATE="${GITEE_REPO_PRIVATE:-true}"
+GITEE_API_BASE="${GITEE_API_BASE:-https://gitee.com/api/v5}"
+
+api_post() {
+  local url="$1"
+  local response_file status
+  response_file="$(mktemp)"
+  status="$(
+    curl -sS -o "${response_file}" -w '%{http_code}' \
+      -X POST "${url}" \
+      -d "access_token=${GITEE_ACCESS_TOKEN}" \
+      -d "name=${REPO_NAME}" \
+      -d "path=${REPO_PATH}" \
+      -d "description=${REPO_DESCRIPTION}" \
+      -d "private=${REPO_PRIVATE}" \
+      -d "has_issues=false" \
+      -d "has_wiki=false"
+  )"
+
+  if [ "${status}" = "201" ]; then
+    sed -n '1,120p' "${response_file}"
+    rm -f "${response_file}"
+    return 0
+  fi
+
+  echo "Gitee repository create failed: http_status=${status}" >&2
+  sed -n '1,120p' "${response_file}" >&2
+  rm -f "${response_file}"
+  return 1
+}
+
+if [ -n "${GITEE_ORG:-}" ]; then
+  api_post "${GITEE_API_BASE}/orgs/${GITEE_ORG}/repos"
+else
+  api_post "${GITEE_API_BASE}/user/repos"
+fi

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -6,6 +6,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 PROTOCOL = ROOT / "frontend/apps/web/src/pages/contractForm/runtimeStateProtocol.ts"
 REDUCER = ROOT / "frontend/apps/web/src/pages/contractForm/runtimeStateReducer.ts"
+APPLIER = ROOT / "frontend/apps/web/src/pages/contractForm/runtimeStateApplier.ts"
 TYPES = ROOT / "frontend/apps/web/src/pages/contractForm/types.ts"
 PAGE = ROOT / "frontend/apps/web/src/pages/ContractFormPage.vue"
 SAVE_HELPER = ROOT / "frontend/apps/web/src/pages/contractForm/saveRecordHelpers.ts"
@@ -22,6 +23,7 @@ def main() -> int:
     errors: list[str] = []
     protocol = _read(PROTOCOL)
     reducer = _read(REDUCER)
+    applier = _read(APPLIER)
     types = _read(TYPES)
     page = _read(PAGE)
     save_helper = _read(SAVE_HELPER)
@@ -33,6 +35,8 @@ def main() -> int:
         errors.append(f"missing protocol: {PROTOCOL.relative_to(ROOT)}")
     if not reducer:
         errors.append(f"missing reducer: {REDUCER.relative_to(ROOT)}")
+    if not applier:
+        errors.append(f"missing applier: {APPLIER.relative_to(ROOT)}")
 
     required_protocol_tokens = [
         "export type FormRuntimeStatus = 'loading' | 'ok' | 'error';",
@@ -101,6 +105,42 @@ def main() -> int:
         if token in reducer:
             errors.append(f"runtimeStateReducer.ts must stay pure; forbidden token: {token}")
 
+    required_applier_tokens = [
+        "export function applyFormRuntimeStatusEvent",
+        "type FormRuntimeStatusEvent = Extract<FormRuntimeStateEvent, { kind: 'status' }>",
+        "FormRuntimeStatusRefs",
+        "INITIAL_FORM_RUNTIME_STATE",
+        "reduceFormRuntimeState",
+        "status: refs.status.value",
+        "errorMessage: refs.errorMessage.value",
+        "refs.status.value = next.status",
+        "refs.errorMessage.value = next.errorMessage",
+    ]
+    for token in required_applier_tokens:
+        if token not in applier:
+            errors.append(f"runtimeStateApplier.ts missing token: {token}")
+
+    forbidden_applier_tokens = [
+        "await ",
+        "async ",
+        "intentRequest",
+        "triggerOnchange",
+        "executeButton",
+        "router.",
+        "window.",
+        "createContractFormRecord",
+        "writeContractFormRecord",
+        "queryRelationOptions",
+        "reload(",
+        "busyKind.value",
+        "submissionFeedback.value",
+        "validationErrors.value",
+        "showOne2manyErrors.value",
+    ]
+    for token in forbidden_applier_tokens:
+        if token in applier:
+            errors.append(f"runtimeStateApplier.ts must stay status-only; forbidden token: {token}")
+
     required_type_exports = [
         "FormRuntimeBusyKind as BusyKind",
         "FormRuntimeStatus as UiStatus",
@@ -125,12 +165,33 @@ def main() -> int:
     required_consumers = [
         (page, "type SubmissionFeedback,", "ContractFormPage.vue"),
         (save_helper, "import type { LayoutNode, SubmissionFeedback } from './types';", "saveRecordHelpers.ts"),
-        (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback } from './types';", "useFormActionRuntime.ts"),
+        (action_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormActionRuntime.ts"),
+        (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "useFormActionRuntime.ts"),
         (primary_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback } from './types';", "usePrimaryFormActionRuntime.ts"),
     ]
     for source, token, label in required_consumers:
         if token not in source:
             errors.append(f"{label} missing runtime protocol consumer token: {token}")
+
+    required_action_applier_tokens = [
+        "applyFormRuntimeStatusEvent(params, {",
+        "transaction: 'runAction'",
+        "errorMessage: '打开操作缺少目标页面'",
+        "errorMessage: err instanceof Error ? err.message : '场景操作执行失败'",
+        "errorMessage: err instanceof Error ? err.message : '操作执行失败'",
+    ]
+    for token in required_action_applier_tokens:
+        if token not in action_runtime:
+            errors.append(f"useFormActionRuntime.ts missing status applier token: {token}")
+
+    stale_action_writes = [
+        "params.errorMessage.value = '打开操作缺少目标页面';",
+        "params.errorMessage.value = err instanceof Error ? err.message : '场景操作执行失败';",
+        "params.errorMessage.value = err instanceof Error ? err.message : '操作执行失败';",
+    ]
+    for token in stale_action_writes:
+        if token in action_runtime:
+            errors.append(f"useFormActionRuntime.ts still bypasses status applier: {token}")
 
     ci_token = "python3 scripts/verify/contract_form_runtime_state_protocol_guard.py"
     if ci_token not in ci:


### PR DESCRIPTION
## Summary

- add a status-only runtime state applier backed by `reduceFormRuntimeState`
- route three `runAction` error status writes through the applier
- extend the runtime state protocol guard so the applier stays status-only and side-effect free
- create and initialize the Gitee mirror repo `leegege/sce-backend-odoo`
- switch the v1.1 quality gate checkout default from GitHub to the domestic Gitee mirror
- add CI checkout credential support through `CI_GIT_USERNAME` / `CI_GIT_PASSWORD` secrets
- refresh the generated complexity budget report for the added file count

## Scope

Runtime state work remains intentionally narrow. It does not migrate `saveRecord`, `runAction`, or `runOnchangeRoundtrip` transaction ownership, and it does not change API, router, loading, feedback, validation, or refresh behavior.

The CI network change is checkout-only: GitHub remains the PR and Actions entrypoint, while the self-hosted runner fetches repository objects from Gitee by default.

## Verification

- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `git diff --check`
- `bash -n scripts/ci/checkout_from_ci_mirror.sh`
- `bash -n scripts/ci/create_gitee_mirror_repo.sh`
- `make ci.local.quick`
- `make ci` passed before checkout mirror switch
- simulated CI checkout from private Gitee mirror succeeded for `ca2e7eb3500441a5da2d9987d1605aff7d66e831`

## Evidence

- Gitee repo: `leegege/sce-backend-odoo`
- Gitee default branch: `main`
- GitHub Actions secrets set: `CI_GIT_USERNAME`, `CI_GIT_PASSWORD`, `GITEE_ACCESS_TOKEN`
- `ContractFormPage.vue`: 5938 lines
- `runtimeStateApplier.ts`: 17 lines
- `runtimeStateReducer.ts`: 61 lines