### PR TITLE
FE-P03：项目详情只读概览

### DIFF
--- a/frontend/apps/web/src/styles/product-patterns.css
+++ b/frontend/apps/web/src/styles/product-patterns.css
@@ -378,6 +378,16 @@
   border-color: var(--sc-app-border);
 }
 
+/* FE-P03: project details are an intentionally read-only overview surface. */
+.sc-project-detail-page .sc-product-main-surface {
+  border-color: var(--sc-app-border);
+  box-shadow: none;
+}
+
+.sc-project-detail-page .record-l1 {
+  border-bottom: 1px solid var(--sc-app-border);
+}
+
 @media (max-width: 900px) {
   .sc-project-list-page .list-header-toolbar {
     width: 100%;

--- a/frontend/apps/web/src/views/RecordView.vue
+++ b/frontend/apps/web/src/views/RecordView.vue
@@ -1,5 +1,9 @@
 <template>
-  <section class="page sc-page sc-product-workspace-stack" data-product-page-mode="detail">
+  <section
+    class="page sc-page sc-product-workspace-stack"
+    :class="{ 'sc-project-detail-page': model === 'project.project' }"
+    data-product-page-mode="detail"
+  >
     <!-- Page intent: surface record status, risks, metrics, and next actions. -->
     <header class="header sc-product-page-header">
       <div>
@@ -32,7 +36,7 @@
         </button>
         <span class="pill" :class="statusTone">{{ statusLabel }}</span>
         <button class="ghost" @click="goBack">{{ pageText('action_back', 'Back') }}</button>
-        <button v-if="status === 'ok' && canEdit" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
+        <button v-if="status === 'ok' && canEdit && model !== 'project.project'" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
         <button v-if="status === 'editing'" :disabled="isSaveDisabled" @click="save">{{ pageText('action_save', 'Save') }}</button>
         <button v-if="status === 'editing'" class="ghost" @click="cancelEdit">{{ pageText('action_cancel', 'Cancel') }}</button>
         <button class="ghost" :disabled="status === 'loading' || status === 'saving'" @click="reload">{{ pageText('action_reload', 'Reload') }}</button>


### PR DESCRIPTION
FE-P03 单页切片：项目详情首屏只读概览。

- 复用现有真实字段、关联入口与权限上下文
- 项目详情明确为只读概览，不新增接口或编辑语义
- 保持现有加载、错误、空状态

L0：diff check、typecheck、lint 已通过。