### PR TITLE
FE-B01：项目与合同业务工作区产品化

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -5,8 +5,8 @@ Generated from repository source files. This report is informational during the 
 ## Summary
 
 - Scanned files: `3947`
-- Files requiring split plan: `41`
-- Files above warning threshold: `65`
+- Files requiring split plan: `42`
+- Files above warning threshold: `64`
 
 ## Split Plan Required
 
@@ -20,7 +20,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3191 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3194 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |
@@ -51,6 +51,7 @@ Generated from repository source files. This report is informational during the 
 | 1552 | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |
+| 1506 | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
 | 599 | Shell script | `scripts/audit/smoke_role_matrix.sh` |
 | 551 | Shell script | `scripts/ops/audit_project_actions.sh` |
 
@@ -60,7 +61,6 @@ Generated from repository source files. This report is informational during the 
 | ---: | --- | --- |
 | 2054 | XML data/view | `addons/smart_construction_core/security/sc_record_rules.xml` |
 | 1807 | XML data/view | `addons/smart_construction_core/data/business_category_seed.xml` |
-| 1499 | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
 | 1490 | Python source | `addons/smart_construction_core/models/support/workflow_contract_service.py` |
 | 1488 | JavaScript source | `addons/smart_construction_core/static/src/js/sc_sidebar.js` |
 | 1486 | Vue source | `frontend/apps/web/src/views/BusinessConfigSurfaceView.vue` |
@@ -136,7 +136,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | split_plan_required | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | split_plan_required | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | split_plan_required | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3191 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3194 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | split_plan_required | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | split_plan_required | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |
@@ -169,7 +169,7 @@ Generated from repository source files. This report is informational during the 
 | 1552 | split_plan_required | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | split_plan_required | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |
-| 1499 | warning | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
+| 1506 | split_plan_required | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
 | 1490 | warning | Python source | `addons/smart_construction_core/models/support/workflow_contract_service.py` |
 | 1488 | warning | JavaScript source | `addons/smart_construction_core/static/src/js/sc_sidebar.js` |
 | 1486 | warning | Vue source | `frontend/apps/web/src/views/BusinessConfigSurfaceView.vue` |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -4,10 +4,10 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 
 ## Summary
 
-- Split-plan files: `41`
+- Split-plan files: `42`
 - P0: `1`
 - P1: `21`
-- P2: `19`
+- P2: `20`
 
 ## Queue
 
@@ -21,7 +21,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P1 | 3518 | Platform owner | `addons/smart_core/handlers/ui_contract_v2.py` | Extract parsing, validation, assembly, and response mapping into owned services. |
 | P1 | 3323 | Construction backend owner | `addons/smart_construction_core/tests/test_p0_state_closure.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
 | P1 | 3202 | Platform owner | `addons/smart_core/tests/test_form_field_configuration_params.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
-| P1 | 3191 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P1 | 3194 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3092 | Construction backend owner | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P1 | 3041 | Platform owner | `addons/smart_core/core/workspace_home_contract_builder.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P1 | 3013 | Platform owner | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` | Separate parser/assembler/dispatcher responsibilities and preserve backend source-of-truth boundary. |
@@ -52,6 +52,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P2 | 1597 | Construction backend owner | `addons/smart_construction_core/models/support/direct_acceptance_formal_visible_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1555 | Construction backend owner | `addons/smart_construction_core/models/support/contract_center.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1523 | Construction backend owner | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
+| P2 | 1506 | Frontend owner | `frontend/apps/web/src/views/RecordView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P2 | 599 | DevOps owner | `scripts/audit/smoke_role_matrix.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |
 | P2 | 551 | DevOps owner | `scripts/ops/audit_project_actions.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |
 

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -2,7 +2,10 @@
 <template>
   <section
     class="page sc-page sc-product-workspace-stack"
-    :class="{ 'sc-project-list-page': model === 'project.project' }"
+    :class="{
+      'sc-project-list-page': model === 'project.project',
+      'sc-contract-list-page': model === 'construction.contract',
+    }"
     data-product-page-mode="list"
   >
     <PageHeader

--- a/frontend/apps/web/src/styles/product-patterns.css
+++ b/frontend/apps/web/src/styles/product-patterns.css
@@ -378,6 +378,20 @@
   border-color: var(--sc-app-border);
 }
 
+/* FE-B01: contracts use the same dense list language and context boundary. */
+.sc-contract-list-page .list-toolbar,
+.sc-contract-detail-page .sc-product-main-surface {
+  border-color: var(--sc-app-border);
+}
+
+.sc-contract-list-page .table {
+  border-radius: var(--sc-component-table-radius);
+}
+
+.sc-contract-detail-page .sc-product-main-surface {
+  box-shadow: none;
+}
+
 /* FE-P03: project details are an intentionally read-only overview surface. */
 .sc-project-detail-page .sc-product-main-surface {
   border-color: var(--sc-app-border);

--- a/frontend/apps/web/src/styles/product-patterns.css
+++ b/frontend/apps/web/src/styles/product-patterns.css
@@ -378,6 +378,16 @@
   border-color: var(--sc-app-border);
 }
 
+/* FE-P03: project details are an intentionally read-only overview surface. */
+.sc-project-detail-page .sc-product-main-surface {
+  border-color: var(--sc-app-border);
+  box-shadow: none;
+}
+
+.sc-project-detail-page .record-l1 {
+  border-bottom: 1px solid var(--sc-app-border);
+}
+
 @media (max-width: 900px) {
   .sc-project-list-page .list-header-toolbar {
     width: 100%;

--- a/frontend/apps/web/src/views/RecordView.vue
+++ b/frontend/apps/web/src/views/RecordView.vue
@@ -1,7 +1,10 @@
 <template>
   <section
     class="page sc-page sc-product-workspace-stack"
-    :class="{ 'sc-project-detail-page': model === 'project.project' }"
+    :class="{
+      'sc-project-detail-page': model === 'project.project',
+      'sc-contract-detail-page': model === 'construction.contract',
+    }"
     data-product-page-mode="detail"
   >
     <!-- Page intent: surface record status, risks, metrics, and next actions. -->
@@ -36,7 +39,7 @@
         </button>
         <span class="pill" :class="statusTone">{{ statusLabel }}</span>
         <button class="ghost" @click="goBack">{{ pageText('action_back', 'Back') }}</button>
-        <button v-if="status === 'ok' && canEdit && model !== 'project.project'" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
+        <button v-if="status === 'ok' && canEdit && !['project.project', 'construction.contract'].includes(model)" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
         <button v-if="status === 'editing'" :disabled="isSaveDisabled" @click="save">{{ pageText('action_save', 'Save') }}</button>
         <button v-if="status === 'editing'" class="ghost" @click="cancelEdit">{{ pageText('action_cancel', 'Cancel') }}</button>
         <button class="ghost" :disabled="status === 'loading' || status === 'saving'" @click="reload">{{ pageText('action_reload', 'Reload') }}</button>

--- a/frontend/apps/web/src/views/RecordView.vue
+++ b/frontend/apps/web/src/views/RecordView.vue
@@ -1,5 +1,9 @@
 <template>
-  <section class="page sc-page sc-product-workspace-stack" data-product-page-mode="detail">
+  <section
+    class="page sc-page sc-product-workspace-stack"
+    :class="{ 'sc-project-detail-page': model === 'project.project' }"
+    data-product-page-mode="detail"
+  >
     <!-- Page intent: surface record status, risks, metrics, and next actions. -->
     <header class="header sc-product-page-header">
       <div>
@@ -32,7 +36,7 @@
         </button>
         <span class="pill" :class="statusTone">{{ statusLabel }}</span>
         <button class="ghost" @click="goBack">{{ pageText('action_back', 'Back') }}</button>
-        <button v-if="status === 'ok' && canEdit" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
+        <button v-if="status === 'ok' && canEdit && model !== 'project.project'" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
         <button v-if="status === 'editing'" :disabled="isSaveDisabled" @click="save">{{ pageText('action_save', 'Save') }}</button>
         <button v-if="status === 'editing'" class="ghost" @click="cancelEdit">{{ pageText('action_cancel', 'Cancel') }}</button>
         <button class="ghost" :disabled="status === 'loading' || status === 'saving'" @click="reload">{{ pageText('action_reload', 'Reload') }}</button>


### PR DESCRIPTION
FE-B01 统一业务域批次：项目列表、项目详情只读概览、合同列表与合同详情只读概览。

范围：仅自定义前端与产品化样式；复用现有契约、导航、权限和状态语义，不修改后端/API/fixture。

验收：
- 固定验收库浏览器旅程通过（sc_frontend_acceptance，finance/project member 隔离）
- 前端 build、lint、typecheck 通过
- make ci.local.quick 通过
- make ci 通过

前序 FE-P02 已经作为 #1064 合并；本 PR 汇总其后续项目详情与合同工作区改造。