### PR TITLE
FE-PRE-01: establish frontend productization fixture

### DIFF
--- a/addons/smart_construction_demo/data/demo/role_matrix_demo_users.xml
+++ b/addons/smart_construction_demo/data/demo/role_matrix_demo_users.xml
@@ -123,6 +123,23 @@
             ]"/>
         </record>
 
+        <record id="user_demo_role_project_a_member" model="res.users">
+            <field name="name">Demo Project A Member</field>
+            <field name="login">demo_role_project_a_member</field>
+            <field name="password">demo</field>
+            <field name="email">demo_role_project_a_member@example.invalid</field>
+            <field name="active">True</field>
+            <field name="share">False</field>
+            <field name="lang">zh_CN</field>
+            <field name="tz">Asia/Shanghai</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="groups_id" eval="[(6, 0, [
+                ref('base.group_user'),
+                ref('smart_construction_core.group_sc_cap_project_read'),
+                ref('smart_construction_core.group_sc_cap_business_initiator')
+            ])]"/>
+        </record>
+
         <record id="user_demo_role_executive" model="res.users">
             <field name="name">Demo Role Executive</field>
             <field name="login">demo_role_executive</field>

--- a/addons/smart_construction_demo/tools/__init__.py
+++ b/addons/smart_construction_demo/tools/__init__.py
@@ -1,2 +1,3 @@
 # -*- coding: utf-8 -*-
 from . import scenario_loader
+from . import frontend_productization_fixture

--- a/addons/smart_construction_demo/tools/frontend_productization_fixture.py
+++ b/addons/smart_construction_demo/tools/frontend_productization_fixture.py
@@ -1,0 +1,413 @@
+# -*- coding: utf-8 -*-
+"""Deterministic browser fixture for frontend productization acceptance.
+
+This module is deliberately hosted by ``smart_construction_demo``.  It is an
+administrative data builder for non-production demo databases; authorization
+is verified separately with the real fixture users and without sudo.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+
+MODULE = "smart_construction_demo"
+PASSWORD = "demo"
+
+
+def _ref(env, xmlid):
+    record = env.ref(xmlid, raise_if_not_found=False)
+    if not record:
+        raise RuntimeError("missing required xmlid: %s" % xmlid)
+    return record
+
+
+def _bind_xmlid(env, name, record):
+    imd = env["ir.model.data"].sudo()
+    row = imd.search([("module", "=", MODULE), ("name", "=", name)], limit=1)
+    values = {"model": record._name, "res_id": record.id, "noupdate": True}
+    if row:
+        row.write(values)
+    else:
+        imd.create({"module": MODULE, "name": name, **values})
+
+
+def _upsert(env, model_name, xmlid_name, domain, values):
+    model = env[model_name].sudo().with_context(active_test=False, tracking_disable=True)
+    record = env.ref("%s.%s" % (MODULE, xmlid_name), raise_if_not_found=False)
+    if record and record._name != model_name:
+        raise RuntimeError("xmlid %s points to %s" % (xmlid_name, record._name))
+    if not record:
+        matches = model.search(domain)
+        if len(matches) > 1:
+            raise RuntimeError("fixture domain is not unique: %s %s" % (model_name, domain))
+        record = matches[:1]
+    if record:
+        changed = {}
+        for field_name, value in values.items():
+            field = record._fields[field_name]
+            current = record[field_name]
+            if field.type == "many2one":
+                is_equal = current.id == (value or False)
+            elif field.type in ("one2many", "many2many"):
+                is_equal = False
+            else:
+                is_equal = current == value
+            if not is_equal:
+                changed[field_name] = value
+        if changed:
+            record.write(changed)
+    else:
+        record = model.create(values)
+    _bind_xmlid(env, xmlid_name, record)
+    return record
+
+
+def _company(env, suffix):
+    name = "FE Company %s" % suffix
+    return _upsert(
+        env,
+        "res.company",
+        "fe_company_%s" % suffix.lower(),
+        [("name", "=", name)],
+        {
+            "name": name,
+            "currency_id": _ref(env, "base.CNY").id,
+            "country_id": _ref(env, "base.cn").id,
+        },
+    )
+
+
+def _user(env, login, name, company, companies, group_xmlids):
+    groups = [_ref(env, "base.group_user")]
+    groups.extend(_ref(env, xmlid) for xmlid in group_xmlids)
+    return _upsert(
+        env,
+        "res.users",
+        "fe_user_%s" % login.replace("demo_role_", ""),
+        [("login", "=", login)],
+        {
+            "name": name,
+            "login": login,
+            "email": "%s@example.invalid" % login,
+            "active": True,
+            "share": False,
+            "lang": "zh_CN",
+            "tz": "Asia/Shanghai",
+            "company_id": company.id,
+            "company_ids": [(6, 0, [item.id for item in companies])],
+            "groups_id": [(6, 0, [group.id for group in groups])],
+            "password": PASSWORD,
+        },
+    )
+
+
+def _partner(env, suffix, company):
+    name = "FE-%s Counterparty" % suffix
+    return _upsert(
+        env,
+        "res.partner",
+        "fe_partner_%s" % suffix.lower(),
+        [("name", "=", name), ("company_id", "=", company.id)],
+        {
+            "name": name,
+            "company_id": company.id,
+            "is_company": True,
+            "company_type": "company",
+            "supplier_rank": 1,
+        },
+    )
+
+
+def _tax(env, suffix, company):
+    helper = env["construction.contract"].sudo().with_company(company)
+    group = helper._sc_contract_tax_group(company)
+    name = helper._sc_format_contract_tax_name(13.0)
+    return _upsert(
+        env,
+        "account.tax",
+        "fe_tax_%s" % suffix.lower(),
+        [
+            ("company_id", "=", company.id),
+            ("type_tax_use", "=", "none"),
+            ("amount_type", "=", "percent"),
+            ("amount", "=", 13.0),
+        ],
+        {
+            "name": name,
+            "company_id": company.id,
+            "country_id": company.account_fiscal_country_id.id or _ref(env, "base.cn").id,
+            "tax_group_id": group.id,
+            "amount": 13.0,
+            "amount_type": "percent",
+            "type_tax_use": "none",
+            "price_include": False,
+            "active": True,
+        },
+    )
+
+
+def _project(env, suffix, company, manager, partner):
+    name = "FE Project %s" % suffix
+    values = {
+        "name": name,
+        "code": "FE-%s" % suffix,
+        "company_id": company.id,
+        "partner_id": partner.id,
+        "user_id": manager.id,
+        "manager_id": manager.id,
+        "privacy_visibility": "followers",
+        "funding_enabled": True,
+        "active": True,
+    }
+    if "project_code" in env["project.project"]._fields:
+        values["project_code"] = "FE-%s" % suffix
+    return _upsert(
+        env,
+        "project.project",
+        "fe_project_%s" % suffix.lower(),
+        [("name", "=", name), ("company_id", "=", company.id)],
+        values,
+    )
+
+
+def _funding_baseline(env, suffix, project):
+    return _upsert(
+        env,
+        "project.funding.baseline",
+        "fe_funding_baseline_%s" % suffix.lower(),
+        [("project_id", "=", project.id), ("state", "=", "active")],
+        {
+            "project_id": project.id,
+            "total_amount": 5000.0,
+            "state": "active",
+        },
+    )
+
+
+def _contract(env, suffix, project, partner, tax, state, amount):
+    subject = "FE-%s Contract" % suffix
+    record = _upsert(
+        env,
+        "construction.contract",
+        "fe_contract_%s" % suffix.lower(),
+        [("subject", "=", subject), ("project_id", "=", project.id)],
+        {
+            "subject": subject,
+            "type": "in",
+            "project_id": project.id,
+            "partner_id": partner.id,
+            "company_id": project.company_id.id,
+            "currency_id": project.company_id.currency_id.id,
+            "tax_id": tax.id,
+            "state": state,
+            "active": True,
+        },
+    )
+    line = _upsert(
+        env,
+        "construction.contract.line",
+        "fe_contract_line_%s" % suffix.lower(),
+        [("contract_id", "=", record.id), ("note", "=", "FE-%s fixed line" % suffix)],
+        {
+            "contract_id": record.id,
+            "qty_contract": 1.0,
+            "price_contract": amount,
+            "note": "FE-%s fixed line" % suffix,
+        },
+    )
+    record.invalidate_recordset()
+    return record, line
+
+
+def _settlement(env, suffix, project, contract, partner, state, amount):
+    name = "FE-%s-SET-001" % suffix
+    record = _upsert(
+        env,
+        "sc.settlement.order",
+        "fe_settlement_%s" % suffix.lower(),
+        [("name", "=", name), ("project_id", "=", project.id)],
+        {
+            "name": name,
+            "title": "FE-%s Settlement" % suffix,
+            "project_id": project.id,
+            "contract_id": contract.id,
+            "partner_id": partner.id,
+            "settlement_unit_id": partner.id,
+            "settlement_type": "out",
+            "company_id": project.company_id.id,
+            "currency_id": project.company_id.currency_id.id,
+            "state": state,
+        },
+    )
+    _upsert(
+        env,
+        "sc.settlement.order.line",
+        "fe_settlement_line_%s" % suffix.lower(),
+        [("settlement_id", "=", record.id), ("name", "=", "FE-%s fixed line" % suffix)],
+        {
+            "settlement_id": record.id,
+            "contract_id": contract.id,
+            "name": "FE-%s fixed line" % suffix,
+            "qty": 1.0,
+            "price_unit": amount,
+        },
+    )
+    record.invalidate_recordset()
+    return record
+
+
+def _request(env, suffix, sequence, project, contract, settlement, partner, state, amount):
+    name = "FE-%s-PR-%03d" % (suffix, sequence)
+    category = _ref(env, "smart_construction_core.business_category_finance_payment_apply_pay")
+    return _upsert(
+        env,
+        "payment.request",
+        "fe_request_%s_%03d" % (suffix.lower(), sequence),
+        [("name", "=", name), ("project_id", "=", project.id)],
+        {
+            "name": name,
+            "type": "pay",
+            "business_category_id": category.id,
+            "project_id": project.id,
+            "contract_id": contract.id,
+            "settlement_id": settlement.id,
+            "partner_id": partner.id,
+            "currency_id": project.company_id.currency_id.id,
+            "amount": amount,
+            "state": state,
+            "note": "FE-%s deterministic payment request" % suffix,
+        },
+    )
+
+
+def _execution(env, suffix, project, contract, request, partner, state, amount):
+    name = "FE-%s-PE-001" % suffix
+    return _upsert(
+        env,
+        "sc.payment.execution",
+        "fe_execution_%s" % suffix.lower(),
+        [("name", "=", name), ("project_id", "=", project.id)],
+        {
+            "name": name,
+            "project_id": project.id,
+            "contract_id": contract.id,
+            "payment_request_id": request.id,
+            "partner_id": partner.id,
+            "currency_id": project.company_id.currency_id.id,
+            "planned_amount": amount,
+            "paid_amount": amount if state == "paid" else 0.0,
+            "state": state,
+            "document_no": name,
+            "note": "FE-%s deterministic payment execution" % suffix,
+            "active": True,
+        },
+    )
+
+
+def ensure_fixture(env) -> Dict[str, Any]:
+    """Create or reconcile the fixed dataset and return a secret-free summary."""
+    module = env["ir.module.module"].sudo().search([("name", "=", MODULE)], limit=1)
+    if not module or module.state != "installed":
+        raise RuntimeError("smart_construction_demo must be installed before fixture initialization")
+
+    company_a = _company(env, "A")
+    company_b = _company(env, "B")
+
+    finance = _user(
+        env,
+        "demo_role_finance",
+        "Demo Role Finance",
+        company_a,
+        [company_a, company_b],
+        ["smart_construction_custom.group_sc_role_finance"],
+    )
+    project_member = _user(
+        env,
+        "demo_role_project_a_member",
+        "Demo Project A Member",
+        company_a,
+        [company_a],
+        [
+            "smart_construction_core.group_sc_cap_project_read",
+            "smart_construction_core.group_sc_cap_business_initiator",
+        ],
+    )
+    pm = _user(
+        env,
+        "demo_role_pm",
+        "Demo Role PM",
+        company_a,
+        [company_a],
+        ["smart_construction_custom.group_sc_role_pm"],
+    )
+    owner = _user(
+        env,
+        "demo_role_owner",
+        "Demo Role Owner",
+        company_a,
+        [company_a],
+        ["smart_construction_custom.group_sc_role_owner"],
+    )
+
+    partner_a = _partner(env, "A", company_a)
+    partner_b = _partner(env, "B", company_a)
+    partner_c = _partner(env, "C", company_b)
+    tax_a = _tax(env, "A", company_a)
+    tax_b = _tax(env, "B", company_b)
+    project_a = _project(env, "A", company_a, pm, partner_a)
+    project_b = _project(env, "B", company_a, pm, partner_b)
+    project_c = _project(env, "C", company_b, finance, partner_c)
+
+    # Keep the PM journey deterministic even when the database previously carried
+    # unrelated demo projects assigned to the same fixed login.
+    historical_pm_projects = env["project.project"].sudo().search(
+        [
+            ("id", "not in", [project_a.id, project_b.id]),
+            "|",
+            ("user_id", "=", pm.id),
+            ("manager_id", "=", pm.id),
+        ]
+    )
+    if historical_pm_projects:
+        historical_pm_projects.write({"user_id": False, "manager_id": False})
+
+    follower_model = env["mail.followers"].sudo()
+    fixture_partners = [project_member.partner_id.id, pm.partner_id.id]
+    follower_model.search(
+        [("res_model", "=", "project.project"), ("partner_id", "in", fixture_partners)]
+    ).unlink()
+    project_a.message_subscribe(partner_ids=[project_member.partner_id.id, pm.partner_id.id])
+    project_b.message_subscribe(partner_ids=[pm.partner_id.id])
+
+    _funding_baseline(env, "A", project_a)
+    _funding_baseline(env, "B", project_b)
+    _funding_baseline(env, "C", project_c)
+
+    contract_a, _ = _contract(env, "A", project_a, partner_a, tax_a, "confirmed", 1000.0)
+    contract_b, _ = _contract(env, "B", project_b, partner_b, tax_a, "draft", 1000.0)
+    contract_c, _ = _contract(env, "C", project_c, partner_c, tax_b, "confirmed", 1000.0)
+    settlement_a = _settlement(env, "A", project_a, contract_a, partner_a, "approve", 1000.0)
+    settlement_b = _settlement(env, "B", project_b, contract_b, partner_b, "draft", 1000.0)
+    settlement_c = _settlement(env, "C", project_c, contract_c, partner_c, "approve", 1000.0)
+    request_a = _request(env, "A", 1, project_a, contract_a, settlement_a, partner_a, "approved", 1000.0)
+    _request(env, "A", 2, project_a, contract_a, settlement_a, partner_a, "draft", 250.0)
+    request_b = _request(env, "B", 1, project_b, contract_b, settlement_b, partner_b, "draft", 1000.0)
+    request_c = _request(env, "C", 1, project_c, contract_c, settlement_c, partner_c, "approved", 1000.0)
+    _execution(env, "A", project_a, contract_a, request_a, partner_a, "paid", 1000.0)
+    _execution(env, "B", project_b, contract_b, request_b, partner_b, "draft", 1000.0)
+    _execution(env, "C", project_c, contract_c, request_c, partner_c, "confirmed", 1000.0)
+
+    env.cr.commit()
+    return {
+        "db": env.cr.dbname,
+        "users": [finance.login, project_member.login, pm.login, owner.login],
+        "companies": [company_a.name, company_b.name],
+        "projects": [project_a.name, project_b.name, project_c.name],
+        "records": {
+            "contracts": 3,
+            "settlements": 3,
+            "payment_requests": 4,
+            "payment_executions": 3,
+        },
+    }

--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -4,7 +4,7 @@ Generated from repository source files. This report is informational during the 
 
 ## Summary
 
-- Scanned files: `3931`
+- Scanned files: `3936`
 - Files requiring split plan: `41`
 - Files above warning threshold: `65`
 

--- a/make/runtime_ops.mk
+++ b/make/runtime_ops.mk
@@ -1726,7 +1726,24 @@ mod.upgrade: guard.codex.fast.upgrade guard.prod.danger check-compose-project ch
 # ======================================================
 # ==================== Policy Ops ======================
 # ======================================================
-.PHONY: policy.apply.business_full policy.apply.role_matrix policy.ensure.role_surface_demo smoke.business_full smoke.role_matrix verify.portal.role_surface_preflight.container verify.portal.role_surface_smoke.container p2.smoke p3.smoke p3.audit codex.preflight codex.merge codex.rollback codex.pr.body codex.release.note db.policy stage.preflight stage.run ops.auth.dev.apply ops.auth.dev.rollback ops.auth.dev.verify
+.PHONY: demo.frontend.fixture verify.frontend.fixture verify.frontend.fixture.browser policy.apply.business_full policy.apply.role_matrix policy.ensure.role_surface_demo smoke.business_full smoke.role_matrix verify.portal.role_surface_preflight.container verify.portal.role_surface_smoke.container p2.smoke p3.smoke p3.audit codex.preflight codex.merge codex.rollback codex.pr.body codex.release.note db.policy stage.preflight stage.run ops.auth.dev.apply ops.auth.dev.rollback ops.auth.dev.verify
+demo.frontend.fixture: guard.prod.forbid check-compose-project check-compose-env
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/demo/frontend_productization_fixture.sh
+
+verify.frontend.fixture: guard.prod.forbid check-compose-project check-compose-env
+	@python3 -m py_compile addons/smart_construction_demo/tools/frontend_productization_fixture.py scripts/verify/frontend_productization_fixture.py
+	@$(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/frontend_productization_fixture.py
+	@$(MAKE) --no-print-directory verify.frontend.fixture.browser DB_NAME=$(DB_NAME)
+
+verify.frontend.fixture.browser: guard.prod.forbid check-compose-project check-compose-env
+	@set -e; \
+	runtime_output="$$( $(RUN_ENV) DB_NAME=$(DB_NAME) bash scripts/ops/odoo_shell_exec.sh < scripts/verify/frontend_productization_fixture_runtime_ids.py 2>&1 )"; \
+	action_line="$$(echo "$$runtime_output" | grep '^FRONTEND_FIXTURE_PAYMENT_ACTION_ID=' | tail -1)"; \
+	menu_line="$$(echo "$$runtime_output" | grep '^FRONTEND_FIXTURE_PAYMENT_MENU_ID=' | tail -1)"; \
+	test -n "$$action_line" -a -n "$$menu_line"; \
+	export "$$action_line" "$$menu_line"; \
+	$(RUN_ENV) DB_NAME=$(DB_NAME) FRONTEND_URL=$${FRONTEND_URL:-http://127.0.0.1:18081} FRONTEND_FIXTURE_PAYMENT_ACTION_ID=$${FRONTEND_FIXTURE_PAYMENT_ACTION_ID} FRONTEND_FIXTURE_PAYMENT_MENU_ID=$${FRONTEND_FIXTURE_PAYMENT_MENU_ID} node scripts/verify/frontend_productization_fixture_browser.mjs
+
 policy.apply.business_full: guard.prod.danger check-compose-project check-compose-env
 	@$(RUN_ENV) POLICY_MODULE=smart_construction_custom DB_NAME=$(DB_NAME) bash scripts/audit/apply_business_full_policy.sh
 policy.apply.role_matrix: guard.prod.danger check-compose-project check-compose-env
@@ -1930,4 +1947,3 @@ gate.full: guard.codex.fast.noheavy guard.prod.forbid check-compose-project chec
 	fi
 	@$(MAKE) verify.phase_9_8.gate_summary
 	@$(MAKE) audit.pull DB_NAME=$(DB_NAME)
-

--- a/scripts/demo/frontend_productization_fixture.sh
+++ b/scripts/demo/frontend_productization_fixture.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR:-$(cd "$(dirname "$0")/../.." && pwd)}"
+export ROOT_DIR
+
+source "$ROOT_DIR/scripts/common/env.sh"
+source "$ROOT_DIR/scripts/common/guard_prod.sh"
+
+guard_prod_forbid
+: "${DB_NAME:?DB_NAME required}"
+export SC_ALLOW_DEMO_DATA=1
+
+make --no-print-directory policy.ensure.role_surface_demo \
+  DB_NAME="$DB_NAME" AUTO_FIX_ROLE_SURFACE_DEMO=1 ROLE_SMOKE_PASSWORD=demo
+
+DB_NAME="$DB_NAME" make --no-print-directory odoo.shell.exec <<'PY'
+import json
+from odoo.addons.smart_construction_demo.tools.frontend_productization_fixture import ensure_fixture
+
+summary = ensure_fixture(env)
+print("[demo.frontend.fixture] PASS")
+print(json.dumps(summary, ensure_ascii=False, indent=2))
+PY
+
+make --no-print-directory restart

--- a/scripts/ops/ensure_role_surface_demo.sh
+++ b/scripts/ops/ensure_role_surface_demo.sh
@@ -22,6 +22,7 @@ required_logins = [
     "demo_role_owner",
     "demo_role_pm",
     "demo_role_finance",
+    "demo_role_project_a_member",
     "demo_role_executive",
 ]
 

--- a/scripts/verify/frontend_productization_fixture.py
+++ b/scripts/verify/frontend_productization_fixture.py
@@ -1,0 +1,205 @@
+# -*- coding: utf-8 -*-
+"""Read-only verification for the fixed frontend productization fixture."""
+
+import json
+
+from odoo.exceptions import AccessError
+
+
+PASSWORD = "demo"
+LOGINS = (
+    "demo_role_finance",
+    "demo_role_project_a_member",
+    "demo_role_pm",
+    "demo_role_owner",
+)
+MODELS = (
+    "construction.contract",
+    "sc.settlement.order",
+    "payment.request",
+    "sc.payment.execution",
+)
+
+
+def fail(message):
+    print("[verify.frontend.fixture] FAIL %s" % message)
+    raise SystemExit(2)
+
+
+users = env["res.users"].sudo().search([("login", "in", list(LOGINS))])
+by_login = {user.login: user for user in users}
+missing = [login for login in LOGINS if login not in by_login]
+if missing:
+    fail("missing users: %s" % ",".join(missing))
+
+login_results = {}
+for login in LOGINS:
+    uid = env["res.users"].sudo().authenticate(
+        env.cr.dbname, login, PASSWORD, {"interactive": True}
+    )
+    login_results[login] = bool(uid)
+if not all(login_results.values()):
+    fail("one or more fixture users cannot authenticate")
+
+companies = env["res.company"].sudo().search([("name", "in", ["FE Company A", "FE Company B"])])
+company_by_name = {company.name: company for company in companies}
+if set(company_by_name) != {"FE Company A", "FE Company B"}:
+    fail("companies are missing or not unique")
+for name in company_by_name:
+    if env["res.company"].sudo().search_count([("name", "=", name)]) != 1:
+        fail("company is not unique: %s" % name)
+
+projects = env["project.project"].sudo().search(
+    [("name", "in", ["FE Project A", "FE Project B", "FE Project C"])]
+)
+project_by_name = {project.name: project for project in projects}
+if set(project_by_name) != {"FE Project A", "FE Project B", "FE Project C"}:
+    fail("projects are missing or not unique")
+for name in project_by_name:
+    if env["project.project"].sudo().search_count([("name", "=", name)]) != 1:
+        fail("project is not unique: %s" % name)
+
+project_a = project_by_name["FE Project A"]
+project_b = project_by_name["FE Project B"]
+project_c = project_by_name["FE Project C"]
+company_a = company_by_name["FE Company A"]
+company_b = company_by_name["FE Company B"]
+if project_a.company_id != company_a or project_b.company_id != company_a or project_c.company_id != company_b:
+    fail("project/company matrix mismatch")
+
+member = by_login["demo_role_project_a_member"]
+member_env = env(user=member, context={**env.context, "allowed_company_ids": [company_a.id]})
+member_projects = member_env["project.project"].search([("name", "like", "FE Project %")])
+if member_projects.ids != project_a.ids:
+    fail("project A member scope mismatch: %s" % member_projects.mapped("name"))
+
+pm = by_login["demo_role_pm"]
+pm_projects = env["project.project"].sudo().search(
+    ["|", ("user_id", "=", pm.id), ("manager_id", "=", pm.id)]
+)
+if set(pm_projects.ids) != {project_a.id, project_b.id}:
+    fail("PM assigned project scope mismatch: %s" % pm_projects.mapped("name"))
+pm_followed_projects = env["project.project"].sudo().search(
+    [("message_partner_ids", "in", [pm.partner_id.id])]
+)
+if set(pm_followed_projects.ids) != {project_a.id, project_b.id}:
+    fail("PM followed project scope mismatch: %s" % pm_followed_projects.mapped("name"))
+
+denied = []
+for model_name in MODELS:
+    model = member_env[model_name]
+    visible = model.search([("project_id", "in", [project_a.id, project_b.id, project_c.id])])
+    if not visible or set(visible.mapped("project_id").ids) != {project_a.id}:
+        fail(
+            "member visible scope mismatch for %s: %s"
+            % (model_name, visible.mapped("project_id.name"))
+        )
+    for project in (project_b, project_c):
+        target = env[model_name].sudo().search([("project_id", "=", project.id)], limit=1)
+        if not target:
+            fail("missing denied target for %s/%s" % (model_name, project.name))
+        try:
+            model.browse(target.id).read(["id"])
+        except AccessError:
+            denied.append("%s:%s" % (model_name, project.name))
+        else:
+            fail("member direct read unexpectedly allowed for %s/%s" % (model_name, project.name))
+
+finance = by_login["demo_role_finance"]
+finance_a = env(user=finance, context={**env.context, "allowed_company_ids": [company_a.id]})
+finance_b = env(user=finance, context={**env.context, "allowed_company_ids": [company_b.id]})
+requests_a = finance_a["payment.request"].search([("name", "like", "FE-%-PR-%")])
+names_a = set(requests_a.mapped("name"))
+if names_a != {"FE-A-PR-001", "FE-A-PR-002", "FE-B-PR-001"}:
+    fail("finance company A scope mismatch: %s" % sorted(names_a))
+requests_b = finance_b["payment.request"].search([("name", "like", "FE-%-PR-%")])
+names_b = set(requests_b.mapped("name"))
+if names_b != {"FE-C-PR-001"}:
+    fail("finance company B scope mismatch or stale context: %s" % sorted(names_b))
+
+for suffix, project in (("A", project_a), ("B", project_b), ("C", project_c)):
+    contract = env["construction.contract"].sudo().search(
+        [("subject", "=", "FE-%s Contract" % suffix)], limit=1
+    )
+    settlement = env["sc.settlement.order"].sudo().search(
+        [("name", "=", "FE-%s-SET-001" % suffix)], limit=1
+    )
+    request = env["payment.request"].sudo().search(
+        [("name", "=", "FE-%s-PR-001" % suffix)], limit=1
+    )
+    execution = env["sc.payment.execution"].sudo().search(
+        [("name", "=", "FE-%s-PE-001" % suffix)], limit=1
+    )
+    if not all((contract, settlement, request, execution)):
+        fail("incomplete business chain FE-%s" % suffix)
+    if not (
+        contract.project_id == project
+        and settlement.project_id == project
+        and settlement.contract_id == contract
+        and request.project_id == project
+        and request.contract_id == contract
+        and request.settlement_id == settlement
+        and execution.project_id == project
+        and execution.contract_id == contract
+        and execution.payment_request_id == request
+    ):
+        fail("business chain relation mismatch FE-%s" % suffix)
+
+    expected_states = {
+        "A": ("confirmed", "approve", "approved", "paid"),
+        "B": ("draft", "draft", "draft", "draft"),
+        "C": ("confirmed", "approve", "approved", "confirmed"),
+    }[suffix]
+    actual_states = (contract.state, settlement.state, request.state, execution.state)
+    if actual_states != expected_states:
+        fail("business chain state mismatch FE-%s: %s" % (suffix, actual_states))
+    if request.amount != 1000.0 or execution.planned_amount != 1000.0:
+        fail("same-amount company isolation fixture mismatch FE-%s" % suffix)
+
+request_distribution = {
+    suffix: env["payment.request"].sudo().search_count(
+        [("project_id", "=", project.id), ("name", "like", "FE-%-PR-%")]
+    )
+    for suffix, project in (("A", project_a), ("B", project_b), ("C", project_c))
+}
+if request_distribution != {"A": 2, "B": 1, "C": 1}:
+    fail("single/multi list fixture mismatch: %s" % request_distribution)
+if env["payment.request"].sudo().search_count(
+    [("name", "like", "FE-%-PR-%"), ("state", "=", "cancel")]
+):
+    fail("empty-state fixture mismatch: cancel filter must be empty")
+
+counts = {
+    "companies": env["res.company"].sudo().search_count([("name", "like", "FE Company %")]),
+    "projects": env["project.project"].sudo().search_count([("name", "like", "FE Project %")]),
+    "contracts": env["construction.contract"].sudo().search_count([("subject", "like", "FE-% Contract")]),
+    "settlements": env["sc.settlement.order"].sudo().search_count([("name", "like", "FE-%-SET-001")]),
+    "payment_requests": env["payment.request"].sudo().search_count([("name", "like", "FE-%-PR-%")]),
+    "payment_executions": env["sc.payment.execution"].sudo().search_count([("name", "like", "FE-%-PE-001")]),
+}
+expected_counts = {
+    "companies": 2,
+    "projects": 3,
+    "contracts": 3,
+    "settlements": 3,
+    "payment_requests": 4,
+    "payment_executions": 3,
+}
+if counts != expected_counts:
+    fail("fixed object counts mismatch: %s" % counts)
+
+print("[verify.frontend.fixture] PASS")
+print(json.dumps({
+    "db": env.cr.dbname,
+    "login_results": login_results,
+    "counts": counts,
+    "member_visible_projects": member_projects.mapped("name"),
+    "member_direct_denials": denied,
+    "pm_assigned_projects": pm_projects.mapped("name"),
+    "pm_followed_projects": pm_followed_projects.mapped("name"),
+    "finance_company_a_requests": sorted(names_a),
+    "finance_company_b_requests": sorted(names_b),
+    "relations": "consistent",
+    "request_distribution": request_distribution,
+    "empty_filter": "payment.request state=cancel",
+}, ensure_ascii=False, indent=2))

--- a/scripts/verify/frontend_productization_fixture_browser.mjs
+++ b/scripts/verify/frontend_productization_fixture_browser.mjs
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { launchChromium } from './playwright_runtime.mjs';
+
+const BASE_URL = process.env.FRONTEND_URL || process.env.BASE_URL || 'http://127.0.0.1:18081';
+const DB_NAME = process.env.DB_NAME || 'sc_demo';
+const PASSWORD = process.env.ROLE_SMOKE_PASSWORD || 'demo';
+const OUTPUT_DIR = process.env.ARTIFACTS_DIR || 'artifacts/playwright/frontend-productization-fixture';
+const PAYMENT_ACTION_ID = Number(process.env.FRONTEND_FIXTURE_PAYMENT_ACTION_ID || 0);
+const PAYMENT_MENU_ID = Number(process.env.FRONTEND_FIXTURE_PAYMENT_MENU_ID || 0);
+
+fs.mkdirSync(OUTPUT_DIR, { recursive: true });
+
+function requireCheck(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+async function login(page, loginName) {
+  await page.goto(`${BASE_URL}/login`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+  const inputs = page.locator('input');
+  await inputs.nth(0).fill(loginName);
+  await inputs.nth(1).fill(PASSWORD);
+  if (await inputs.nth(2).isEnabled()) {
+    await inputs.nth(2).fill(DB_NAME);
+  } else {
+    requireCheck((await inputs.nth(2).inputValue()) === DB_NAME, 'configured login database mismatch');
+  }
+  await page.getByRole('button', { name: /^登录$/ }).click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 45000 });
+  await page.locator('.layout-shell').waitFor({ timeout: 45000 });
+}
+
+async function openAction(page, action) {
+  const target = action.menuId > 0
+    ? `/m/${action.menuId}?action_id=${action.actionId}`
+    : `/a/${action.actionId}`;
+  await page.goto(`${BASE_URL}${target}`, {
+    waitUntil: 'domcontentloaded',
+    timeout: 45000,
+  });
+  await page.locator('.layout-shell').waitFor({ timeout: 45000 });
+  await page.locator('section.page[data-product-page-mode="list"]').first().waitFor({ timeout: 45000 });
+  const loading = page.getByText('正在加载列表...', { exact: true }).last();
+  await loading.waitFor({ state: 'visible', timeout: 45000 });
+  await loading.waitFor({ state: 'hidden', timeout: 45000 });
+}
+
+async function openScene(page, sceneKey) {
+  await page.goto(`${BASE_URL}/s/${sceneKey}`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+  await page.locator('.layout-shell').waitFor({ timeout: 45000 });
+  await page.waitForFunction(() => {
+    const text = document.body.innerText || '';
+    return !text.includes('正在加载页面') && !text.includes('正在加载场景');
+  }, null, { timeout: 45000 });
+}
+
+async function bodyText(page) {
+  return page.locator('body').innerText();
+}
+
+async function selectCompany(page, companyName) {
+  const selector = page.locator('label.business-scope-field select').filter({
+    has: page.locator(`option:has-text("${companyName}")`),
+  }).first();
+  await selector.waitFor({ timeout: 30000 });
+  await selector.selectOption({ label: companyName });
+  await page.waitForTimeout(500);
+  await page.waitForFunction((name) => {
+    const select = [...document.querySelectorAll('label.business-scope-field select')]
+      .find((node) => [...node.options].some((option) => option.textContent?.trim() === name));
+    return select?.selectedOptions?.[0]?.textContent?.trim() === name;
+  }, companyName, { timeout: 30000 });
+}
+
+function actionableErrors(errors) {
+  return errors.filter((line) => !line.includes('favicon') && !line.includes('ResizeObserver'));
+}
+
+async function main() {
+  const browser = await launchChromium({ headless: true });
+  const result = { pass: false, base_url: BASE_URL, db: DB_NAME, checks: [], screenshots: [] };
+  try {
+    const finance = await browser.newPage({ viewport: { width: 1440, height: 900 }, locale: 'zh-CN' });
+    const financeErrors = [];
+    finance.on('console', (msg) => { if (msg.type() === 'error') financeErrors.push(msg.text()); });
+    finance.on('pageerror', (error) => financeErrors.push(error.message));
+    await login(finance, 'demo_role_finance');
+    requireCheck(PAYMENT_ACTION_ID > 0 && PAYMENT_MENU_ID > 0, 'fixture payment action context was not provided');
+    const paymentAction = { actionId: PAYMENT_ACTION_ID, menuId: PAYMENT_MENU_ID };
+    await openAction(finance, paymentAction);
+    await selectCompany(finance, 'FE Company A');
+    await finance.waitForFunction(() => (document.body.innerText || '').includes('FE-A-PR-001'), null, { timeout: 45000 });
+    let text = await bodyText(finance);
+    requireCheck(text.includes('FE-A-PR-001') && text.includes('FE-B-PR-001'), 'finance company A payment rows missing');
+    requireCheck(!text.includes('FE-C-PR-001'), 'finance company A leaked company B row');
+    const financeA = path.join(OUTPUT_DIR, 'finance-company-a-payments.png');
+    await finance.screenshot({ path: financeA, fullPage: true });
+    result.screenshots.push(financeA);
+
+    await selectCompany(finance, 'FE Company B');
+    await finance.waitForFunction(() => (document.body.innerText || '').includes('FE-C-PR-001'), null, { timeout: 30000 });
+    text = await bodyText(finance);
+    requireCheck(text.includes('FE-C-PR-001'), 'finance company B payment row missing');
+    requireCheck(!text.includes('FE-A-PR-001') && !text.includes('FE-B-PR-001'), 'finance company switch retained company A rows');
+    const financeB = path.join(OUTPUT_DIR, 'finance-company-b-payments.png');
+    await finance.screenshot({ path: financeB, fullPage: true });
+    result.screenshots.push(financeB);
+    requireCheck(actionableErrors(financeErrors).length === 0, `finance browser errors: ${actionableErrors(financeErrors).join(' | ')}`);
+    result.checks.push('finance_login', 'finance_company_a_isolation', 'finance_company_b_switch_refresh');
+    await finance.close();
+
+    const member = await browser.newPage({ viewport: { width: 1440, height: 900 }, locale: 'zh-CN' });
+    const memberErrors = [];
+    member.on('console', (msg) => { if (msg.type() === 'error') memberErrors.push(msg.text()); });
+    member.on('pageerror', (error) => memberErrors.push(error.message));
+    await login(member, 'demo_role_project_a_member');
+    await openScene(member, 'projects.list');
+    await member.waitForFunction(() => (document.body.innerText || '').includes('FE Project A'), null, { timeout: 45000 });
+    const memberText = await bodyText(member);
+    requireCheck(memberText.includes('FE Project A'), 'project A member cannot see FE Project A');
+    requireCheck(!memberText.includes('FE Project B') && !memberText.includes('FE Project C'), 'project A member sees out-of-scope project');
+    requireCheck(actionableErrors(memberErrors).length === 0, `member browser errors: ${actionableErrors(memberErrors).join(' | ')}`);
+    const memberShot = path.join(OUTPUT_DIR, 'project-a-member-projects.png');
+    await member.screenshot({ path: memberShot, fullPage: true });
+    result.screenshots.push(memberShot);
+    result.checks.push('project_a_member_login', 'project_a_member_project_isolation');
+    await member.close();
+    result.pass = true;
+  } finally {
+    await browser.close();
+    fs.writeFileSync(path.join(OUTPUT_DIR, 'report.json'), `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+  }
+  console.log('[verify.frontend.fixture.browser] PASS');
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error(`[verify.frontend.fixture.browser] FAIL ${error.stack || error.message}`);
+  process.exitCode = 2;
+});

--- a/scripts/verify/frontend_productization_fixture_runtime_ids.py
+++ b/scripts/verify/frontend_productization_fixture_runtime_ids.py
@@ -1,0 +1,6 @@
+"""Resolve database-local action ids for the browser fixture runner."""
+
+payment_action = env.ref("smart_construction_core.action_payment_request_user_payment_apply")
+payment_menu = env.ref("smart_construction_core.menu_sc_user_payment_apply_acceptance")
+print("FRONTEND_FIXTURE_PAYMENT_ACTION_ID=%s" % payment_action.id)
+print("FRONTEND_FIXTURE_PAYMENT_MENU_ID=%s" % payment_menu.id)

--- a/scripts/verify/role_surface_preflight.sh
+++ b/scripts/verify/role_surface_preflight.sh
@@ -28,6 +28,7 @@ required_logins = [
     "demo_role_owner",
     "demo_role_pm",
     "demo_role_finance",
+    "demo_role_project_a_member",
     "demo_role_executive",
 ]
 


### PR DESCRIPTION
## Summary
- Add an idempotent FE-PRE-01 fixture to the existing `smart_construction_demo` carrier.
- Provision fixed multi-company, multi-project, multi-role contract/settlement/payment chains without changing production modules or record rules.
- Add read-only permission/idempotency verification and real-browser company/project isolation smoke coverage.

## Fixed data
- companies: FE Company A, FE Company B
- projects: FE Project A, FE Project B, FE Project C
- roles: demo_role_finance, demo_role_project_a_member, demo_role_pm, demo_role_owner
- business records: 3 contracts, 3 settlements, 4 payment requests, 3 payment executions

## Verification
- `git diff --check`
- `make demo.frontend.fixture DB_NAME=sc_demo` (twice)
- `make verify.frontend.fixture DB_NAME=sc_demo`
- `make verify.portal.role_surface_preflight.container DB_NAME=sc_demo`
- `make ci.local.quick`
- `make ci` reached the repository-generated complexity report stale gate; refreshed it once and `make architecture.complexity_report` passed.
- Browser evidence: finance A/B payment isolation and project-A-member project isolation, with three screenshots under `artifacts/playwright/frontend-productization-fixture/`.

## Evidence
- artifacts: artifacts/codex/feature/frontend-productization-fixture

## Changes
```
addons/smart_construction_demo/data/demo/role_matrix_demo_users.xml
addons/smart_construction_demo/tools/__init__.py
addons/smart_construction_demo/tools/frontend_productization_fixture.py
docs/engineering_convergence/complexity_budget_report.md
make/runtime_ops.mk
scripts/demo/frontend_productization_fixture.sh
scripts/ops/ensure_role_surface_demo.sh
scripts/verify/frontend_productization_fixture.py
scripts/verify/frontend_productization_fixture_browser.mjs
scripts/verify/frontend_productization_fixture_runtime_ids.py
scripts/verify/role_surface_preflight.sh
```
