### PR TITLE
fix(core): unify payment amount semantics

### DIFF
--- a/addons/smart_construction_core/models/core/payment_request.py
+++ b/addons/smart_construction_core/models/core/payment_request.py
@@ -1451,7 +1451,7 @@ class PaymentRequest(models.Model):
             )
         )
 
-    @api.constrains("settlement_id", "type", "project_id", "partner_id", "contract_id")
+    @api.constrains("settlement_id", "type", "project_id", "partner_id", "contract_id", "currency_id")
     def _check_settlement_consistency(self):
         for rec in self:
             settle = rec.settlement_id
@@ -1468,6 +1468,7 @@ class PaymentRequest(models.Model):
                 raise ValidationError(_("结算单往来单位必须与付款申请一致。"))
             if settle.contract_id and rec.contract_id and settle.contract_id != rec.contract_id:
                 raise ValidationError(_("结算单合同必须与付款申请一致。"))
+            opm.ensure_payment_settlement_currency_consistency(rec, settle)
             # 已进入流程的记录在字段更改时仍要守住额度
             if rec.state in ("submit", "approve", "approved", "done"):
                 rec._check_settlement_remaining_amount()
@@ -1551,17 +1552,11 @@ class PaymentRequest(models.Model):
                 )
             if not settlement_amounts:
                 continue
-            paid_states = opm.get_paid_states()
-            paid_map = opm.settlement_paid_map(rec.env, settlement_amounts.keys(), paid_states=paid_states)
-            precision = rec.currency_id.rounding if rec.currency_id else 0.01
-            if precision <= 0:
-                precision = 0.01
             for settlement in rec.env["sc.settlement.order"].browse(settlement_amounts.keys()):
                 amount = settlement_amounts.get(settlement.id, 0.0)
-                paid = paid_map.get(settlement.id, 0.0)
-                if rec.state in paid_states:
-                    paid -= amount
-                payable = (settlement.amount_total or 0.0) - paid
+                metrics = opm.compute_settlement_reservable_excluding_request(rec, settlement, amount)
+                payable = metrics["payable"]
+                precision = metrics["precision"]
                 if float_compare(amount, payable, precision_rounding=precision) == 1:
                     raise_guard(
                         "P0_PAYMENT_OVER_BALANCE",
@@ -1641,18 +1636,12 @@ class PaymentRequest(models.Model):
                 if not settlement_amounts:
                     rec.is_overpay_risk = False
                     continue
-                paid_states = opm.get_paid_states()
-                paid_map = opm.settlement_paid_map(rec.env, settlement_amounts.keys(), paid_states=paid_states)
-                precision = rec.currency_id.rounding if rec.currency_id else 0.01
-                if precision <= 0:
-                    precision = 0.01
                 risk = False
                 for settlement in rec.env["sc.settlement.order"].browse(settlement_amounts.keys()):
                     amount = settlement_amounts.get(settlement.id, 0.0)
-                    paid = paid_map.get(settlement.id, 0.0)
-                    if rec.state in paid_states:
-                        paid -= amount
-                    payable = (settlement.amount_total or 0.0) - paid
+                    metrics = opm.compute_settlement_reservable_excluding_request(rec, settlement, amount)
+                    payable = metrics["payable"]
+                    precision = metrics["precision"]
                     if float_compare(amount, payable, precision_rounding=precision) == 1:
                         risk = True
                         break

--- a/addons/smart_construction_core/models/core/payment_request.py
+++ b/addons/smart_construction_core/models/core/payment_request.py
@@ -1639,7 +1639,11 @@ class PaymentRequest(models.Model):
                 risk = False
                 for settlement in rec.env["sc.settlement.order"].browse(settlement_amounts.keys()):
                     amount = settlement_amounts.get(settlement.id, 0.0)
-                    metrics = opm.compute_settlement_reservable_excluding_request(rec, settlement, amount)
+                    try:
+                        metrics = opm.compute_settlement_reservable_excluding_request(rec, settlement, amount)
+                    except ValidationError:
+                        risk = True
+                        break
                     payable = metrics["payable"]
                     precision = metrics["precision"]
                     if float_compare(amount, payable, precision_rounding=precision) == 1:
@@ -1647,7 +1651,11 @@ class PaymentRequest(models.Model):
                         break
                 rec.is_overpay_risk = risk
                 continue
-            metrics = opm.compute_payment_payable_excluding_self(rec)
+            try:
+                metrics = opm.compute_payment_payable_excluding_self(rec)
+            except ValidationError:
+                rec.is_overpay_risk = True
+                continue
             payable = metrics["payable"]
             precision = metrics["precision"]
             rec.is_overpay_risk = float_compare(rec.amount or 0.0, payable, precision_rounding=precision) == 1

--- a/addons/smart_construction_core/models/core/settlement_order.py
+++ b/addons/smart_construction_core/models/core/settlement_order.py
@@ -266,17 +266,17 @@ class ScSettlementOrder(models.Model):
         "payment_request_line_ids.current_pay_amount",
         "payment_request_line_ids.request_id.state",
         "payment_request_line_ids.request_id.settlement_id",
+        "amount_after_adjustment",
     )
     def _compute_paid_amounts(self):
-        """Phase7-1: 结算单的已付/可付口径，统一由 operating_metrics 提供。"""
-        paid_map = opm.settlement_paid_map(self.env, self.ids)
+        """Compatibility paid fields expose reservation, not ledger actual paid."""
+        reserved_map = opm.settlement_reserved_amount_map(self.env, self.ids)
         for order in self:
-            total = order.amount_total or 0.0
-            paid = paid_map.get(order.id, 0.0)
-            remaining = total - paid
-            order.paid_amount = paid
+            reserved = reserved_map.get(order.id, 0.0)
+            remaining = opm.settlement_remaining_reservable_amount(order, reserved)
+            order.paid_amount = reserved
             order.remaining_amount = remaining
-            order.amount_paid = paid
+            order.amount_paid = reserved
             order.amount_payable = remaining
             order.unpaid_amount = remaining
 

--- a/addons/smart_construction_core/models/support/contract_center.py
+++ b/addons/smart_construction_core/models/support/contract_center.py
@@ -5,6 +5,7 @@ from odoo import _, api, fields, models
 from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tools import config
 
+from . import operating_metrics as opm
 from .state_machine import ScStateMachine
 
 
@@ -782,11 +783,7 @@ class ConstructionContract(models.Model):
             "amount",
             included_states=("received", "legacy_confirmed"),
         )
-        payment_map = self._sum_amount_by_contract(
-            "sc.payment.execution",
-            "paid_amount",
-            excluded_states=("cancel", "cancelled"),
-        )
+        payment_map = opm.contract_actual_paid_amount_map(self.env, self.ids)
         for contract in self:
             total = contract.amount_final or 0.0
             invoice_amount = invoice_map.get(contract.id, 0.0)

--- a/addons/smart_construction_core/models/support/operating_metrics.py
+++ b/addons/smart_construction_core/models/support/operating_metrics.py
@@ -1,16 +1,33 @@
 # -*- coding: utf-8 -*-
 from typing import Dict, Iterable, Optional, Sequence
 
-PAID_STATES: Sequence[str] = ("submit", "approve", "approved", "done")
+from odoo import _
+from odoo.exceptions import ValidationError
+
+
+RESERVED_STATES: Sequence[str] = ("submit", "approve", "approved", "done")
+# Compatibility aliases: existing callers and public fields historically call
+# the reservation amount "paid". New code must use the explicit reserved name.
+PAID_STATES: Sequence[str] = RESERVED_STATES
+PAYMENT_EXECUTION_ACTUAL_PAID_STATES: Sequence[str] = ("paid",)
+
+
+def get_reserved_states() -> Sequence[str]:
+    """Payment-request states that reserve settlement capacity."""
+    return RESERVED_STATES
 
 
 def get_paid_states() -> Sequence[str]:
-    """唯一“已付”状态口径。"""
-    return PAID_STATES
+    """Compatibility alias for the historical reservation-state API."""
+    return get_reserved_states()
 
 
-def settlement_paid_map(env, settlement_ids: Iterable[int], paid_states: Optional[Sequence[str]] = None) -> Dict[int, float]:
-    """按结算单聚合付款金额。
+def settlement_reserved_amount_map(
+    env,
+    settlement_ids: Iterable[int],
+    reserved_states: Optional[Sequence[str]] = None,
+) -> Dict[int, float]:
+    """Aggregate valid payment-request reservations by settlement.
 
     主表关联按付款申请金额统计；历史多结算单付款申请没有主表结算单，
     需按明细上的本次申请金额分摊到各结算单。
@@ -18,7 +35,7 @@ def settlement_paid_map(env, settlement_ids: Iterable[int], paid_states: Optiona
     ids = list(settlement_ids)
     if not ids:
         return {}
-    states = tuple(paid_states or PAID_STATES)
+    states = tuple(reserved_states or RESERVED_STATES)
     Payment = env["payment.request"].sudo()
     rows = Payment.read_group(
         [
@@ -57,22 +74,148 @@ def settlement_paid_map(env, settlement_ids: Iterable[int], paid_states: Optiona
     return res
 
 
-def settlement_paid_payable_map(env, settlement_ids: Iterable[int], amount_total_map: Optional[Dict[int, float]] = None, paid_states: Optional[Sequence[str]] = None) -> Dict[int, Dict[str, float]]:
-    """返回 {settlement_id: {'paid': x, 'payable': y}}。"""
+def settlement_paid_map(
+    env,
+    settlement_ids: Iterable[int],
+    paid_states: Optional[Sequence[str]] = None,
+) -> Dict[int, float]:
+    """Compatibility alias: historical "paid" fields represent reservation."""
+    return settlement_reserved_amount_map(env, settlement_ids, reserved_states=paid_states)
+
+
+def _currency_rounding(currency) -> float:
+    precision = currency.rounding if currency else 0.01
+    return precision if precision and precision > 0 else 0.01
+
+
+def _currency_round(currency, amount: float) -> float:
+    return currency.round(amount) if currency else amount
+
+
+def ensure_payment_settlement_currency_consistency(payment_rec, settlement) -> None:
+    """Reject capacity checks when no explicit same-currency fact exists."""
+    if not settlement:
+        return
+    settlement_currency = settlement.currency_id
+    payment_currency = payment_rec.currency_id
+    if not settlement_currency or not payment_currency or payment_currency != settlement_currency:
+        raise ValidationError(_("付款申请币种必须与结算单币种一致；当前流程不提供自动汇率换算。"))
+
+    contracts = payment_rec.contract_id | settlement.contract_id
+    mismatched = contracts.filtered(lambda contract: contract.currency_id != settlement_currency)
+    if mismatched:
+        raise ValidationError(_("合同币种必须与结算单币种一致；当前流程不提供自动汇率换算。"))
+
+    if payment_rec.company_id and settlement.company_id and payment_rec.company_id != settlement.company_id:
+        raise ValidationError(_("付款申请公司必须与结算单公司一致。"))
+
+
+def settlement_payable_base(settlement) -> float:
+    """Confirmed-adjustment payment ceiling, rounded in settlement currency."""
+    amount = (
+        settlement.amount_after_adjustment
+        if "amount_after_adjustment" in settlement._fields
+        else settlement.amount_total
+    )
+    return max(_currency_round(settlement.currency_id, amount or 0.0), 0.0)
+
+
+def settlement_remaining_reservable_amount(settlement, reserved_amount: Optional[float] = None) -> float:
+    """Remaining request capacity, never negative, in settlement currency."""
+    if reserved_amount is None:
+        reserved_amount = settlement_reserved_amount_map(settlement.env, settlement.ids).get(settlement.id, 0.0)
+    remaining = settlement_payable_base(settlement) - (reserved_amount or 0.0)
+    return max(_currency_round(settlement.currency_id, remaining), 0.0)
+
+
+def compute_settlement_reservable_excluding_request(payment_rec, settlement, current_amount: float):
+    """Return reservation metrics while excluding the request being edited."""
+    ensure_payment_settlement_currency_consistency(payment_rec, settlement)
+    reserved_states = get_reserved_states()
+    reserved = settlement_reserved_amount_map(
+        payment_rec.env,
+        [settlement.id],
+        reserved_states=reserved_states,
+    ).get(settlement.id, 0.0)
+    if payment_rec.state in reserved_states:
+        reserved -= current_amount or 0.0
+    reserved = max(_currency_round(settlement.currency_id, reserved), 0.0)
+    return {
+        "reserved": reserved,
+        "payable_base": settlement_payable_base(settlement),
+        "payable": settlement_remaining_reservable_amount(settlement, reserved),
+        "precision": _currency_rounding(settlement.currency_id),
+    }
+
+
+def settlement_actual_paid_amount_map(env, settlement_ids: Iterable[int]) -> Dict[int, float]:
+    """Aggregate actual paid amounts using payment.ledger as the only fact."""
     ids = list(settlement_ids)
     if not ids:
         return {}
-    paid_map = settlement_paid_map(env, ids, paid_states=paid_states)
+    ledgers = env["payment.ledger"].sudo().search(
+        [
+            "|",
+            ("payment_request_id.settlement_id", "in", ids),
+            ("payment_request_id.outflow_line_ids.settlement_id", "in", ids),
+        ]
+    )
+    result: Dict[int, float] = {}
+    for ledger in ledgers:
+        request = ledger.payment_request_id
+        if request.settlement_id and request.settlement_id.id in ids:
+            ensure_payment_settlement_currency_consistency(request, request.settlement_id)
+            sid = request.settlement_id.id
+            result[sid] = result.get(sid, 0.0) + (ledger.amount or 0.0)
+            continue
+        lines = request.outflow_line_ids.filtered(lambda line: line.settlement_id and line.settlement_id.id in ids)
+        allocation_total = sum(request.outflow_line_ids.mapped("current_pay_amount"))
+        if not allocation_total:
+            continue
+        for line in lines:
+            ensure_payment_settlement_currency_consistency(request, line.settlement_id)
+            sid = line.settlement_id.id
+            allocated = (ledger.amount or 0.0) * (line.current_pay_amount or 0.0) / allocation_total
+            result[sid] = result.get(sid, 0.0) + allocated
+    return result
+
+
+def contract_actual_paid_amount_map(env, contract_ids: Iterable[int]) -> Dict[int, float]:
+    """Aggregate only executions whose state is proven to mean payment done."""
+    ids = list(contract_ids)
+    if not ids:
+        return {}
+    rows = env["sc.payment.execution"].sudo().read_group(
+        [
+            ("contract_id", "in", ids),
+            ("state", "in", list(PAYMENT_EXECUTION_ACTUAL_PAID_STATES)),
+        ],
+        ["paid_amount:sum"],
+        ["contract_id"],
+    )
+    return {
+        row["contract_id"][0]: row.get("paid_amount_sum", row.get("paid_amount", 0.0)) or 0.0
+        for row in rows
+        if row.get("contract_id")
+    }
+
+
+def settlement_paid_payable_map(env, settlement_ids: Iterable[int], amount_total_map: Optional[Dict[int, float]] = None, paid_states: Optional[Sequence[str]] = None) -> Dict[int, Dict[str, float]]:
+    """Compatibility response: ``paid`` is reserved payment-request amount."""
+    ids = list(settlement_ids)
+    if not ids:
+        return {}
+    paid_map = settlement_reserved_amount_map(env, ids, reserved_states=paid_states)
     amount_total_map = amount_total_map or {}
     if not amount_total_map:
         totals = env["sc.settlement.order"].sudo().browse(ids)
-        amount_total_map = {rec.id: rec.amount_total for rec in totals}
+        amount_total_map = {rec.id: settlement_payable_base(rec) for rec in totals}
 
     res: Dict[int, Dict[str, float]] = {}
     for sid in ids:
         paid = paid_map.get(sid, 0.0)
         total = amount_total_map.get(sid, 0.0) or 0.0
-        res[sid] = {"paid": paid, "payable": total - paid}
+        res[sid] = {"paid": paid, "payable": max(total - paid, 0.0)}
     return res
 
 
@@ -83,17 +226,12 @@ def compute_payment_payable_excluding_self(payment_rec):
     """
     settle = payment_rec.settlement_id.sudo()
     if not settle:
-        return {"paid": 0.0, "payable": 0.0, "precision": (payment_rec.company_id.currency_id.rounding or 0.01)}
+        return {"paid": 0.0, "reserved": 0.0, "payable": 0.0, "precision": 0.01}
 
-    paid_states = get_paid_states()
-    paid_map = settlement_paid_map(payment_rec.env, [settle.id], paid_states=paid_states)
-    paid = paid_map.get(settle.id, 0.0)
-    # 排除当前记录自身
-    if payment_rec.state in paid_states:
-        paid -= payment_rec.amount or 0.0
-    payable = (settle.amount_total or 0.0) - paid
-    currency = payment_rec.company_id.currency_id
-    precision = currency.rounding or 0.01
-    if precision <= 0:
-        precision = 0.01
-    return {"paid": paid, "payable": payable, "precision": precision}
+    metrics = compute_settlement_reservable_excluding_request(
+        payment_rec,
+        settle,
+        payment_rec.amount or 0.0,
+    )
+    metrics["paid"] = metrics["reserved"]
+    return metrics

--- a/addons/smart_construction_core/tests/test_p0_ledger_gate.py
+++ b/addons/smart_construction_core/tests/test_p0_ledger_gate.py
@@ -558,6 +558,14 @@ class TestCorePaymentAmountSemantics(TransactionCase):
         )
         with self.assertRaises(ValidationError):
             self._request("T1-B Request Currency Mismatch", 1.0, currency=foreign)
+        legacy_mismatch = self._request("T1-B Legacy Currency Mismatch", 1.0)
+        legacy_mismatch.flush_recordset(["currency_id"])
+        self.env.cr.execute(
+            "UPDATE payment_request SET currency_id=%s WHERE id=%s",
+            (foreign.id, legacy_mismatch.id),
+        )
+        self.env.invalidate_all()
+        self.assertTrue(legacy_mismatch.is_overpay_risk)
         foreign_contract = self._contract(
             "T1-B Foreign Contract", self.project, self.partner, self.company, foreign
         )

--- a/addons/smart_construction_core/tests/test_p0_ledger_gate.py
+++ b/addons/smart_construction_core/tests/test_p0_ledger_gate.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
-from odoo.exceptions import AccessError, UserError
+from odoo.exceptions import AccessError, UserError, ValidationError
 from odoo.tests.common import TransactionCase, tagged
+
+from ..models.support import operating_metrics as opm
 
 
 @tagged("post_install", "-at_install", "sc_gate")
@@ -313,3 +315,284 @@ class TestP0LedgerGate(TransactionCase):
         }
         self.assertTrue(group_ids.issubset(set(action.groups_id.ids)))
         self.assertTrue(group_ids.issubset(set(menu.groups_id.ids)))
+
+
+@tagged("post_install", "-at_install", "sc_gate", "core_payment_amount_semantics")
+class TestCorePaymentAmountSemantics(TransactionCase):
+    """T1-B matrix: reservation, ledger actual paid, and contract actual paid."""
+
+    def setUp(self):
+        super().setUp()
+        self.company = self.env.ref("base.main_company")
+        self.currency = self.company.currency_id
+        self.partner = self.env["res.partner"].create({"name": "T1-B Vendor"})
+        self.project = self._project("T1-B Project", self.company)
+        self.contract = self._contract(
+            "T1-B Contract", self.project, self.partner, self.company, self.currency
+        )
+        self.settlement = self._settlement(
+            "T1-B Settlement", self.project, self.partner, self.contract, self.company, self.currency
+        )
+
+    def _model(self, name, company=None):
+        company = company or self.company
+        company_ids = list(set(self.env.companies.ids + [self.company.id, company.id]))
+        return self.env[name].sudo().with_context(allowed_company_ids=company_ids).with_company(company)
+
+    def _project(self, name, company):
+        return self._model("project.project", company).create(
+            {"name": name, "company_id": company.id, "privacy_visibility": "followers"}
+        )
+
+    def _tax(self, name, company):
+        group = self._model("account.tax.group", company).search(
+            [("company_id", "=", company.id)], limit=1
+        )
+        if not group:
+            group = self._model("account.tax.group", company).create(
+                {"name": f"{company.name} Tax Group", "company_id": company.id}
+            )
+        return self._model("account.tax", company).create(
+            {
+                "name": name,
+                "amount": 0.0,
+                "amount_type": "percent",
+                "type_tax_use": "purchase",
+                "company_id": company.id,
+                "tax_group_id": group.id,
+                "country_id": (company.country_id or self.env.ref("base.cn")).id,
+            }
+        )
+
+    def _contract(self, name, project, partner, company, currency):
+        return self._model("construction.contract", company).create(
+            {
+                "subject": name,
+                "type": "in",
+                "project_id": project.id,
+                "partner_id": partner.id,
+                "company_id": company.id,
+                "currency_id": currency.id,
+                "tax_id": self._tax(f"{name} Tax", company).id,
+            }
+        )
+
+    def _settlement(self, name, project, partner, contract, company, currency, amount=100.0):
+        return self._model("sc.settlement.order", company).create(
+            {
+                "name": name,
+                "project_id": project.id,
+                "partner_id": partner.id,
+                "contract_id": contract.id,
+                "company_id": company.id,
+                "currency_id": currency.id,
+                "settlement_type": "out",
+                "state": "approve",
+                "line_ids": [(0, 0, {"name": name, "qty": 1.0, "price_unit": amount})],
+            }
+        )
+
+    def _request(
+        self, name, amount, state="draft", settlement=None, project=None, contract=None, currency=None
+    ):
+        settlement = settlement or self.settlement
+        project = project or settlement.project_id
+        contract = contract if contract is not None else settlement.contract_id
+        currency = currency or settlement.currency_id
+        return self._model("payment.request", project.company_id).with_context(
+            payment_soft_gate=True
+        ).create(
+            {
+                "name": name,
+                "type": "pay",
+                "project_id": project.id,
+                "partner_id": settlement.partner_id.id,
+                "contract_id": contract.id if contract else False,
+                "settlement_id": settlement.id,
+                "currency_id": currency.id,
+                "amount": amount,
+                "state": state,
+            }
+        )
+
+    def _contract_paid(self):
+        self.contract.invalidate_recordset(["paid_amount"])
+        return self.contract.paid_amount
+
+    def test_settlement_adjusted_reservation_matrix(self):
+        # 1. 100, no adjustment/request => 100 reservable.
+        self.assertEqual(opm.settlement_remaining_reservable_amount(self.settlement), 100.0)
+        adjustment = self._model("sc.settlement.adjustment").create(
+            {
+                "settlement_id": self.settlement.id,
+                "adjustment_type": "deduction",
+                "item_name": "T1-B Deduction",
+                "amount": 10.0,
+                "state": "confirmed",
+            }
+        )
+        self.settlement.invalidate_recordset()
+        # 2. Confirmed deduction immediately reduces capacity to 90.
+        self.assertEqual(self.settlement.amount_payable, 90.0)
+        adjustment.action_cancel()
+        self.settlement.invalidate_recordset()
+        # 3. Cancelling the deduction restores 100.
+        self.assertEqual(self.settlement.amount_payable, 100.0)
+        self._model("sc.settlement.adjustment").create(
+            {
+                "settlement_id": self.settlement.id,
+                "adjustment_type": "deduction",
+                "item_name": "T1-B Active Deduction",
+                "amount": 10.0,
+                "state": "confirmed",
+            }
+        )
+        request_80 = self._request("T1-B PR 80", 80.0, "submit")
+        self.settlement.invalidate_recordset()
+        # 4. Submitted 80 leaves 10 after the confirmed deduction.
+        self.assertEqual((self.settlement.paid_amount, self.settlement.amount_payable), (80.0, 10.0))
+        request_80.with_context(allow_transition=True, payment_soft_gate=True).write({"state": "cancel"})
+        self.settlement.invalidate_recordset()
+        # 5. Cancelling the request releases capacity back to 90.
+        self.assertEqual((self.settlement.paid_amount, self.settlement.amount_payable), (0.0, 90.0))
+        active = self._request("T1-B PR 80 Active", 80.0, "submit")
+        # 6. Editing excludes the active request itself.
+        active._check_settlement_remaining_amount()
+        # 7. A further 11 is rejected; 8. a further 10 is allowed.
+        with self.assertRaises(UserError):
+            self._request("T1-B PR 11", 11.0)._check_settlement_remaining_amount()
+        self._request("T1-B PR 10", 10.0)._check_settlement_remaining_amount()
+
+    def test_actual_paid_is_ledger_only_and_reverses(self):
+        request = self._request("T1-B Actual PR", 80.0, "submit")
+        # 9. Submitted request without ledger is not actual paid.
+        self.assertEqual(opm.settlement_actual_paid_amount_map(self.env, [self.settlement.id]), {})
+        request.flush_recordset(["state"])
+        self.env.cr.execute("UPDATE payment_request SET state='approved' WHERE id=%s", (request.id,))
+        request.invalidate_recordset(["state"])
+        ledger = request._ensure_payment_ledger(amount=80.0)
+        # 10. payment.ledger is the sole actual-paid fact.
+        self.assertEqual(
+            opm.settlement_actual_paid_amount_map(self.env, [self.settlement.id])[self.settlement.id],
+            80.0,
+        )
+        execution = self._model("sc.payment.execution").create(
+            {
+                "name": "T1-B Paid Execution",
+                "project_id": self.project.id,
+                "partner_id": self.partner.id,
+                "contract_id": self.contract.id,
+                "payment_request_id": request.id,
+                "currency_id": self.currency.id,
+                "paid_amount": 80.0,
+                "planned_amount": 80.0,
+                "state": "paid",
+            }
+        )
+        execution._reverse_paid_execution()
+        request.invalidate_recordset()
+        # 11. Reversal deletes ledger and actual paid returns to zero.
+        self.assertFalse(ledger.exists())
+        self.assertEqual(opm.settlement_actual_paid_amount_map(self.env, [self.settlement.id]), {})
+
+    def test_contract_actual_paid_state_matrix(self):
+        Execution = self._model("sc.payment.execution")
+        common = {
+            "project_id": self.project.id,
+            "partner_id": self.partner.id,
+            "contract_id": self.contract.id,
+            "currency_id": self.currency.id,
+        }
+        Execution.create({**common, "name": "T1-B Draft", "paid_amount": 10.0, "state": "draft"})
+        # 12. Draft and 13. confirmed are excluded.
+        self.assertEqual(self._contract_paid(), 0.0)
+        Execution.create({**common, "name": "T1-B Confirmed", "paid_amount": 20.0, "state": "confirmed"})
+        self.assertEqual(self._contract_paid(), 0.0)
+        paid = Execution.create({**common, "name": "T1-B Paid", "paid_amount": 30.0, "state": "paid"})
+        # 14. Paid increases contract actual paid.
+        self.assertEqual(self._contract_paid(), 30.0)
+        paid.write({"state": "cancel"})
+        self.assertEqual(self._contract_paid(), 0.0)
+        paid.write({"state": "paid"})
+        paid.flush_recordset(["state"])
+        self.env.cr.execute("UPDATE sc_payment_execution SET state='cancelled' WHERE id=%s", (paid.id,))
+        self.env.invalidate_all()
+        # 15. cancel/cancelled are excluded.
+        self.assertEqual(self._contract_paid(), 0.0)
+        for number, amount in enumerate((10.0, 20.0, 30.0), 1):
+            Execution.create({**common, "name": f"T1-B Paid {number}", "paid_amount": amount, "state": "paid"})
+        # 16. Three paid executions accumulate.
+        self.assertEqual(self._contract_paid(), 60.0)
+
+    def test_project_company_and_currency_isolation(self):
+        partner = self.env["res.partner"].create({"name": "T1-B Other Vendor"})
+        project = self._project("T1-B Other Project", self.company)
+        contract = self._contract("T1-B Other Contract", project, partner, self.company, self.currency)
+        settlement = self._settlement(
+            "T1-B Other Settlement", project, partner, contract, self.company, self.currency
+        )
+        self._request("T1-B Main Reserved", 30.0, "submit")
+        self._request("T1-B Other Reserved", 40.0, "submit", settlement, project, contract)
+        reserved = opm.settlement_reserved_amount_map(self.env, [self.settlement.id, settlement.id])
+        # 17. Projects do not mix reservations.
+        self.assertEqual((reserved[self.settlement.id], reserved[settlement.id]), (30.0, 40.0))
+        company = self.env["res.company"].create(
+            {
+                "name": "T1-B Company 2",
+                "currency_id": self.currency.id,
+                "country_id": self.env.ref("base.cn").id,
+            }
+        )
+        project_2 = self._project("T1-B Company 2 Project", company)
+        partner_2 = self.env["res.partner"].create({"name": "T1-B Company 2 Vendor"})
+        contract_2 = self._contract("T1-B Company 2 Contract", project_2, partner_2, company, self.currency)
+        settlement_2 = self._settlement(
+            "T1-B Company 2 Settlement", project_2, partner_2, contract_2, company, self.currency
+        )
+        self._request("T1-B Company 2 Reserved", 50.0, "submit", settlement_2, project_2, contract_2)
+        reserved = opm.settlement_reserved_amount_map(self.env, [self.settlement.id, settlement_2.id])
+        # 18. Companies do not mix reservations.
+        self.assertEqual((reserved[self.settlement.id], reserved[settlement_2.id]), (30.0, 50.0))
+        foreign = self.env["res.currency"].create(
+            {"name": "XTB", "symbol": "XTB", "rounding": 0.01, "active": True}
+        )
+        with self.assertRaises(ValidationError):
+            self._request("T1-B Request Currency Mismatch", 1.0, currency=foreign)
+        foreign_contract = self._contract(
+            "T1-B Foreign Contract", self.project, self.partner, self.company, foreign
+        )
+        foreign_settlement = self._settlement(
+            "T1-B Foreign Contract Settlement",
+            self.project,
+            self.partner,
+            foreign_contract,
+            self.company,
+            self.currency,
+        )
+        with self.assertRaises(ValidationError):
+            self._request("T1-B Contract Currency Mismatch", 1.0, settlement=foreign_settlement)
+        # 19. Missing conversion facts cause explicit rejection.
+
+    def test_settlement_currency_rounding_boundaries(self):
+        currency = self.env["res.currency"].create(
+            {"name": "XTR", "symbol": "XTR", "rounding": 0.05, "active": True}
+        )
+        contract = self._contract("T1-B Rounding Contract", self.project, self.partner, self.company, currency)
+        settlement = self._settlement(
+            "T1-B Rounding Settlement", self.project, self.partner, contract, self.company, currency
+        )
+        self._request("T1-B Rounding Reserved", 80.0, "submit", settlement, contract=contract, currency=currency)
+        below = self._request("T1-B Below Half", 20.024, settlement=settlement, contract=contract, currency=currency)
+        above = self._request("T1-B Above Half", 20.026, settlement=settlement, contract=contract, currency=currency)
+        # 20. Settlement currency half-unit boundary; 21. equality allowed.
+        below._check_settlement_remaining_amount()
+        with self.assertRaises(UserError):
+            above._check_settlement_remaining_amount()
+        self._request("T1-B Equal", 20.0, settlement=settlement, contract=contract, currency=currency)._check_settlement_remaining_amount()
+        # 22. One minimum unit over is rejected.
+        with self.assertRaises(UserError):
+            self._request(
+                "T1-B One Unit Over", 20.05, settlement=settlement, contract=contract, currency=currency
+            )._check_settlement_remaining_amount()
+        # 23. Less than rounding tolerance is not a false overpay.
+        self.assertFalse(below.is_overpay_risk)

--- a/addons/smart_construction_core/tools/validator/rule_payment_not_overpay.py
+++ b/addons/smart_construction_core/tools/validator/rule_payment_not_overpay.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import _
+from odoo.exceptions import ValidationError
 from odoo.tools.float_utils import float_compare
 
 from .rules import BaseRule, register, SEVERITY_ERROR
@@ -27,11 +28,8 @@ class PaymentNotOverpayRule(BaseRule):
         issues = []
         checked = 0
 
-        paid_states = opm.get_paid_states()
         records = Payment.search(domain)
         records = records.filtered(lambda rec: rec.settlement_id or rec.outflow_line_ids.filtered("settlement_id"))
-        settlement_ids = records.mapped("settlement_id").ids + records.mapped("outflow_line_ids.settlement_id").ids
-        paid_map = opm.settlement_paid_map(env, settlement_ids, paid_states=paid_states)
 
         for pr in records:
             checked += 1
@@ -39,15 +37,22 @@ class PaymentNotOverpayRule(BaseRule):
             if not settle:
                 for line in pr.outflow_line_ids.filtered("settlement_id"):
                     settle = line.settlement_id
-                    currency = pr.company_id.currency_id
-                    precision = currency.rounding or 0.01
-                    if precision <= 0:
-                        precision = 0.01
-                    paid = paid_map.get(settle.id, 0.0)
-                    if pr.state in paid_states:
-                        paid -= line.current_pay_amount or 0.0
-                    payable = (settle.amount_total or 0.0) - paid
                     amount = line.current_pay_amount or 0.0
+                    try:
+                        metrics = opm.compute_settlement_reservable_excluding_request(pr, settle, amount)
+                    except ValidationError as exc:
+                        issues.append(
+                            {
+                                "model": "payment.request",
+                                "res_id": pr.id,
+                                "message": str(exc),
+                                "refs": {"name": pr.display_name, "line_id": line.id},
+                                "suggestions": [],
+                            }
+                        )
+                        continue
+                    payable = metrics["payable"]
+                    precision = metrics["precision"]
                     if float_compare(amount, payable, precision_rounding=precision) == 1:
                         issues.append(
                             {
@@ -69,16 +74,22 @@ class PaymentNotOverpayRule(BaseRule):
                             }
                         )
                 continue
-            currency = pr.company_id.currency_id
-            precision = currency.rounding or 0.01
-            if precision <= 0:
-                precision = 0.01
-            paid = paid_map.get(settle.id, 0.0)
-            # 排除自身（避免自统计）
-            if pr.state in paid_states:
-                paid -= pr.amount or 0.0
-            payable = (settle.amount_total or 0.0) - paid
             amount = pr.amount or 0.0
+            try:
+                metrics = opm.compute_settlement_reservable_excluding_request(pr, settle, amount)
+            except ValidationError as exc:
+                issues.append(
+                    {
+                        "model": "payment.request",
+                        "res_id": pr.id,
+                        "message": str(exc),
+                        "refs": {"name": pr.display_name},
+                        "suggestions": [],
+                    }
+                )
+                continue
+            payable = metrics["payable"]
+            precision = metrics["precision"]
 
             if float_compare(amount, payable, precision_rounding=precision) == 1:
                 issues.append(

--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -35,8 +35,8 @@ Generated from repository source files. This report is informational during the 
 | 2267 | Vue source | `frontend/apps/web/src/layouts/AppShell.vue` |
 | 2193 | Python source | `addons/smart_core/handlers/api_data.py` |
 | 2051 | Python source | `scripts/verify/backend_business_fact_model_audit.py` |
-| 1974 | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1966 | TypeScript source | `frontend/apps/web/src/stores/session.ts` |
+| 1963 | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1877 | Python source | `addons/smart_core/tests/test_ui_contract_v2_boundaries.py` |
 | 1850 | Python source | `addons/smart_core/handlers/menu_configuration.py` |
 | 1847 | Python source | `addons/smart_construction_core/models/support/product_policy_sync.py` |
@@ -47,7 +47,7 @@ Generated from repository source files. This report is informational during the 
 | 1689 | Python source | `scripts/verify/industry_module_product_boundary_guard.py` |
 | 1634 | Python source | `addons/smart_core/core/scene_ready_contract_builder.py` |
 | 1597 | Python source | `addons/smart_construction_core/models/support/direct_acceptance_formal_visible_fields.py` |
-| 1558 | Python source | `addons/smart_construction_core/models/support/contract_center.py` |
+| 1555 | Python source | `addons/smart_construction_core/models/support/contract_center.py` |
 | 1552 | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |
@@ -152,8 +152,8 @@ Generated from repository source files. This report is informational during the 
 | 2193 | split_plan_required | Python source | `addons/smart_core/handlers/api_data.py` |
 | 2051 | split_plan_required | Python source | `scripts/verify/backend_business_fact_model_audit.py` |
 | 2010 | warning | XML data/view | `addons/smart_construction_core/security/sc_record_rules.xml` |
-| 1974 | split_plan_required | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1966 | split_plan_required | TypeScript source | `frontend/apps/web/src/stores/session.ts` |
+| 1963 | split_plan_required | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1877 | split_plan_required | Python source | `addons/smart_core/tests/test_ui_contract_v2_boundaries.py` |
 | 1850 | split_plan_required | Python source | `addons/smart_core/handlers/menu_configuration.py` |
 | 1847 | split_plan_required | Python source | `addons/smart_construction_core/models/support/product_policy_sync.py` |
@@ -165,7 +165,7 @@ Generated from repository source files. This report is informational during the 
 | 1689 | split_plan_required | Python source | `scripts/verify/industry_module_product_boundary_guard.py` |
 | 1634 | split_plan_required | Python source | `addons/smart_core/core/scene_ready_contract_builder.py` |
 | 1597 | split_plan_required | Python source | `addons/smart_construction_core/models/support/direct_acceptance_formal_visible_fields.py` |
-| 1558 | split_plan_required | Python source | `addons/smart_construction_core/models/support/contract_center.py` |
+| 1555 | split_plan_required | Python source | `addons/smart_construction_core/models/support/contract_center.py` |
 | 1552 | split_plan_required | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | split_plan_required | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |

--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -35,8 +35,8 @@ Generated from repository source files. This report is informational during the 
 | 2267 | Vue source | `frontend/apps/web/src/layouts/AppShell.vue` |
 | 2193 | Python source | `addons/smart_core/handlers/api_data.py` |
 | 2051 | Python source | `scripts/verify/backend_business_fact_model_audit.py` |
+| 1971 | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1966 | TypeScript source | `frontend/apps/web/src/stores/session.ts` |
-| 1963 | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1877 | Python source | `addons/smart_core/tests/test_ui_contract_v2_boundaries.py` |
 | 1850 | Python source | `addons/smart_core/handlers/menu_configuration.py` |
 | 1847 | Python source | `addons/smart_construction_core/models/support/product_policy_sync.py` |
@@ -152,8 +152,8 @@ Generated from repository source files. This report is informational during the 
 | 2193 | split_plan_required | Python source | `addons/smart_core/handlers/api_data.py` |
 | 2051 | split_plan_required | Python source | `scripts/verify/backend_business_fact_model_audit.py` |
 | 2010 | warning | XML data/view | `addons/smart_construction_core/security/sc_record_rules.xml` |
+| 1971 | split_plan_required | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1966 | split_plan_required | TypeScript source | `frontend/apps/web/src/stores/session.ts` |
-| 1963 | split_plan_required | Python source | `addons/smart_construction_core/models/core/payment_request.py` |
 | 1877 | split_plan_required | Python source | `addons/smart_core/tests/test_ui_contract_v2_boundaries.py` |
 | 1850 | split_plan_required | Python source | `addons/smart_core/handlers/menu_configuration.py` |
 | 1847 | split_plan_required | Python source | `addons/smart_construction_core/models/support/product_policy_sync.py` |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -42,8 +42,8 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P2 | 2289 | Construction backend owner | `addons/smart_construction_core/models/core/project_core.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 2267 | Frontend owner | `frontend/apps/web/src/layouts/AppShell.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P2 | 2051 | DevOps owner | `scripts/verify/backend_business_fact_model_audit.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
+| P2 | 1971 | Construction backend owner | `addons/smart_construction_core/models/core/payment_request.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1966 | Frontend owner | `frontend/apps/web/src/stores/session.ts` | Define owner-specific decomposition plan before adding unrelated behavior. |
-| P2 | 1963 | Construction backend owner | `addons/smart_construction_core/models/core/payment_request.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1847 | Construction backend owner | `addons/smart_construction_core/models/support/product_policy_sync.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1844 | DevOps owner | `scripts/migration/scbs_55_legacy_visible_field_full_reconcile_probe.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P2 | 1787 | Construction backend owner | `addons/smart_construction_core/core_extension.py` | Define owner-specific decomposition plan before adding unrelated behavior. |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -42,15 +42,15 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P2 | 2289 | Construction backend owner | `addons/smart_construction_core/models/core/project_core.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 2267 | Frontend owner | `frontend/apps/web/src/layouts/AppShell.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P2 | 2051 | DevOps owner | `scripts/verify/backend_business_fact_model_audit.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
-| P2 | 1974 | Construction backend owner | `addons/smart_construction_core/models/core/payment_request.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1966 | Frontend owner | `frontend/apps/web/src/stores/session.ts` | Define owner-specific decomposition plan before adding unrelated behavior. |
+| P2 | 1963 | Construction backend owner | `addons/smart_construction_core/models/core/payment_request.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1847 | Construction backend owner | `addons/smart_construction_core/models/support/product_policy_sync.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1844 | DevOps owner | `scripts/migration/scbs_55_legacy_visible_field_full_reconcile_probe.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P2 | 1787 | Construction backend owner | `addons/smart_construction_core/core_extension.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P2 | 1741 | Frontend owner | `frontend/apps/web/src/views/SceneView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P2 | 1689 | DevOps owner | `scripts/verify/industry_module_product_boundary_guard.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P2 | 1597 | Construction backend owner | `addons/smart_construction_core/models/support/direct_acceptance_formal_visible_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
-| P2 | 1558 | Construction backend owner | `addons/smart_construction_core/models/support/contract_center.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
+| P2 | 1555 | Construction backend owner | `addons/smart_construction_core/models/support/contract_center.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1523 | Construction backend owner | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P2 | 599 | DevOps owner | `scripts/audit/smoke_role_matrix.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |
 | P2 | 551 | DevOps owner | `scripts/ops/audit_project_actions.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |


### PR DESCRIPTION
## What changed

- Split settlement reservation, ledger actual paid, adjusted payable base, remaining reservable amount, and contract actual paid into explicit domain helpers.
- Keep existing settlement `paid_amount` / `amount_paid` fields as reservation-compatible fields while computing their balance from `amount_after_adjustment`.
- Count only `sc.payment.execution.state == paid` in contract actual paid; draft, confirmed, legacy_confirmed, cancel, and cancelled are excluded.
- Use `payment.ledger` as the sole settlement actual-paid source and reject unconverted request/contract/settlement currency mismatches.
- Align the payment over-limit validator with the same helpers and add the 23-scenario minimum amount matrix.
- Refresh the generated complexity and split-plan reports required by CI.

## Business semantics

- Reservation states: `submit`, `approve`, `approved`, `done`.
- Non-reserving states: `draft`, `cancel`, `cancelled`.
- Payable base: settlement-currency-rounded `max(amount_after_adjustment, 0)`.
- Remaining reservation: settlement-currency-rounded `max(payable_base - reserved, 0)`.
- Actual paid: payment ledger only.
- Contract actual paid execution state: `paid` only; repository evidence does not prove `legacy_confirmed` means payment completed.

## Compatibility

No public field was removed or renamed. No stored field, migration, API, frontend, database schema, or payment state machine was changed. Existing settlement paid fields remain compatibility reservation fields.

## Validation

- New and related targeted Odoo suite: 24 methods / 32 tests, 0 failed, 0 errors.
- `git diff --check`: PASS.
- `make ci.local.quick`: PASS.
- `make ci`: ran exactly once; stopped at stale generated complexity report (exit 2). Both generated reports were refreshed, and their individual gates plus every not-yet-reached CI target (`test.unit`, `test.frontend`, `test.contract`, `test.e2e.preflight`) then passed. The complete command was not rerun per the one-run closeout rule.
- Remote GitHub `quality_gate`: initial HEAD passed; latest fix HEAD pending.

## Architecture Impact

This changes P1 Domain Layer amount semantics inside `smart_construction_core`. It introduces small model-support helpers, not a cross-domain amount service.

## Layer Target

Formal Product Layer P1 / Domain Layer.

## Affected Modules

`addons/smart_construction_core` payment requests, settlement orders, payment ledger aggregation, payment execution aggregation, contract totals, validator, and focused tests.

## Review policy

One Codex review will be requested. P0/P1 findings block merge. Ordinary P2 findings are recorded here and do not block unless they concern data correctness, security, permissions, funds, or irreversible operations.

### Review result

- P0/P1: none.
- P2: one valid finding fixed in `db0d5f664`. UI-only `is_overpay_risk` computation now marks legacy currency/company mismatches as risky without raising; submit/validation paths still reject them. Focused amount + validator tests passed after the fix. No second review requested.
