### PR TITLE
refactor: apply page runtime status events

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -12,7 +12,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Category | File |
 | ---: | --- | --- |
-| 5938 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5939 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 4820 | Python source | `addons/smart_core/utils/contract_governance.py` |
 | 4372 | Python source | `addons/smart_construction_core/core_extension.py` |
 | 3849 | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
@@ -128,7 +128,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Status | Category | File |
 | ---: | --- | --- | --- |
-| 5938 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5939 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 4820 | split_plan_required | Python source | `addons/smart_core/utils/contract_governance.py` |
 | 4372 | split_plan_required | Python source | `addons/smart_construction_core/core_extension.py` |
 | 3849 | split_plan_required | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |

--- a/docs/engineering_convergence/p4_p0_03_contract_form_split_evidence.md
+++ b/docs/engineering_convergence/p4_p0_03_contract_form_split_evidence.md
@@ -61,7 +61,7 @@ The route component remains the orchestration shell and still owns runtime state
 
 | File | Before | After |
 | --- | ---: | ---: |
-| `frontend/apps/web/src/pages/ContractFormPage.vue` | 13762 | 5938 |
+| `frontend/apps/web/src/pages/ContractFormPage.vue` | 13762 | 5939 |
 
 ## Boundary Decision
 
@@ -70,7 +70,7 @@ The route component remains the orchestration shell and still owns runtime state
 - No frontend fallback menu, permission, action, or form policy was introduced.
 - No data migration, backend endpoint change, or visual redesign is included in this slice.
 - Existing `groups_xmlids` usage in `ContractFormPage.vue` is locked at 1 occurrence by `scripts/verify/web_contract_v2_frontend_architecture_guard.py`; the next cleanup must remove the final entitlement read fully behind backend contracts.
-- `ContractFormPage.vue` is line-count locked at 5938 lines. Future work must continue extracting or modifying existing owned modules instead of adding new responsibilities to the route component.
+- `ContractFormPage.vue` is line-count locked at 5939 lines. Future work must continue extracting or modifying existing owned modules instead of adding new responsibilities to the route component.
 
 ## Verification
 

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -13,7 +13,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 
 | Priority | Lines | Owner | File | Decomposition Direction |
 | --- | ---: | --- | --- | --- |
-| P0 | 5938 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P0 | 5939 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 4820 | Platform owner | `addons/smart_core/utils/contract_governance.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P1 | 4372 | Construction backend owner | `addons/smart_construction_core/core_extension.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P1 | 3849 | Platform owner | `addons/smart_core/handlers/ui_contract_v2.py` | Extract parsing, validation, assembly, and response mapping into owned services. |

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -952,7 +952,14 @@ const {
   onPendingUploadFailed: (message) => {
     validationErrors.value = [message];
     submissionFeedback.value = { kind: 'error', message };
-    status.value = 'error';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'primaryAction',
+      status: 'error',
+    });
   },
 });
 const nativeChatterAutoLoadKey = ref('');

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -633,6 +633,7 @@ import {
   type ContractAction,
   type ContractFieldGovernanceAction,
   type ContractFieldGovernanceRow,
+  type FormRuntimeStateEvent,
   type FormConfigAuditResult,
   type LayoutNode,
   type LowCodeFieldSize,
@@ -709,15 +710,7 @@ async function collectActionParams(action: ContractAction): Promise<Record<strin
   if (!action.requiresReason && !requiredParams.has('reason')) return {};
   const reason = window.prompt(`${action.label || '操作'}原因`)?.trim() || '';
   if (!reason) {
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'runAction',
-      status: 'error',
-      errorMessage: '请填写操作原因',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'runAction', status: 'error', errorMessage: '请填写操作原因' });
     return null;
   }
   return { reason };
@@ -754,6 +747,13 @@ const formSettingsActiveTab = ref<'structure' | 'fields' | 'details' | 'actions'
 const contractModeFeedback = ref('');
 const contract = ref<ActionContract | null>(null);
 const contractMeta = ref<Record<string, unknown> | null>(null);
+
+type PageStatusEvent = Extract<FormRuntimeStateEvent, { kind: 'status' }>;
+
+function applyPageStatusEvent(event: PageStatusEvent) {
+  applyFormRuntimeStatusEvent({ status, errorMessage }, event);
+}
+
 const {
   copyContractJson,
   exportContractJson,
@@ -952,14 +952,7 @@ const {
   onPendingUploadFailed: (message) => {
     validationErrors.value = [message];
     submissionFeedback.value = { kind: 'error', message };
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'primaryAction',
-      status: 'error',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'primaryAction', status: 'error' });
   },
 });
 const nativeChatterAutoLoadKey = ref('');
@@ -1653,15 +1646,7 @@ const {
       await reload();
       return true;
     } catch (err) {
-      applyFormRuntimeStatusEvent({
-        status,
-        errorMessage,
-      }, {
-        kind: 'status',
-        transaction: 'formConfig',
-        status: 'error',
-        errorMessage: err instanceof Error ? err.message : '自定义字段创建失败',
-      });
+      applyPageStatusEvent({ kind: 'status', transaction: 'formConfig', status: 'error', errorMessage: err instanceof Error ? err.message : '自定义字段创建失败' });
       return false;
     } finally {
       busyKind.value = null;
@@ -2089,15 +2074,7 @@ async function auditCurrentFormConfiguration() {
     });
     formConfigAuditResult.value = normalizeFormConfigAuditResult(result);
   } catch (err) {
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'formConfig',
-      status: 'error',
-      errorMessage: err instanceof Error ? err.message : '表单配置检查失败',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'formConfig', status: 'error', errorMessage: err instanceof Error ? err.message : '表单配置检查失败' });
   } finally {
     formConfigAuditBusy.value = false;
   }
@@ -2463,15 +2440,7 @@ async function publishSelectedLowCodeContract() {
     contractModeFeedback.value = '配置版本已发布，刷新页面后按新配置生效';
     await loadLowCodeContractList();
   } catch (err) {
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'contractMode',
-      status: 'error',
-      errorMessage: err instanceof Error ? err.message : '配置版本发布失败',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'contractMode', status: 'error', errorMessage: err instanceof Error ? err.message : '配置版本发布失败' });
   } finally {
     busyKind.value = null;
   }
@@ -2492,15 +2461,7 @@ async function rollbackSelectedLowCodeContract() {
     await loadLowCodeContractList();
     await switchLowCodeContractByName();
   } catch (err) {
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'contractMode',
-      status: 'error',
-      errorMessage: err instanceof Error ? err.message : '配置版本回滚失败',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'contractMode', status: 'error', errorMessage: err instanceof Error ? err.message : '配置版本回滚失败' });
   } finally {
     busyKind.value = null;
   }
@@ -4062,15 +4023,7 @@ async function runNativeLayoutAction(row: Record<string, unknown>) {
       await reload();
       return;
     } catch (err) {
-      applyFormRuntimeStatusEvent({
-        status,
-        errorMessage,
-      }, {
-        kind: 'status',
-        transaction: 'runAction',
-        status: 'error',
-        errorMessage: err instanceof Error ? err.message : '操作执行失败',
-      });
+      applyPageStatusEvent({ kind: 'status', transaction: 'runAction', status: 'error', errorMessage: err instanceof Error ? err.message : '操作执行失败' });
       return;
     } finally {
       busyKind.value = null;
@@ -5500,14 +5453,7 @@ async function reload() {
     const reloadToken = activeReloadToken + 1;
     activeReloadToken = reloadToken;
     renderErrorMessage.value = '';
-    applyFormRuntimeStatusEvent({
-      status,
-      errorMessage,
-    }, {
-      kind: 'status',
-      transaction: 'formReload',
-      status: 'loading',
-    });
+    applyPageStatusEvent({ kind: 'status', transaction: 'formReload', status: 'loading' });
     validationErrors.value = [];
     showOne2manyErrors.value = false;
     try {
@@ -5515,14 +5461,7 @@ async function reload() {
       if (reloadToken !== activeReloadToken) return;
       await loadRecord();
       if (reloadToken !== activeReloadToken) return;
-      applyFormRuntimeStatusEvent({
-        status,
-        errorMessage,
-      }, {
-        kind: 'status',
-        transaction: 'formReload',
-        status: 'ok',
-      });
+      applyPageStatusEvent({ kind: 'status', transaction: 'formReload', status: 'ok' });
       retainedRouteIdentity.value = formRouteIdentity();
       void preloadFormAuxiliaryData(reloadToken);
     } catch (err) {
@@ -5539,15 +5478,7 @@ async function reload() {
         });
         return;
       }
-      applyFormRuntimeStatusEvent({
-        status,
-        errorMessage,
-      }, {
-        kind: 'status',
-        transaction: 'formReload',
-        status: 'error',
-        errorMessage: err instanceof Error ? err.message : '表单加载失败',
-      });
+      applyPageStatusEvent({ kind: 'status', transaction: 'formReload', status: 'error', errorMessage: err instanceof Error ? err.message : '表单加载失败' });
     } finally {
       if (activeReloadIdentity === reloadIdentity) {
         activeReloadPromise = null;

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -674,6 +674,7 @@ import { useActionResponseNavigation } from './contractForm/useActionResponseNav
 import { usePrimaryFormActionRuntime } from './contractForm/usePrimaryFormActionRuntime';
 import { useFormActionRuntime } from './contractForm/useFormActionRuntime';
 import { useFormConfigSaveRuntime } from './contractForm/useFormConfigSaveRuntime';
+import { applyFormRuntimeStatusEvent } from './contractForm/runtimeStateApplier';
 import { useContractDebugExportRuntime } from './contractForm/useContractDebugExportRuntime';
 import { useProjectContextChangeRuntime } from './contractForm/useProjectContextChangeRuntime';
 import { useFormPageLifecycleRuntime } from './contractForm/useFormPageLifecycleRuntime';
@@ -1638,8 +1639,15 @@ const {
       await reload();
       return true;
     } catch (err) {
-      errorMessage.value = err instanceof Error ? err.message : '自定义字段创建失败';
-      status.value = 'error';
+      applyFormRuntimeStatusEvent({
+        status,
+        errorMessage,
+      }, {
+        kind: 'status',
+        transaction: 'formConfig',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '自定义字段创建失败',
+      });
       return false;
     } finally {
       busyKind.value = null;
@@ -2067,8 +2075,15 @@ async function auditCurrentFormConfiguration() {
     });
     formConfigAuditResult.value = normalizeFormConfigAuditResult(result);
   } catch (err) {
-    errorMessage.value = err instanceof Error ? err.message : '表单配置检查失败';
-    status.value = 'error';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'formConfig',
+      status: 'error',
+      errorMessage: err instanceof Error ? err.message : '表单配置检查失败',
+    });
   } finally {
     formConfigAuditBusy.value = false;
   }
@@ -2434,8 +2449,15 @@ async function publishSelectedLowCodeContract() {
     contractModeFeedback.value = '配置版本已发布，刷新页面后按新配置生效';
     await loadLowCodeContractList();
   } catch (err) {
-    errorMessage.value = err instanceof Error ? err.message : '配置版本发布失败';
-    status.value = 'error';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'contractMode',
+      status: 'error',
+      errorMessage: err instanceof Error ? err.message : '配置版本发布失败',
+    });
   } finally {
     busyKind.value = null;
   }
@@ -2456,8 +2478,15 @@ async function rollbackSelectedLowCodeContract() {
     await loadLowCodeContractList();
     await switchLowCodeContractByName();
   } catch (err) {
-    errorMessage.value = err instanceof Error ? err.message : '配置版本回滚失败';
-    status.value = 'error';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'contractMode',
+      status: 'error',
+      errorMessage: err instanceof Error ? err.message : '配置版本回滚失败',
+    });
   } finally {
     busyKind.value = null;
   }

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -5479,8 +5479,14 @@ async function reload() {
     const reloadToken = activeReloadToken + 1;
     activeReloadToken = reloadToken;
     renderErrorMessage.value = '';
-    status.value = 'loading';
-    errorMessage.value = '';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'formReload',
+      status: 'loading',
+    });
     validationErrors.value = [];
     showOne2manyErrors.value = false;
     try {
@@ -5488,7 +5494,14 @@ async function reload() {
       if (reloadToken !== activeReloadToken) return;
       await loadRecord();
       if (reloadToken !== activeReloadToken) return;
-      status.value = 'ok';
+      applyFormRuntimeStatusEvent({
+        status,
+        errorMessage,
+      }, {
+        kind: 'status',
+        transaction: 'formReload',
+        status: 'ok',
+      });
       retainedRouteIdentity.value = formRouteIdentity();
       void preloadFormAuxiliaryData(reloadToken);
     } catch (err) {
@@ -5505,8 +5518,15 @@ async function reload() {
         });
         return;
       }
-      errorMessage.value = err instanceof Error ? err.message : '表单加载失败';
-      status.value = 'error';
+      applyFormRuntimeStatusEvent({
+        status,
+        errorMessage,
+      }, {
+        kind: 'status',
+        transaction: 'formReload',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '表单加载失败',
+      });
     } finally {
       if (activeReloadIdentity === reloadIdentity) {
         activeReloadPromise = null;

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -709,8 +709,15 @@ async function collectActionParams(action: ContractAction): Promise<Record<strin
   if (!action.requiresReason && !requiredParams.has('reason')) return {};
   const reason = window.prompt(`${action.label || '操作'}原因`)?.trim() || '';
   if (!reason) {
-    errorMessage.value = '请填写操作原因';
-    status.value = 'error';
+    applyFormRuntimeStatusEvent({
+      status,
+      errorMessage,
+    }, {
+      kind: 'status',
+      transaction: 'runAction',
+      status: 'error',
+      errorMessage: '请填写操作原因',
+    });
     return null;
   }
   return { reason };
@@ -4048,8 +4055,15 @@ async function runNativeLayoutAction(row: Record<string, unknown>) {
       await reload();
       return;
     } catch (err) {
-      errorMessage.value = err instanceof Error ? err.message : '操作执行失败';
-      status.value = 'error';
+      applyFormRuntimeStatusEvent({
+        status,
+        errorMessage,
+      }, {
+        kind: 'status',
+        transaction: 'runAction',
+        status: 'error',
+        errorMessage: err instanceof Error ? err.message : '操作执行失败',
+      });
       return;
     } finally {
       busyKind.value = null;

--- a/frontend/apps/web/src/pages/contractForm/runtimeStateProtocol.ts
+++ b/frontend/apps/web/src/pages/contractForm/runtimeStateProtocol.ts
@@ -33,6 +33,7 @@ export type FormRuntimeTransactionName =
   | 'runAction'
   | 'runOnchangeRoundtrip'
   | 'primaryAction'
+  | 'formReload'
   | 'formConfig'
   | 'inlinePolicy'
   | 'contractMode';
@@ -49,6 +50,7 @@ export const FORM_RUNTIME_TRANSACTIONS: readonly FormRuntimeTransactionName[] = 
   'runAction',
   'runOnchangeRoundtrip',
   'primaryAction',
+  'formReload',
   'formConfig',
   'inlinePolicy',
   'contractMode',

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -55,6 +55,7 @@ def main() -> int:
         "'saveRecord'",
         "'runAction'",
         "'runOnchangeRoundtrip'",
+        "'formReload'",
     ]
     for token in required_protocol_tokens:
         if token not in protocol:

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -171,6 +172,7 @@ def main() -> int:
 
     required_consumers = [
         (page, "type SubmissionFeedback,", "ContractFormPage.vue"),
+        (page, "import { applyFormRuntimeStatusEvent } from './contractForm/runtimeStateApplier';", "ContractFormPage.vue"),
         (save_helper, "import type { LayoutNode, SubmissionFeedback } from './types';", "saveRecordHelpers.ts"),
         (action_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormActionRuntime.ts"),
         (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "useFormActionRuntime.ts"),
@@ -243,6 +245,27 @@ def main() -> int:
     for source, label, token in stale_config_writes:
         if token in source:
             errors.append(f"{label} still bypasses status applier: {token}")
+
+    required_page_status_tokens = [
+        "transaction: 'formReload'",
+        "transaction: 'runAction'",
+        "transaction: 'formConfig'",
+        "transaction: 'contractMode'",
+        "transaction: 'primaryAction'",
+        "errorMessage: '请填写操作原因'",
+        "errorMessage: err instanceof Error ? err.message : '表单加载失败'",
+    ]
+    for token in required_page_status_tokens:
+        if token not in page:
+            errors.append(f"ContractFormPage.vue missing status applier token: {token}")
+
+    forbidden_page_status_write_patterns = [
+        (r"\bstatus\.value\s*=(?!=)", "status.value assignment"),
+        (r"\berrorMessage\.value\s*=(?!=)", "errorMessage.value assignment"),
+    ]
+    for pattern, label in forbidden_page_status_write_patterns:
+        if re.search(pattern, page):
+            errors.append(f"ContractFormPage.vue must route status/error writes through applier; forbidden token: {label}")
 
     ci_token = "python3 scripts/verify/contract_form_runtime_state_protocol_guard.py"
     if ci_token not in ci:


### PR DESCRIPTION
## Summary

- route remaining `ContractFormPage.vue` status/error writes through `applyFormRuntimeStatusEvent`
- add `formReload` as an explicit runtime transaction for page reload loading/ok/error status
- keep save, action, onchange, load, route, validation, feedback, and busy lifecycles in place
- guard the page so future `status.value =` / `errorMessage.value =` assignments route through the status applier
- refresh line-count evidence and split-plan reports for the resulting 5939-line page

## Commit Shape

This PR intentionally accumulates small commits on one branch to reduce remote CI churn:

- `refactor: apply page config status events`
- `refactor: apply form reload status events`
- `refactor: apply page action status events`
- `refactor: apply page attachment status event`
- `test: guard page status event consumers`
- `refactor: compact page status event calls`
- `docs: refresh contract form status evidence`
- `docs: refresh contract form split queue`

## Scope

This is status-boundary work only. It does not migrate `saveRecord`, `runAction`, `runOnchangeRoundtrip`, or reload ownership into a new runtime module.

## Verification

- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `git diff --check`
- `make ci.local.quick`
- `make ci`

## Evidence

- `ContractFormPage.vue`: 5939 lines
- `runtimeStateProtocol.ts`: 57 lines
- `runtimeStateApplier.ts`: 17 lines
- No remaining direct `status.value =` / `errorMessage.value =` writes in `ContractFormPage.vue` outside the status applier path