### PR TITLE
fix(frontend): recover from stale deployment chunks

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -4,7 +4,7 @@ Generated from repository source files. This report is informational during the 
 
 ## Summary
 
-- Scanned files: `4012`
+- Scanned files: `4013`
 - Files requiring split plan: `42`
 - Files above warning threshold: `64`
 

--- a/frontend/apps/web/src/app/staleAssetRecovery.ts
+++ b/frontend/apps/web/src/app/staleAssetRecovery.ts
@@ -1,0 +1,26 @@
+const RECOVERY_STORAGE_KEY = 'sc_stale_asset_recovery_at';
+const RECOVERY_COOLDOWN_MS = 60_000;
+
+type BrowserRuntime = Pick<Window, 'addEventListener' | 'location' | 'sessionStorage'>;
+
+function recoveryAllowed(runtime: BrowserRuntime, now: number): boolean {
+  const previous = Number(runtime.sessionStorage.getItem(RECOVERY_STORAGE_KEY) || 0);
+  return !Number.isFinite(previous) || previous <= 0 || now - previous >= RECOVERY_COOLDOWN_MS;
+}
+
+/**
+ * Vite emits `vite:preloadError` when an already-open page requests a hashed
+ * lazy chunk that disappeared during a new deployment. Reload the document
+ * once so it receives the current asset manifest instead of presenting the
+ * failure as a backend/network outage.
+ */
+export function installStaleAssetRecovery(runtime: BrowserRuntime = window, now: () => number = Date.now): void {
+  runtime.addEventListener('vite:preloadError', (event) => {
+    event.preventDefault();
+    const occurredAt = now();
+    if (!recoveryAllowed(runtime, occurredAt)) return;
+    runtime.sessionStorage.setItem(RECOVERY_STORAGE_KEY, String(occurredAt));
+    runtime.location.reload();
+  });
+}
+

--- a/frontend/apps/web/src/main.ts
+++ b/frontend/apps/web/src/main.ts
@@ -6,6 +6,9 @@ import App from './App.vue';
 import './styles/design-system.css';
 import './styles/product-patterns.css';
 import { bootTheme } from './styles/theme';
+import { installStaleAssetRecovery } from './app/staleAssetRecovery';
+
+installStaleAssetRecovery();
 
 const app = createApp(App);
 


### PR DESCRIPTION
## Summary
- reload an already-open SPA once when Vite reports a missing lazy chunk after deployment
- guard the recovery with a session cooldown to prevent reload loops

## Root cause
The daily development server served the current build, but an old browser tab requested the previous MenuConfigView chunk and received 404. Login and system.init both succeeded, while the stale chunk failure was presented as a network error.

## Validation
- `pnpm -C frontend/apps/web typecheck:strict`
- `pnpm -C frontend/apps/web build`
- Playwright dispatch of `vite:preloadError`: first event reloads, repeated event is blocked
- `git diff --check`