### PR TITLE
fix(frontend): restore list horizontal scrolling

### DIFF
--- a/docs/engineering_convergence/complexity_budget_report.md
+++ b/docs/engineering_convergence/complexity_budget_report.md
@@ -19,7 +19,7 @@ Generated from repository source files. This report is informational during the 
 | 3525 | Vue source | `frontend/apps/web/src/views/HomeView.vue` |
 | 3518 | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
-| 3243 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3257 | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3202 | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
 | 3092 | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3046 | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |
@@ -135,7 +135,7 @@ Generated from repository source files. This report is informational during the 
 | 3525 | split_plan_required | Vue source | `frontend/apps/web/src/views/HomeView.vue` |
 | 3518 | split_plan_required | Python source | `addons/smart_core/handlers/ui_contract_v2.py` |
 | 3323 | split_plan_required | Python source | `addons/smart_construction_core/tests/test_p0_state_closure.py` |
-| 3243 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
+| 3257 | split_plan_required | Vue source | `frontend/apps/web/src/pages/ListPage.vue` |
 | 3202 | split_plan_required | Python source | `addons/smart_core/tests/test_form_field_configuration_params.py` |
 | 3092 | split_plan_required | Python source | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` |
 | 3046 | split_plan_required | Python source | `addons/smart_core/core/workspace_home_contract_builder.py` |

--- a/docs/engineering_convergence/split_plan_queue.md
+++ b/docs/engineering_convergence/split_plan_queue.md
@@ -20,7 +20,7 @@ Generated from `complexity_budget_report.md` split-plan-required files.
 | P1 | 3525 | Frontend owner | `frontend/apps/web/src/views/HomeView.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3518 | Platform owner | `addons/smart_core/handlers/ui_contract_v2.py` | Extract parsing, validation, assembly, and response mapping into owned services. |
 | P1 | 3323 | Construction backend owner | `addons/smart_construction_core/tests/test_p0_state_closure.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
-| P1 | 3243 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
+| P1 | 3257 | Frontend owner | `frontend/apps/web/src/pages/ListPage.vue` | Extract composables, child panels, data adapters, and action handlers; keep the route component as orchestration shell. |
 | P1 | 3202 | Platform owner | `addons/smart_core/tests/test_form_field_configuration_params.py` | Split fixtures, scenario builders, and assertion groups by behavior area. |
 | P1 | 3092 | Construction backend owner | `addons/smart_construction_core/models/support/p1_daily_business_visible_alias_fields.py` | Extract service methods for cross-model workflow, amount, and policy logic. |
 | P1 | 3046 | Platform owner | `addons/smart_core/core/workspace_home_contract_builder.py` | Define owner-specific decomposition plan before adding unrelated behavior. |

--- a/frontend/apps/web/src/pages/ListPage.vue
+++ b/frontend/apps/web/src/pages/ListPage.vue
@@ -127,7 +127,13 @@
         <span v-if="selectedCount > 0 && batchMessage" class="batch-message">{{ batchMessage }}</span>
       </section>
 
-      <section class="table sc-product-main-surface">
+
+      <section
+        class="table sc-product-main-surface"
+        role="region"
+        aria-label="业务列表，可横向滚动"
+        tabindex="0"
+      >
 	        <section v-if="showGroupedRows" class="grouped-table">
         <header class="grouped-toolbar">
           <div class="grouped-toolbar-title">
@@ -2240,16 +2246,24 @@ onBeforeUnmount(() => {
 }
 
 .table {
+  display: block;
+  min-width: 0;
   width: 100%;
   max-width: 100%;
   max-height: max(420px, calc(100vh - 210px));
-  overflow-x: auto;
+  overflow-x: scroll;
   overflow-y: auto;
+  scrollbar-gutter: stable;
   background: var(--sc-app-panel);
   border-radius: 8px;
   box-shadow: 0 20px 40px var(--sc-app-shadow);
   overscroll-behavior: contain;
   touch-action: pan-x pan-y;
+}
+
+.table:focus-visible {
+  outline: 3px solid var(--sc-app-focus-ring);
+  outline-offset: 2px;
 }
 
 .mobile-record-list {

--- a/scripts/verify/frontend_shell_usability_browser.mjs
+++ b/scripts/verify/frontend_shell_usability_browser.mjs
@@ -64,6 +64,24 @@ try {
   await login(desktop);
   await desktop.goto(`${BASE_URL}${listRoute(TARGETS.payment_request)}`, { waitUntil: 'domcontentloaded', timeout: 45000 });
   await desktop.locator('table.flat-table').waitFor({ timeout: 45000 });
+  const horizontalScroll = await desktop.locator('.table[role="region"]').evaluate((container) => {
+    const table = container.querySelector('table.flat-table');
+    if (!(table instanceof HTMLElement)) return { scrollable: false, labelled: false, focusable: false };
+    const originalMinWidth = table.style.minWidth;
+    table.style.minWidth = `${container.clientWidth + 400}px`;
+    container.scrollLeft = 240;
+    const result = {
+      scrollable: container.scrollWidth > container.clientWidth && container.scrollLeft > 0,
+      labelled: container.getAttribute('aria-label') === '业务列表，可横向滚动',
+      focusable: container.tabIndex === 0,
+    };
+    container.scrollLeft = 0;
+    table.style.minWidth = originalMinWidth;
+    return result;
+  });
+  check(horizontalScroll.scrollable, 'desktop list: horizontal table scrolling is unavailable');
+  check(horizontalScroll.labelled, 'desktop list: horizontal table region lacks an accessible name');
+  check(horizontalScroll.focusable, 'desktop list: horizontal table region is not keyboard focusable');
   const createBox = await desktop.getByRole('button', { name: '新建', exact: true }).boundingBox();
   check(createBox && createBox.x + createBox.width <= 1440, 'desktop: create action clipped outside viewport');
   check(await desktop.locator('h1').count() === 1, 'desktop list: expected one h1');
@@ -81,7 +99,7 @@ try {
   await desktop.locator('[data-field-name="amount"]').waitFor({ timeout: 45000 });
   check(await desktop.locator('h1').count() === 1, 'desktop form: expected one h1');
   await noPageOverflow(desktop, 'desktop form');
-  report.desktop = { list: 'PASS', detail: 'PASS', form: 'PASS', create_action_visible: true };
+  report.desktop = { list: 'PASS', detail: 'PASS', form: 'PASS', create_action_visible: true, horizontal_scroll: 'PASS' };
   await desktop.close();
 
   const mobile = await browser.newPage({ viewport: { width: 390, height: 844 } });


### PR DESCRIPTION
## What changed

- keep list pages aligned within the application shell
- restore an explicit horizontal scroll region for wide business tables
- add keyboard focus and an accessible region label
- add a browser regression assertion that exercises `scrollLeft`

## Root cause

The shell width containment fix removed page-level drift, but the list surface relied on an auto/implicit scrollbar. In the production project ledger this left wide columns without a stable, user-operable horizontal scroll surface.

## Validation

- `git diff --check`
- frontend strict typecheck
- frontend lint
- production frontend build
- production static asset and CSS assertions
- production HTTPS/API/Odoo/PostgreSQL health
- manual project-ledger horizontal scrolling acceptance

No database write, module upgrade, or backend restart was performed.