### PR TITLE
fix(ci): catch stale generated reports before push

### DIFF
--- a/docs/engineering_convergence/action_view_responsibility_map.md
+++ b/docs/engineering_convergence/action_view_responsibility_map.md
@@ -3,7 +3,7 @@
 Date: 2026-07-14
 Owner: Frontend owner
 Target file: `frontend/apps/web/src/views/ActionView.vue`
-Current size: 3,681 lines
+Current size: 3,684 lines
 Phase: Stage 6 business category create nav query split
 
 ## Purpose
@@ -150,7 +150,7 @@ Stage 6 is complete:
   `buildBusinessCategoryCreateNavQuery` helper;
 - `ActionView.vue` keeps `createRouteQueryForBusinessCategory` as carry-query
   orchestration only;
-- `ActionView.vue` is locked at `<=3681` lines;
+- `ActionView.vue` is locked at `<=3684` lines; the three-line increase records the responsive width containment added in PR `#1081` and must not become a new growth allowance;
 - no router, API, session, lifecycle, window, or notification side effects were
   moved.
 

--- a/make/ci.mk
+++ b/make/ci.mk
@@ -672,13 +672,33 @@ verify.unified_page_contract.lite: guard.prod.forbid
 # ----------------------------------------------------------------------
 # v1.1 Engineering Convergence quality entries
 # ----------------------------------------------------------------------
-.PHONY: ci ci.local.quick test.frontend test.unit test.odoo.integration test.contract test.e2e.preflight test.e2e.fixed_data.odoo test.e2e test.all test.inventory test.inventory.summary test.e2e.matrix architecture.module_dependency_map architecture.complexity_report architecture.complexity_baseline_lock architecture.split_plan_queue github.remote_execution_plan security.secrets.scan
+.PHONY: ci ci.local.quick ci.generated_reports.guard refresh.generated_reports test.frontend test.unit test.odoo.integration test.contract test.e2e.preflight test.e2e.fixed_data.odoo test.e2e test.all test.inventory test.inventory.summary test.e2e.matrix architecture.module_dependency_map architecture.complexity_report architecture.complexity_baseline_lock architecture.split_plan_queue github.remote_execution_plan security.secrets.scan
 
-ci: guard.prod.forbid security.secrets.scan test.inventory test.inventory.summary test.e2e.matrix architecture.module_dependency_map architecture.complexity_report architecture.complexity_baseline_lock architecture.split_plan_queue verify.unified_page_contract.v2.web_architecture github.remote_execution_plan test.unit test.frontend test.contract test.e2e.preflight
+ci: guard.prod.forbid security.secrets.scan ci.generated_reports.guard architecture.complexity_baseline_lock verify.unified_page_contract.v2.web_architecture test.unit test.frontend test.contract test.e2e.preflight
 	@git diff --check
 	@echo "[OK] v1.1 PR quality gate passed"
 
-ci.local.quick: guard.prod.forbid architecture.complexity_baseline_lock verify.unified_page_contract.v2.web_architecture
+ci.generated_reports.guard: guard.prod.forbid
+	@python3 scripts/ci/generate_test_inventory.py
+	@python3 scripts/ci/summarize_test_inventory.py
+	@python3 scripts/ci/generate_e2e_journey_matrix.py
+	@python3 scripts/ci/generate_module_dependency_map.py
+	@python3 scripts/ci/generate_complexity_budget_report.py
+	@python3 scripts/ci/generate_split_plan_queue.py
+	@python3 scripts/ci/generate_github_remote_execution_plan.py
+	@echo "[OK] tracked generated reports are current"
+
+refresh.generated_reports: guard.prod.forbid
+	@python3 scripts/ci/generate_test_inventory.py --write
+	@python3 scripts/ci/summarize_test_inventory.py --write
+	@python3 scripts/ci/generate_e2e_journey_matrix.py --write
+	@python3 scripts/ci/generate_module_dependency_map.py --write
+	@python3 scripts/ci/generate_complexity_budget_report.py --write
+	@python3 scripts/ci/generate_split_plan_queue.py --write
+	@python3 scripts/ci/generate_github_remote_execution_plan.py --write
+	@echo "[OK] tracked generated reports refreshed; review and commit any changes before push"
+
+ci.local.quick: guard.prod.forbid ci.generated_reports.guard architecture.complexity_baseline_lock verify.unified_page_contract.v2.web_architecture
 	@python3 scripts/ci/verify_contract_form_split_evidence.py
 	@python3 scripts/verify/contract_form_runtime_state_protocol_guard.py
 	@scripts/verify/contract_form_runtime_state_behavior_guard.sh

--- a/scripts/ops/git_safe_push.sh
+++ b/scripts/ops/git_safe_push.sh
@@ -56,12 +56,19 @@ if [[ "${GIT_SAFE_PUSH_FAKE_GIT:-0}" == "1" && "$(basename "$0")" == "git" ]]; t
   exit $?
 fi
 
+if [[ "${GIT_SAFE_PUSH_FAKE_MAKE:-0}" == "1" && "$(basename "$0")" == "make" ]]; then
+  printf 'make %s\n' "$*" >>"${FAKE_GIT_LOG:?}"
+  [[ "${FAKE_GENERATED_REPORTS_STALE:-0}" != "1" ]]
+  exit $?
+fi
+
 if [[ "${1:-}" == "--self-test" ]]; then
   self="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
   tmp_dir="$(mktemp -d)"
   trap 'rm -rf "$tmp_dir"' EXIT
   mkdir -p "$tmp_dir/bin"
   ln -s "$self" "$tmp_dir/bin/git"
+  ln -s "$self" "$tmp_dir/bin/make"
   log_file="$tmp_dir/git.log"
   output=''
   status=0
@@ -72,6 +79,7 @@ if [[ "${1:-}" == "--self-test" ]]; then
     output="$(
       PATH="$tmp_dir/bin:$PATH" \
         GIT_SAFE_PUSH_FAKE_GIT=1 \
+        GIT_SAFE_PUSH_FAKE_MAKE=1 \
         FAKE_GIT_LOG="$log_file" \
         FAKE_BRANCH="${FAKE_BRANCH:-fix/test-branch}" \
         FAKE_MISSING_REMOTES="${FAKE_MISSING_REMOTES:-}" \
@@ -80,6 +88,7 @@ if [[ "${1:-}" == "--self-test" ]]; then
         FAKE_PUSH_FAIL_REMOTES="${FAKE_PUSH_FAIL_REMOTES:-}" \
         FAKE_DIRTY="${FAKE_DIRTY:-0}" \
         FAKE_INVALID_BRANCH="${FAKE_INVALID_BRANCH:-0}" \
+        FAKE_GENERATED_REPORTS_STALE="${FAKE_GENERATED_REPORTS_STALE:-0}" \
         bash "$self" 2>&1
     )"
     status=$?
@@ -107,6 +116,12 @@ if [[ "${1:-}" == "--self-test" ]]; then
   assert_nonzero 'origin inaccessible'; assert_output 'origin inaccessible' "remote 'origin' is not accessible"; assert_push_count 'origin inaccessible' 0
   FAKE_INACCESSIBLE_REMOTES=gitee run_push
   assert_nonzero 'gitee inaccessible'; assert_output 'gitee inaccessible' "remote 'gitee' is not accessible"; assert_push_count 'gitee inaccessible' 0
+
+  FAKE_GENERATED_REPORTS_STALE=1 run_push
+  assert_nonzero 'stale generated reports'
+  assert_output 'stale generated reports' "generated reports are stale"
+  assert_push_count 'stale generated reports' 0
+  grep -q '^make --no-print-directory ci.generated_reports.guard$' "$log_file" || fail 'stale generated reports: local guard missing'
 
   FAKE_EXISTING_REMOTES='origin gitee' run_push
   assert_zero 'existing branches'; assert_push_count 'existing branches' 2
@@ -137,7 +152,7 @@ if [[ "${1:-}" == "--self-test" ]]; then
   FAKE_INVALID_BRANCH=1 run_push
   assert_nonzero 'invalid branch name'; assert_output 'invalid branch name' 'invalid local branch name'; assert_push_count 'invalid branch name' 0
 
-  printf 'PASS: git_safe_push isolated scenarios=11 (no real remotes)\n'
+  printf 'PASS: git_safe_push isolated scenarios=12 (no real remotes)\n'
   exit 0
 fi
 
@@ -164,6 +179,12 @@ fi
 
 if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
   echo "❌ working tree dirty; commit or stash before push" >&2
+  exit 2
+fi
+
+echo "[pr.push] verifying tracked generated reports before remote access"
+if ! make --no-print-directory ci.generated_reports.guard; then
+  echo "❌ generated reports are stale; run 'make refresh.generated_reports', review, and commit the result before pushing" >&2
   exit 2
 fi
 

--- a/scripts/verify/action_view_responsibility_map_guard.py
+++ b/scripts/verify/action_view_responsibility_map_guard.py
@@ -11,7 +11,7 @@ CONTRACT_ACTION_RUNTIME = ROOT / "frontend/apps/web/src/app/runtime/actionViewCo
 NAVIGATION_CONTEXT = ROOT / "frontend/apps/web/src/app/navigationContext.ts"
 CI = ROOT / "make/ci.mk"
 
-LINE_BUDGET = 3681
+LINE_BUDGET = 3684
 
 
 def _read(path: Path) -> str:
@@ -44,7 +44,7 @@ def main() -> int:
 
     for token in [
         "Action View Responsibility Map",
-        "Current size: 3,681 lines",
+        "Current size: 3,684 lines",
         "Phase: Stage 6 business category create nav query split",
         "## Purpose",
         "## Route Entry",
@@ -59,7 +59,7 @@ def main() -> int:
         "## Stage 6 Target",
         "## Verification Gaps",
         "## Invariants",
-        "`ActionView.vue` is locked at `<=3681` lines",
+        "`ActionView.vue` is locked at `<=3684` lines",
         "`usePageContract('action')`",
         "`useActionPageModel`",
         "`useActionViewActionRuntime`",


### PR DESCRIPTION
## Summary
- add one command to refresh all tracked engineering reports in dependency order
- add one read-only guard shared by full CI and `ci.local.quick`
- make `pr.push` run the guard before contacting either remote
- add an isolated test proving stale reports cause zero push attempts
- record the legitimate three-line responsive containment increase already merged into ActionView while preserving its new hard ceiling

## Why
A new source file predictably changed the complexity inventory, but the local quick and push paths did not validate tracked reports. The first remote CI therefore failed mechanically and required a second run.

## Validation
- `make refresh.generated_reports`
- `make ci.local.quick`
- `bash scripts/ops/git_safe_push.sh --self-test` (12 scenarios)
- `bash -n scripts/ops/git_safe_push.sh`
- `git diff --check`
- `make pr.push` verified reports before synchronizing both remotes