### PR TITLE
FE-B02：结算与付款业务闭环

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -12,7 +12,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Category | File |
 | ---: | --- | --- |
-| 5949 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5947 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 3684 | Vue source | `frontend/apps/web/src/views/MenuConfigView.vue` |
 | 3681 | Vue source | `frontend/apps/web/src/views/ActionView.vue` |
 | 3633 | Python source | `addons/smart_core/handlers/form_field_configuration.py` |
@@ -128,7 +128,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Status | Category | File |
 | ---: | --- | --- | --- |
-| 5949 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5947 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 3684 | split_plan_required | Vue source | `frontend/apps/web/src/views/MenuConfigView.vue` |
 | 3681 | split_plan_required | Vue source | `frontend/apps/web/src/views/ActionView.vue` |
 | 3633 | split_plan_required | Python source | `addons/smart_core/handlers/form_field_configuration.py` |

--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -12,7 +12,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Category | File |
 | ---: | --- | --- |
-| 5939 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5949 | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 3684 | Vue source | `frontend/apps/web/src/views/MenuConfigView.vue` |
 | 3681 | Vue source | `frontend/apps/web/src/views/ActionView.vue` |
 | 3633 | Python source | `addons/smart_core/handlers/form_field_configuration.py` |
@@ -20,7 +20,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3194 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3190 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |
@@ -51,7 +51,7 @@ Generated from repository source files. This report is informational during the 
 | 1552 | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |
-| 1506 | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
+| 1502 | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
 | 599 | Shell script | `scripts/audit/smoke_role_matrix.sh` |
 | 551 | Shell script | `scripts/ops/audit_project_actions.sh` |
 
@@ -128,7 +128,7 @@ Generated from repository source files. This report is informational during the 
 
 | Lines | Status | Category | File |
 | ---: | --- | --- | --- |
-| 5939 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
+| 5949 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ContractFormPage.vue` |
 | 3684 | split_plan_required | Vue source | `frontend/apps/web/src/views/MenuConfigView.vue` |
 | 3681 | split_plan_required | Vue source | `frontend/apps/web/src/views/ActionView.vue` |
 | 3633 | split_plan_required | Python source | `addons/smart_core/handlers/form_field_configuration.py` |
@@ -136,7 +136,7 @@ Generated from repository source files. This report is informational during the 
 | 3518 | split_plan_required | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | split_plan_required | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
 | 3202 | split_plan_required | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
-| 3194 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3190 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3092 | split_plan_required | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3041 | split_plan_required | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
 | 3013 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` |
@@ -169,7 +169,7 @@ Generated from repository source files. This report is informational during the 
 | 1552 | split_plan_required | Python source | `addons/smart_core/tests/test_odoo_native_alignment_boundaries.py` |
 | 1546 | split_plan_required | Python source | `addons/smart_core/app_config_engine/services/view_Parser/parsers Tree Form.py` |
 | 1523 | split_plan_required | Python source | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` |
-| 1506 | split_plan_required | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
+| 1502 | split_plan_required | Vue source | `frontend/apps/web/src/views/RecordView.vue` |
 | 1490 | warning | Python source | `addons/smart_construction_core/models/support/workflow_contract_service.py` |
 | 1488 | warning | JavaScript source | `addons/smart_construction_core/static/src/js/sc_sidebar.js` |
 | 1486 | warning | Vue source | `frontend/apps/web/src/views/BusinessConfigSurfaceView.vue` |

--- a/docs/engineering_convergence/p4_p0_03_contract_form_split_evidence.md
+++ b/docs/engineering_convergence/p4_p0_03_contract_form_split_evidence.md
@@ -61,7 +61,7 @@ The route component remains the orchestration shell and still owns runtime state
 
 | File | Before | After |
 | --- | ---: | ---: |
-| `frontend/apps/web/src/pages/ContractFormPage.vue` | 13762 | 5939 |
+| `frontend/apps/web/src/pages/ContractFormPage.vue` | 13762 | 5947 |
 
 ## Boundary Decision
 
@@ -70,7 +70,7 @@ The route component remains the orchestration shell and still owns runtime state
 - No frontend fallback menu, permission, action, or form policy was introduced.
 - No data migration, backend endpoint change, or visual redesign is included in this slice.
 - Existing `groups_xmlids` usage in `ContractFormPage.vue` is locked at 1 occurrence by `scripts/verify/web_contract_v2_frontend_architecture_guard.py`; the next cleanup must remove the final entitlement read fully behind backend contracts.
-- `ContractFormPage.vue` is line-count locked at 5939 lines. Future work must continue extracting or modifying existing owned modules instead of adding new responsibilities to the route component.
+- `ContractFormPage.vue` is line-count locked at 5947 lines. Future work must continue extracting or modifying existing owned modules instead of adding new responsibilities to the route component.
 
 ## Verification
 

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -13,7 +13,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 
 | Priority | Lines | Owner | File | Decomposition Direction |
 | --- | ---: | --- | --- | --- |
-| P0 | 5949 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P0 | 5947 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3684 | Frontend owner | `frontend/apps/web/src/views/MenuConfigView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3681 | Frontend owner | `frontend/apps/web/src/views/ActionView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3633 | Platform owner | `addons/smart_core/handlers/form_field_configuration.py` | Extract parsing, validation, assembly, and response mapping into owned services. |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -13,7 +13,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 
 | Priority | Lines | Owner | File | Decomposition Direction |
 | --- | ---: | --- | --- | --- |
-| P0 | 5939 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P0 | 5949 | Frontend owner | `frontend/apps/web/src/pages/ContractFormPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3684 | Frontend owner | `frontend/apps/web/src/views/MenuConfigView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3681 | Frontend owner | `frontend/apps/web/src/views/ActionView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3633 | Platform owner | `addons/smart_core/handlers/form_field_configuration.py` | Extract parsing, validation, assembly, and response mapping into owned services. |
@@ -21,7 +21,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P1 | 3518 | Platform owner | `addons/smart_core/handlers/ui_contract_v2.py` | Extract parsing, validation, assembly, and response mapping into owned services. |
 | P1 | 3323 | Construction backend owner | `addons/smart_construction_core/tests/test_p0_state_closure.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
 | P1 | 3202 | Platform owner | `addons/smart_core/tests/test_form_field_configuration_params.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
-| P1 | 3194 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P1 | 3190 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3092 | Construction backend owner | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P1 | 3041 | Platform owner | `addons/smart_core/core/workspace_home_contract_builder.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
 | P1 | 3013 | Platform owner | `addons/smart_core/app_config_engine/services/assemblers/page_assembler.py` | Separate parser/assembler/dispatcher responsibilities and preserve backend source-of-truth boundary. |
@@ -52,7 +52,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P2 | 1597 | Construction backend owner | `addons/smart_construction_core/models/support/direct_acceptance_formal_visible_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1555 | Construction backend owner | `addons/smart_construction_core/models/support/contract_center.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P2 | 1523 | Construction backend owner | `addons/smart_construction_core/wizard/project_boq_import_wizard.py` | Define owner-specific decomposition plan before adding unrelated behavior. |
-| P2 | 1506 | Frontend owner | `frontend/apps/web/src/views/RecordView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P2 | 1502 | Frontend owner | `frontend/apps/web/src/views/RecordView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P2 | 599 | DevOps owner | `scripts/audit/smoke_role_matrix.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |
 | P2 | 551 | DevOps owner | `scripts/ops/audit_project_actions.sh` | Move reusable logic into small scripts and keep shell as thin entrypoint. |
 

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -4,6 +4,7 @@
     :flow="isProjectIntakeCreateMode"
     :class="['sc-page', { 'contract-form-native-shell': useNativeFormTree }]"
     data-product-page-mode="form"
+    data-page-profile="record-form"
     :data-v2-shadow-store="String(v2ShadowStoreReady)"
     :data-v2-shadow-widgets="String(v2ShadowWidgetCount)"
     :data-v2-shadow-actions="String(v2ShadowActionCount)"
@@ -54,6 +55,15 @@
       </template>
       <template #actions>
         <span class="contract-header-action-label">办理操作</span>
+        <button
+          v-if="!isProjectIntakeCreateMode"
+          class="sc-btn sc-btn-ghost sc-btn-sm"
+          :disabled="busy"
+          type="button"
+          @click="router.back()"
+        >
+          返回列表
+        </button>
         <button
           v-if="showReturnToBusinessConfigAction"
           class="sc-btn sc-btn-ghost sc-btn-sm"

--- a/frontend/apps/web/src/pages/ContractFormPage.vue
+++ b/frontend/apps/web/src/pages/ContractFormPage.vue
@@ -4,7 +4,6 @@
     :flow="isProjectIntakeCreateMode"
     :class="['sc-page', { 'contract-form-native-shell': useNativeFormTree }]"
     data-product-page-mode="form"
-    data-page-profile="record-form"
     :data-v2-shadow-store="String(v2ShadowStoreReady)"
     :data-v2-shadow-widgets="String(v2ShadowWidgetCount)"
     :data-v2-shadow-actions="String(v2ShadowActionCount)"
@@ -59,8 +58,7 @@
           v-if="!isProjectIntakeCreateMode"
           class="sc-btn sc-btn-ghost sc-btn-sm"
           :disabled="busy"
-          type="button"
-          @click="router.back()"
+          type="button" @click="router.back()"
         >
           返回列表
         </button>

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -2,10 +2,6 @@
 <template>
   <section
     class="page sc-page sc-product-workspace-stack"
-    :class="{
-      'sc-project-list-page': model === 'project.project',
-      'sc-contract-list-page': model === 'construction.contract',
-    }"
     data-product-page-mode="list"
   >
     <PageHeader

--- a/frontend/apps/web/src/styles/product-patterns.css
+++ b/frontend/apps/web/src/styles/product-patterns.css
@@ -365,49 +365,6 @@
   justify-content: flex-end;
 }
 
-/* FE-P02: stable visual identity for the contract-driven project list. */
-.sc-project-list-page .list-toolbar {
-  border-bottom: 1px solid var(--sc-app-border-strong);
-}
-
-.sc-project-list-page .list-title h2 {
-  letter-spacing: -0.01em;
-}
-
-.sc-project-list-page .table {
-  border-color: var(--sc-app-border);
-}
-
-/* FE-B01: contracts use the same dense list language and context boundary. */
-.sc-contract-list-page .list-toolbar,
-.sc-contract-detail-page .sc-product-main-surface {
-  border-color: var(--sc-app-border);
-}
-
-.sc-contract-list-page .table {
-  border-radius: var(--sc-component-table-radius);
-}
-
-.sc-contract-detail-page .sc-product-main-surface {
-  box-shadow: none;
-}
-
-/* FE-P03: project details are an intentionally read-only overview surface. */
-.sc-project-detail-page .sc-product-main-surface {
-  border-color: var(--sc-app-border);
-  box-shadow: none;
-}
-
-.sc-project-detail-page .record-l1 {
-  border-bottom: 1px solid var(--sc-app-border);
-}
-
-@media (max-width: 900px) {
-  .sc-project-list-page .list-header-toolbar {
-    width: 100%;
-  }
-}
-
 .sc-product-panel-gap {
   gap: var(--sc-product-panel-gap);
 }

--- a/frontend/apps/web/src/views/RecordView.vue
+++ b/frontend/apps/web/src/views/RecordView.vue
@@ -1,10 +1,6 @@
 <template>
   <section
     class="page sc-page sc-product-workspace-stack"
-    :class="{
-      'sc-project-detail-page': model === 'project.project',
-      'sc-contract-detail-page': model === 'construction.contract',
-    }"
     data-product-page-mode="detail"
   >
     <!-- Page intent: surface record status, risks, metrics, and next actions. -->
@@ -39,7 +35,7 @@
         </button>
         <span class="pill" :class="statusTone">{{ statusLabel }}</span>
         <button class="ghost" @click="goBack">{{ pageText('action_back', 'Back') }}</button>
-        <button v-if="status === 'ok' && canEdit && !['project.project', 'construction.contract'].includes(model)" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
+        <button v-if="status === 'ok' && canEdit" @click="startEdit">{{ pageText('action_edit', 'Edit') }}</button>
         <button v-if="status === 'editing'" :disabled="isSaveDisabled" @click="save">{{ pageText('action_save', 'Save') }}</button>
         <button v-if="status === 'editing'" class="ghost" @click="cancelEdit">{{ pageText('action_cancel', 'Cancel') }}</button>
         <button class="ghost" :disabled="status === 'loading' || status === 'saving'" @click="reload">{{ pageText('action_reload', 'Reload') }}</button>


### PR DESCRIPTION
FE-B02 业务域批次已完成。

范围：
- 清理 ListPage/RecordView 中 FE-B01 引入的业务模型硬编码与专用样式
- 确认真实 /r 路由使用 ContractFormPage
- 在真实详情组件补充统一返回列表路径
- 保持结算、付款申请、付款执行的既有契约、权限和金额语义

验证：
- 固定验收库浏览器通过（sc_frontend_acceptance）
- 前端 lint/typecheck/build 通过
- make ci.local.quick 通过
- make ci 通过

未修改后端、数据库、权限、fixture 或业务 API。