### PR TITLE
refactor: apply config runtime status events

### DIFF
--- a/frontend/apps/web/src/pages/contractForm/useContractModeActionRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useContractModeActionRuntime.ts
@@ -6,12 +6,13 @@ import {
   contractPromptFieldsFromRule,
   contractPromptParamsFromRule,
 } from './actionContract';
-import type { BusyKind } from './types';
+import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import type { BusyKind, UiStatus } from './types';
 
 export function useContractModeActionRuntime(params: {
   busyKind: Ref<BusyKind>;
   errorMessage: Ref<string>;
-  status: Ref<string>;
+  status: Ref<UiStatus>;
   contractModeFeedback: Ref<string>;
   applyClientMode: (mode: string, toggle?: boolean) => boolean | void;
   reload: () => Promise<void>;
@@ -54,8 +55,12 @@ export function useContractModeActionRuntime(params: {
       params.contractModeFeedback.value = String(target.success_message || '已更新').trim();
       await params.reload();
     } catch (err) {
-      params.errorMessage.value = err instanceof Error ? err.message : '表单配置操作失败';
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'contractMode',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '表单配置操作失败',
+      });
     } finally {
       params.busyKind.value = null;
     }

--- a/frontend/apps/web/src/pages/contractForm/useFormConfigSaveRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useFormConfigSaveRuntime.ts
@@ -11,7 +11,8 @@ import {
   lowCodeScopedContractName,
   normalizeLowCodeApplyParams,
 } from './formConfigHelpers';
-import type { BusyKind, FormConfigAuditResult, LowCodeFieldSize } from './types';
+import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import type { BusyKind, FormConfigAuditResult, LowCodeFieldSize, UiStatus } from './types';
 
 type LowCodeColumns = 1 | 2 | 3;
 
@@ -53,7 +54,7 @@ export function useFormConfigSaveRuntime(params: {
   markPendingOperations: (status: 'saved' | 'reverted') => void;
   modelName: () => string;
   reload: () => Promise<void>;
-  status: Ref<string>;
+  status: Ref<UiStatus>;
 }) {
   function formConfigSaveOperationSummary(changedVisibility: Record<string, boolean>, changedGroups: Record<string, string>) {
     return formConfigSaveOperationSummaryFromDraft({
@@ -153,8 +154,12 @@ export function useFormConfigSaveRuntime(params: {
       await params.hydrateLowCodeDraftFromContract();
       return true;
     } catch (err) {
-      params.errorMessage.value = err instanceof Error ? err.message : '表单字段顺序更新失败';
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'formConfig',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '表单字段顺序更新失败',
+      });
       return false;
     } finally {
       params.busyKind.value = null;

--- a/frontend/apps/web/src/pages/contractForm/useInlineFieldPolicyRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useInlineFieldPolicyRuntime.ts
@@ -2,13 +2,14 @@ import type { Ref } from 'vue';
 import { intentRequest } from '../../api/intents';
 import { FORM_FIELD_CONFIG_INTENTS } from '../../app/businessConfigBoundaries';
 import { normalizeFieldGroupTitle } from './formConfigHelpers';
-import type { BusyKind, FormConfigOperationLogEntry } from './types';
+import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import type { BusyKind, FormConfigOperationLogEntry, UiStatus } from './types';
 
 export function useInlineFieldPolicyRuntime(params: {
   busy: () => boolean;
   busyKind: Ref<BusyKind>;
   errorMessage: Ref<string>;
-  status: Ref<string>;
+  status: Ref<UiStatus>;
   contractModeFeedback: Ref<string>;
   lowCodeApplyBaseParams: () => Record<string, unknown>;
   contractFieldSequence: (fieldKey: string) => number;
@@ -42,8 +43,12 @@ export function useInlineFieldPolicyRuntime(params: {
       params.contractModeFeedback.value = '字段配置已更新';
       await params.reload();
     } catch (err) {
-      params.errorMessage.value = err instanceof Error ? err.message : '字段显示规则更新失败';
-      params.status.value = 'error';
+      applyFormRuntimeStatusEvent(params, {
+        kind: 'status',
+        transaction: 'inlinePolicy',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '字段显示规则更新失败',
+      });
     } finally {
       params.busyKind.value = null;
     }

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -12,6 +12,9 @@ PAGE = ROOT / "frontend/apps/web/src/pages/ContractFormPage.vue"
 SAVE_HELPER = ROOT / "frontend/apps/web/src/pages/contractForm/saveRecordHelpers.ts"
 ACTION_RUNTIME = ROOT / "frontend/apps/web/src/pages/contractForm/useFormActionRuntime.ts"
 PRIMARY_RUNTIME = ROOT / "frontend/apps/web/src/pages/contractForm/usePrimaryFormActionRuntime.ts"
+FORM_CONFIG_RUNTIME = ROOT / "frontend/apps/web/src/pages/contractForm/useFormConfigSaveRuntime.ts"
+INLINE_POLICY_RUNTIME = ROOT / "frontend/apps/web/src/pages/contractForm/useInlineFieldPolicyRuntime.ts"
+CONTRACT_MODE_RUNTIME = ROOT / "frontend/apps/web/src/pages/contractForm/useContractModeActionRuntime.ts"
 CI = ROOT / "make/ci.mk"
 
 
@@ -29,6 +32,9 @@ def main() -> int:
     save_helper = _read(SAVE_HELPER)
     action_runtime = _read(ACTION_RUNTIME)
     primary_runtime = _read(PRIMARY_RUNTIME)
+    form_config_runtime = _read(FORM_CONFIG_RUNTIME)
+    inline_policy_runtime = _read(INLINE_POLICY_RUNTIME)
+    contract_mode_runtime = _read(CONTRACT_MODE_RUNTIME)
     ci = _read(CI)
 
     if not protocol:
@@ -169,6 +175,12 @@ def main() -> int:
         (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "useFormActionRuntime.ts"),
         (primary_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "usePrimaryFormActionRuntime.ts"),
         (primary_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "usePrimaryFormActionRuntime.ts"),
+        (form_config_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormConfigSaveRuntime.ts"),
+        (form_config_runtime, "UiStatus", "useFormConfigSaveRuntime.ts"),
+        (inline_policy_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useInlineFieldPolicyRuntime.ts"),
+        (inline_policy_runtime, "UiStatus", "useInlineFieldPolicyRuntime.ts"),
+        (contract_mode_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useContractModeActionRuntime.ts"),
+        (contract_mode_runtime, "UiStatus", "useContractModeActionRuntime.ts"),
     ]
     for source, token, label in required_consumers:
         if token not in source:
@@ -211,6 +223,25 @@ def main() -> int:
     for token in stale_primary_writes:
         if token in primary_runtime:
             errors.append(f"usePrimaryFormActionRuntime.ts still bypasses status applier: {token}")
+
+    config_status_event_requirements = [
+        (form_config_runtime, "useFormConfigSaveRuntime.ts", "transaction: 'formConfig'", "errorMessage: err instanceof Error ? err.message : '表单字段顺序更新失败'"),
+        (inline_policy_runtime, "useInlineFieldPolicyRuntime.ts", "transaction: 'inlinePolicy'", "errorMessage: err instanceof Error ? err.message : '字段显示规则更新失败'"),
+        (contract_mode_runtime, "useContractModeActionRuntime.ts", "transaction: 'contractMode'", "errorMessage: err instanceof Error ? err.message : '表单配置操作失败'"),
+    ]
+    for source, label, transaction_token, error_token in config_status_event_requirements:
+        for token in ["applyFormRuntimeStatusEvent(params, {", transaction_token, error_token]:
+            if token not in source:
+                errors.append(f"{label} missing config status applier token: {token}")
+
+    stale_config_writes = [
+        (form_config_runtime, "useFormConfigSaveRuntime.ts", "params.errorMessage.value = err instanceof Error ? err.message : '表单字段顺序更新失败';"),
+        (inline_policy_runtime, "useInlineFieldPolicyRuntime.ts", "params.errorMessage.value = err instanceof Error ? err.message : '字段显示规则更新失败';"),
+        (contract_mode_runtime, "useContractModeActionRuntime.ts", "params.errorMessage.value = err instanceof Error ? err.message : '表单配置操作失败';"),
+    ]
+    for source, label, token in stale_config_writes:
+        if token in source:
+            errors.append(f"{label} still bypasses status applier: {token}")
 
     ci_token = "python3 scripts/verify/contract_form_runtime_state_protocol_guard.py"
     if ci_token not in ci:


### PR DESCRIPTION
## Summary

- route `formConfig`, `inlinePolicy`, and `contractMode` error status writes through `applyFormRuntimeStatusEvent`
- keep API calls, reload order, busy state, operation logs, and feedback writes unchanged
- extend `contract_form_runtime_state_protocol_guard.py` so these config-side runtimes continue using status events instead of direct `errorMessage/status` writes

## Commit Shape

This PR intentionally keeps three small commits on one branch:

- `refactor: apply form config status events`
- `refactor: apply config policy status events`
- `test: guard config status event consumers`

## Scope

This is still status-boundary work only. It does not migrate `saveRecord`, `runAction`, `runOnchangeRoundtrip`, or config-side API transactions into a new runtime owner.

## Verification

- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `git diff --check`
- `make ci.local.quick`
- `make ci`

## Evidence

- `ContractFormPage.vue`: 5938 lines
- `runtimeStateApplier.ts`: 17 lines
- `useFormConfigSaveRuntime.ts`: 173 lines
- `useInlineFieldPolicyRuntime.ts`: 68 lines
- `useContractModeActionRuntime.ts`: 108 lines