### PR TITLE
refactor: apply primary form runtime status events

### DIFF
--- a/frontend/apps/web/src/pages/contractForm/usePrimaryFormActionRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/usePrimaryFormActionRuntime.ts
@@ -1,7 +1,8 @@
 import { nextTick, type Ref } from 'vue';
 import { executeButton } from '../../api/executeButton';
 import { sanitizeUiErrorMessage } from './fieldUtils';
-import type { BusyKind, ContractAction, SubmissionFeedback } from './types';
+import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';
 
 export function usePrimaryFormActionRuntime(params: {
   actionId: () => number;
@@ -17,7 +18,7 @@ export function usePrimaryFormActionRuntime(params: {
   reload: () => Promise<void>;
   routeMenuId: () => unknown;
   saveRecord: (refreshPolicy?: ContractAction['refreshPolicy']) => Promise<boolean | number>;
-  status: Ref<string>;
+  status: Ref<UiStatus>;
   submissionFeedback: Ref<SubmissionFeedback>;
   validationErrors: Ref<string[]>;
 }) {
@@ -46,7 +47,11 @@ export function usePrimaryFormActionRuntime(params: {
       const message = sanitizeUiErrorMessage(err instanceof Error ? err.message : err, '提交失败，请检查填写内容');
       params.validationErrors.value = [message];
       params.submissionFeedback.value = { kind: 'error', message: '提交失败，请检查填写内容' };
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'primaryAction',
+        status: 'error',
+      });
     } finally {
       params.busyKind.value = null;
     }
@@ -60,8 +65,12 @@ export function usePrimaryFormActionRuntime(params: {
       await nextTick();
       const submittedRecordId = typeof saved === 'number' ? saved : params.recordId.value;
       if (!submittedRecordId) {
-        params.errorMessage.value = '操作失败：请先保存记录后再执行';
-        params.status.value = 'error';
+        applyFormRuntimeStatusEvent(params, {
+          kind: 'status',
+          transaction: 'primaryAction',
+          status: 'error',
+          errorMessage: '操作失败：请先保存记录后再执行',
+        });
         return;
       }
       await executePrimarySubmitAction({
@@ -81,8 +90,12 @@ export function usePrimaryFormActionRuntime(params: {
     await nextTick();
     const submittedRecordId = typeof saved === 'number' ? saved : params.recordId.value;
     if (!submittedRecordId) {
-      params.errorMessage.value = '提交失败：请先保存记录后再提交';
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'primaryAction',
+        status: 'error',
+        errorMessage: '提交失败：请先保存记录后再提交',
+      });
       return;
     }
     await executePrimarySubmitAction({

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -167,7 +167,8 @@ def main() -> int:
         (save_helper, "import type { LayoutNode, SubmissionFeedback } from './types';", "saveRecordHelpers.ts"),
         (action_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormActionRuntime.ts"),
         (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "useFormActionRuntime.ts"),
-        (primary_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback } from './types';", "usePrimaryFormActionRuntime.ts"),
+        (primary_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "usePrimaryFormActionRuntime.ts"),
+        (primary_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "usePrimaryFormActionRuntime.ts"),
     ]
     for source, token, label in required_consumers:
         if token not in source:
@@ -192,6 +193,24 @@ def main() -> int:
     for token in stale_action_writes:
         if token in action_runtime:
             errors.append(f"useFormActionRuntime.ts still bypasses status applier: {token}")
+
+    required_primary_applier_tokens = [
+        "applyFormRuntimeStatusEvent(params, {",
+        "transaction: 'primaryAction'",
+        "errorMessage: '操作失败：请先保存记录后再执行'",
+        "errorMessage: '提交失败：请先保存记录后再提交'",
+    ]
+    for token in required_primary_applier_tokens:
+        if token not in primary_runtime:
+            errors.append(f"usePrimaryFormActionRuntime.ts missing status applier token: {token}")
+
+    stale_primary_writes = [
+        "params.errorMessage.value = '操作失败：请先保存记录后再执行';",
+        "params.errorMessage.value = '提交失败：请先保存记录后再提交';",
+    ]
+    for token in stale_primary_writes:
+        if token in primary_runtime:
+            errors.append(f"usePrimaryFormActionRuntime.ts still bypasses status applier: {token}")
 
     ci_token = "python3 scripts/verify/contract_form_runtime_state_protocol_guard.py"
     if ci_token not in ci:


### PR DESCRIPTION
## Summary

- route `primaryAction` error status writes through `applyFormRuntimeStatusEvent`
- keep validation, feedback, busy state, API calls, navigation, save, and refresh order unchanged
- tighten `contract_form_runtime_state_protocol_guard.py` so primary-action status events keep using the applier

## Scope

This is a narrow runtime boundary step. It does not migrate `saveRecord`, `runAction`, `runOnchangeRoundtrip`, or the primary submit transaction body. It only replaces three status/error writes in `usePrimaryFormActionRuntime` with status events.

## Verification

- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `git diff --check`
- `make ci.local.quick`
- `make ci`

## Evidence

- `ContractFormPage.vue`: 5938 lines
- `runtimeStateApplier.ts`: 17 lines
- `usePrimaryFormActionRuntime.ts`: 112 lines