### PR TITLE
refactor: apply config runtime busy events

### DIFF
--- a/frontend/apps/web/src/pages/contractForm/runtimeStateApplier.ts
+++ b/frontend/apps/web/src/pages/contractForm/runtimeStateApplier.ts
@@ -1,7 +1,8 @@
-import type { FormRuntimeStateEvent, FormRuntimeStatusRefs } from './runtimeStateProtocol';
+import type { FormRuntimeBusyRefs, FormRuntimeStateEvent, FormRuntimeStatusRefs } from './runtimeStateProtocol';
 import { INITIAL_FORM_RUNTIME_STATE, reduceFormRuntimeState } from './runtimeStateReducer';
 
 type FormRuntimeStatusEvent = Extract<FormRuntimeStateEvent, { kind: 'status' }>;
+type FormRuntimeBusyEvent = Extract<FormRuntimeStateEvent, { kind: 'begin' } | { kind: 'end' }>;
 
 export function applyFormRuntimeStatusEvent(
   refs: FormRuntimeStatusRefs,
@@ -14,4 +15,15 @@ export function applyFormRuntimeStatusEvent(
   }, event);
   refs.status.value = next.status;
   refs.errorMessage.value = next.errorMessage;
+}
+
+export function applyFormRuntimeBusyEvent(
+  refs: FormRuntimeBusyRefs,
+  event: FormRuntimeBusyEvent,
+) {
+  const next = reduceFormRuntimeState({
+    ...INITIAL_FORM_RUNTIME_STATE,
+    busyKind: refs.busyKind.value,
+  }, event);
+  refs.busyKind.value = next.busyKind;
 }

--- a/frontend/apps/web/src/pages/contractForm/useContractModeActionRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useContractModeActionRuntime.ts
@@ -6,7 +6,7 @@ import {
   contractPromptFieldsFromRule,
   contractPromptParamsFromRule,
 } from './actionContract';
-import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';
 import type { BusyKind, UiStatus } from './types';
 
 export function useContractModeActionRuntime(params: {
@@ -45,7 +45,11 @@ export function useContractModeActionRuntime(params: {
     }
     const actionParams = providedParams || contractPromptParamsFromRule(rule);
     if (actionParams === null) return;
-    params.busyKind.value = 'action';
+    applyFormRuntimeBusyEvent(params, {
+      kind: 'begin',
+      transaction: 'contractMode',
+      busyKind: 'action',
+    });
     try {
       await intentRequest({
         intent,
@@ -62,7 +66,10 @@ export function useContractModeActionRuntime(params: {
         errorMessage: err instanceof Error ? err.message : '表单配置操作失败',
       });
     } finally {
-      params.busyKind.value = null;
+      applyFormRuntimeBusyEvent(params, {
+        kind: 'end',
+        transaction: 'contractMode',
+      });
     }
   }
 

--- a/frontend/apps/web/src/pages/contractForm/useFormConfigSaveRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useFormConfigSaveRuntime.ts
@@ -11,7 +11,7 @@ import {
   lowCodeScopedContractName,
   normalizeLowCodeApplyParams,
 } from './formConfigHelpers';
-import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';
 import type { BusyKind, FormConfigAuditResult, LowCodeFieldSize, UiStatus } from './types';
 
 type LowCodeColumns = 1 | 2 | 3;
@@ -91,7 +91,11 @@ export function useFormConfigSaveRuntime(params: {
       params.contractModeFeedback.value = '';
       return true;
     }
-    params.busyKind.value = 'action';
+    applyFormRuntimeBusyEvent(params, {
+      kind: 'begin',
+      transaction: 'formConfig',
+      busyKind: 'action',
+    });
     try {
       if (hasFieldApplyParams) {
         await intentRequest({
@@ -162,7 +166,10 @@ export function useFormConfigSaveRuntime(params: {
       });
       return false;
     } finally {
-      params.busyKind.value = null;
+      applyFormRuntimeBusyEvent(params, {
+        kind: 'end',
+        transaction: 'formConfig',
+      });
     }
   }
 

--- a/frontend/apps/web/src/pages/contractForm/useInlineFieldPolicyRuntime.ts
+++ b/frontend/apps/web/src/pages/contractForm/useInlineFieldPolicyRuntime.ts
@@ -2,7 +2,7 @@ import type { Ref } from 'vue';
 import { intentRequest } from '../../api/intents';
 import { FORM_FIELD_CONFIG_INTENTS } from '../../app/businessConfigBoundaries';
 import { normalizeFieldGroupTitle } from './formConfigHelpers';
-import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';
+import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';
 import type { BusyKind, FormConfigOperationLogEntry, UiStatus } from './types';
 
 export function useInlineFieldPolicyRuntime(params: {
@@ -22,7 +22,11 @@ export function useInlineFieldPolicyRuntime(params: {
     if (!fieldKey || params.busy()) return;
     const label = String(policyParams.label || '').trim();
     const groupTitle = normalizeFieldGroupTitle(policyParams.group_title);
-    params.busyKind.value = 'action';
+    applyFormRuntimeBusyEvent(params, {
+      kind: 'begin',
+      transaction: 'inlinePolicy',
+      busyKind: 'action',
+    });
     try {
       await intentRequest({
         intent: FORM_FIELD_CONFIG_INTENTS.policySet,
@@ -50,7 +54,10 @@ export function useInlineFieldPolicyRuntime(params: {
         errorMessage: err instanceof Error ? err.message : '字段显示规则更新失败',
       });
     } finally {
-      params.busyKind.value = null;
+      applyFormRuntimeBusyEvent(params, {
+        kind: 'end',
+        transaction: 'inlinePolicy',
+      });
     }
   }
 

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -115,14 +115,19 @@ def main() -> int:
 
     required_applier_tokens = [
         "export function applyFormRuntimeStatusEvent",
+        "export function applyFormRuntimeBusyEvent",
         "type FormRuntimeStatusEvent = Extract<FormRuntimeStateEvent, { kind: 'status' }>",
+        "type FormRuntimeBusyEvent = Extract<FormRuntimeStateEvent, { kind: 'begin' } | { kind: 'end' }>",
         "FormRuntimeStatusRefs",
+        "FormRuntimeBusyRefs",
         "INITIAL_FORM_RUNTIME_STATE",
         "reduceFormRuntimeState",
         "status: refs.status.value",
         "errorMessage: refs.errorMessage.value",
+        "busyKind: refs.busyKind.value",
         "refs.status.value = next.status",
         "refs.errorMessage.value = next.errorMessage",
+        "refs.busyKind.value = next.busyKind",
     ]
     for token in required_applier_tokens:
         if token not in applier:
@@ -140,14 +145,13 @@ def main() -> int:
         "writeContractFormRecord",
         "queryRelationOptions",
         "reload(",
-        "busyKind.value",
         "submissionFeedback.value",
         "validationErrors.value",
         "showOne2manyErrors.value",
     ]
     for token in forbidden_applier_tokens:
         if token in applier:
-            errors.append(f"runtimeStateApplier.ts must stay status-only; forbidden token: {token}")
+            errors.append(f"runtimeStateApplier.ts must stay event-only; forbidden token: {token}")
 
     required_type_exports = [
         "FormRuntimeBusyKind as BusyKind",

--- a/scripts/verify/contract_form_runtime_state_protocol_guard.py
+++ b/scripts/verify/contract_form_runtime_state_protocol_guard.py
@@ -182,11 +182,11 @@ def main() -> int:
         (action_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "useFormActionRuntime.ts"),
         (primary_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "usePrimaryFormActionRuntime.ts"),
         (primary_runtime, "import type { BusyKind, ContractAction, SubmissionFeedback, UiStatus } from './types';", "usePrimaryFormActionRuntime.ts"),
-        (form_config_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormConfigSaveRuntime.ts"),
+        (form_config_runtime, "import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useFormConfigSaveRuntime.ts"),
         (form_config_runtime, "UiStatus", "useFormConfigSaveRuntime.ts"),
-        (inline_policy_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useInlineFieldPolicyRuntime.ts"),
+        (inline_policy_runtime, "import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useInlineFieldPolicyRuntime.ts"),
         (inline_policy_runtime, "UiStatus", "useInlineFieldPolicyRuntime.ts"),
-        (contract_mode_runtime, "import { applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useContractModeActionRuntime.ts"),
+        (contract_mode_runtime, "import { applyFormRuntimeBusyEvent, applyFormRuntimeStatusEvent } from './runtimeStateApplier';", "useContractModeActionRuntime.ts"),
         (contract_mode_runtime, "UiStatus", "useContractModeActionRuntime.ts"),
     ]
     for source, token, label in required_consumers:
@@ -249,6 +249,31 @@ def main() -> int:
     for source, label, token in stale_config_writes:
         if token in source:
             errors.append(f"{label} still bypasses status applier: {token}")
+
+    config_busy_event_requirements = [
+        (form_config_runtime, "useFormConfigSaveRuntime.ts", "transaction: 'formConfig'"),
+        (inline_policy_runtime, "useInlineFieldPolicyRuntime.ts", "transaction: 'inlinePolicy'"),
+        (contract_mode_runtime, "useContractModeActionRuntime.ts", "transaction: 'contractMode'"),
+    ]
+    for source, label, transaction_token in config_busy_event_requirements:
+        for token in [
+            "applyFormRuntimeBusyEvent(params, {",
+            "kind: 'begin'",
+            "busyKind: 'action'",
+            "kind: 'end'",
+            transaction_token,
+        ]:
+            if token not in source:
+                errors.append(f"{label} missing config busy applier token: {token}")
+
+    stale_config_busy_writes = [
+        (form_config_runtime, "useFormConfigSaveRuntime.ts"),
+        (inline_policy_runtime, "useInlineFieldPolicyRuntime.ts"),
+        (contract_mode_runtime, "useContractModeActionRuntime.ts"),
+    ]
+    for source, label in stale_config_busy_writes:
+        if "params.busyKind.value =" in source:
+            errors.append(f"{label} still bypasses busy applier")
 
     required_page_status_tokens = [
         "transaction: 'formReload'",


### PR DESCRIPTION
## Summary

- add `applyFormRuntimeBusyEvent` for `begin` / `end` runtime events
- route config-side `busyKind` writes through the busy event applier in `formConfig`, `inlinePolicy`, and `contractMode` runtimes
- keep API calls, reload order, feedback, status handling, and transaction bodies unchanged
- extend the runtime state protocol guard so config-side busy writes keep using the applier

## Commit Shape

This branch intentionally accumulates small commits before one PR:

- `refactor: add contract form busy event applier`
- `refactor: apply form config busy events`
- `refactor: apply config policy busy events`
- `test: guard config busy event consumers`

## Scope

This only covers config-side busy begin/end events. It does not migrate `saveRecord`, `runAction`, `runOnchangeRoundtrip`, or page-level busy writes.

## Verification

- `python3 scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `python3 -m py_compile scripts/verify/contract_form_runtime_state_protocol_guard.py`
- `scripts/dev/pnpm_exec.sh -C frontend/apps/web typecheck:strict`
- `git diff --check`
- `make ci.local.quick`
- `make ci`

## Evidence

- `ContractFormPage.vue`: 5939 lines
- `runtimeStateApplier.ts`: 31 lines
- no direct `params.busyKind.value =` writes remain in the three config-side runtimes