### PR TITLE
FE-P02：项目列表产品化

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -20,7 +20,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3187 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3191 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |
@@ -136,7 +136,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | split_plan_required | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | split_plan_required | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | split_plan_required | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3187 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3191 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | split_plan_required | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | split_plan_required | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -21,7 +21,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P1 | 3518 | Platform owner | `addons/smart_core/handlers/ui_contract_v2.py` | Extract parsing, validation, assembly, and response mapping into owned services. |
 | P1 | 3323 | Construction backend owner | `addons/smart_construction_core/tests/test_p0_state_closure.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
 | P1 | 3202 | Platform owner | `addons/smart_core/tests/test_form_field_configuration_params.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
-| P1 | 3187 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P1 | 3191 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3092 | Construction backend owner | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P1 | 3041 | Platform owner | `addons/smart_core/core/workspace_home_contract_builder.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P1 | 3013 | Platform owner | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` | Separate parser/assembler/dispatcher responsibilities and preserve backend source-of-truth boundary. |

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -1,6 +1,10 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 <template>
-  <section class="page sc-page sc-product-workspace-stack" data-product-page-mode="list">
+  <section
+    class="page sc-page sc-product-workspace-stack"
+    :class="{ 'sc-project-list-page': model === 'project.project' }"
+    data-product-page-mode="list"
+  >
     <PageHeader
       v-if="status !== 'ok' && status !== 'empty'"
       :title="title"

--- a/frontend/apps/web/src/styles/product-patterns.css
+++ b/frontend/apps/web/src/styles/product-patterns.css
@@ -365,6 +365,25 @@
   justify-content: flex-end;
 }
 
+/* FE-P02: stable visual identity for the contract-driven project list. */
+.sc-project-list-page .list-toolbar {
+  border-bottom: 1px solid var(--sc-app-border-strong);
+}
+
+.sc-project-list-page .list-title h2 {
+  letter-spacing: -0.01em;
+}
+
+.sc-project-list-page .table {
+  border-color: var(--sc-app-border);
+}
+
+@media (max-width: 900px) {
+  .sc-project-list-page .list-header-toolbar {
+    width: 100%;
+  }
+}
+
 .sc-product-panel-gap {
   gap: var(--sc-product-panel-gap);
 }


### PR DESCRIPTION
FE-P02 单页切片：项目列表产品化。

- 复用现有契约驱动列表、筛选、状态与权限边界
- 为项目列表建立稳定页面标识与产品化视觉密度
- 不修改后端、API、权限或业务语义

L0：typecheck、lint、diff check 已通过。
L1：等待相关浏览器旅程与远端 quality gate。